### PR TITLE
Add v3.0 of awslab's plantuml icons

### DIFF
--- a/awslib/ARVR/ARVR.puml
+++ b/awslib/ARVR/ARVR.puml
@@ -1,0 +1,12 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ARVR [64x64/16z] {
+xTG3WiH054NHzutP_th7RHkfsmnEdE1HZMZsIn0_DGDuuVsZJwnMVJ-57txuuKrsP4Tv1mjl3Nw43qZlo147VO9xPueyu8j1l3jm7V0GtPFWe8_UKzpL3rzc
+TO4l0gZEzufCsDd-rnhoN2zKtKLoWk-bkHq--vabr0TypEy_WiwEmc9K7FATAd_fVDwOZygdU_uEF_pmLgUMA_wChkV1SavCc4LdXNVe2m
+}
+
+AWSEntityColoring(ARVR)
+!define ARVR(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, ARVR, ARVR)
+!define ARVR(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, ARVR, ARVR)
+!define ARVRParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, ARVR, ARVR)
+!define ARVRParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, ARVR, ARVR)

--- a/awslib/ARVR/Sumerian.puml
+++ b/awslib/ARVR/Sumerian.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Sumerian [64x64/16z] {
+xPO5qkim38HN3FU_xuE29mMx-Hbtg4to6GIZxVVJhtvLLI-XbK2QJo6sVv90JA3SImUJRVuAjBeDl8zE0G2EyVy42d87NGOmGG0vVHuu7iRWZt4daBUWWW6j
+8w_zNufuHES9KgxpKjr5o6CKQyh5uGi59BTfEuR1GHvEi6cu0N2sWE8sb99j03370L41CkryG9FQh6rTffOJlEWGLz-cbv5N4Pqh83Vf5THL67BA-qXltEu_
+2XWrtrzlzZUfwuBCdjy_3ilGeY0Pgmj0NO5ehtb1vh9c0OhsaV_Qfa_hKUzKUDIs_eJgy7myMFEPLzinwd3nSQ0rpwYR_kiWmAgVmezmYuKSJ_94VZJDABad
+y4EnAVcdyy4Xo6H_7g-02Se1oIVprMqKX_YdW9_AEtjtdVlNiykVmAS0Tjd_1exTl8wS3Ju5q5sydGux-94Dty4xGtfeyAEewG4FQCvv0vQy0b8zvuiN_EYw
+AHy0nu8Ue-gMJrFBOgjTKr_pYfyChlaOjDhmay6vj0xaWvyFxdKOyiYlZSFQGGZIVMbSrhaa46WOf-dmcOS1a3mPjp9mFqqf77FZ-7JZ-Y76UQvV_Uel
+}
+
+AWSEntityColoring(Sumerian)
+!define Sumerian(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, Sumerian, Sumerian)
+!define Sumerian(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, Sumerian, Sumerian)
+!define SumerianParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, Sumerian, Sumerian)
+!define SumerianParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, Sumerian, Sumerian)

--- a/awslib/ARVR/all.puml
+++ b/awslib/ARVR/all.puml
@@ -1,0 +1,28 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $ARVR [64x64/16z] {
+xTG3WiH054NHzutP_th7RHkfsmnEdE1HZMZsIn0_DGDuuVsZJwnMVJ-57txuuKrsP4Tv1mjl3Nw43qZlo147VO9xPueyu8j1l3jm7V0GtPFWe8_UKzpL3rzc
+TO4l0gZEzufCsDd-rnhoN2zKtKLoWk-bkHq--vabr0TypEy_WiwEmc9K7FATAd_fVDwOZygdU_uEF_pmLgUMA_wChkV1SavCc4LdXNVe2m
+}
+
+AWSEntityColoring(ARVR)
+!define ARVR(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, ARVR, ARVR)
+!define ARVR(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, ARVR, ARVR)
+!define ARVRParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, ARVR, ARVR)
+!define ARVRParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, ARVR, ARVR)
+
+sprite $Sumerian [64x64/16z] {
+xPO5qkim38HN3FU_xuE29mMx-Hbtg4to6GIZxVVJhtvLLI-XbK2QJo6sVv90JA3SImUJRVuAjBeDl8zE0G2EyVy42d87NGOmGG0vVHuu7iRWZt4daBUWWW6j
+8w_zNufuHES9KgxpKjr5o6CKQyh5uGi59BTfEuR1GHvEi6cu0N2sWE8sb99j03370L41CkryG9FQh6rTffOJlEWGLz-cbv5N4Pqh83Vf5THL67BA-qXltEu_
+2XWrtrzlzZUfwuBCdjy_3ilGeY0Pgmj0NO5ehtb1vh9c0OhsaV_Qfa_hKUzKUDIs_eJgy7myMFEPLzinwd3nSQ0rpwYR_kiWmAgVmezmYuKSJ_94VZJDABad
+y4EnAVcdyy4Xo6H_7g-02Se1oIVprMqKX_YdW9_AEtjtdVlNiykVmAS0Tjd_1exTl8wS3Ju5q5sydGux-94Dty4xGtfeyAEewG4FQCvv0vQy0b8zvuiN_EYw
+AHy0nu8Ue-gMJrFBOgjTKr_pYfyChlaOjDhmay6vj0xaWvyFxdKOyiYlZSFQGGZIVMbSrhaa46WOf-dmcOS1a3mPjp9mFqqf77FZ-7JZ-Y76UQvV_Uel
+}
+
+AWSEntityColoring(Sumerian)
+!define Sumerian(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, Sumerian, Sumerian)
+!define Sumerian(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, Sumerian, Sumerian)
+!define SumerianParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, Sumerian, Sumerian)
+!define SumerianParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, Sumerian, Sumerian)
+

--- a/awslib/AWSC4Integration.puml
+++ b/awslib/AWSC4Integration.puml
@@ -1,0 +1,70 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+' AWS C4 UML Integration
+
+!ifdef COMPONENT_BG_COLOR
+    !define COMPONENT_LEGEND
+!else
+    !ifdef CONTAINER_BG_COLOR 
+        !define CONTAINER_LEGEND
+    !else
+        !define CONTEXT_LEGEND
+    !endif
+!endif
+
+!ifdef CONTEXT_LEGEND
+    !definelong LAYOUT_WITH_LEGEND
+        hide <<person>> stereotype
+        hide <<external_system>> stereotype
+        hide <<system>> stereotype
+        hide <<external_system>> stereotype
+        legend right
+        |=              |= Type |
+        |<PERSON_BG_COLOR>      | person |
+        |<EXTERNAL_PERSON_BG_COLOR>      | external person |
+        |<SYSTEM_BG_COLOR>   | system |
+        |<EXTERNAL_SYSTEM_BG_COLOR>      | external system |
+        |<AWS_BG_COLOR>       | AWS service container |
+        endlegend
+    !enddefinelong
+!endif
+
+!ifdef CONTAINER_LEGEND
+    !definelong LAYOUT_WITH_LEGEND
+        hide <<person>> stereotype
+        hide <<external_system>> stereotype
+        hide <<system>> stereotype
+        hide <<external_system>> stereotype
+        hide <<container>> stereotype
+        legend right
+        |=              |= Type |
+        |<PERSON_BG_COLOR>      | person |
+        |<EXTERNAL_PERSON_BG_COLOR>      | external person |
+        |<SYSTEM_BG_COLOR>   | system |
+        |<EXTERNAL_SYSTEM_BG_COLOR>      | external system |
+        |<CONTAINER_BG_COLOR>   | container |
+        |<AWS_BG_COLOR>       | AWS service container |
+        endlegend
+    !enddefinelong
+!endif
+
+!ifdef COMPONENT_LEGEND
+    !definelong LAYOUT_WITH_LEGEND
+        hide <<person>> stereotype
+        hide <<external_system>> stereotype
+        hide <<system>> stereotype
+        hide <<external_system>> stereotype
+        hide <<container>> stereotype
+        hide <<component>> stereotype
+        legend right
+        |=              |= Type |
+        |<PERSON_BG_COLOR>      | person |
+        |<EXTERNAL_PERSON_BG_COLOR>      | external person |
+        |<SYSTEM_BG_COLOR>   | system |
+        |<EXTERNAL_SYSTEM_BG_COLOR>      | external system |
+        |<CONTAINER_BG_COLOR>   | container |
+        |<AWS_BG_COLOR>       | AWS service container |
+        |<COMPONENT_BG_COLOR>   | component |
+        endlegend
+    !enddefinelong
+!endif

--- a/awslib/AWSCommon.puml
+++ b/awslib/AWSCommon.puml
@@ -1,0 +1,72 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+' Colors
+' ##################################
+!define AWS_COLOR #232F3E
+!define AWS_BG_COLOR #FFFFFF
+!define AWS_BORDER_COLOR #FF9900
+!define AWS_SYMBOL_COLOR AWS_COLOR
+
+' Styling
+' ##################################
+
+!define TECHN_FONT_SIZE 12
+
+skinparam defaultTextAlignment center
+
+skinparam wrapWidth 200
+skinparam maxMessageSize 150
+
+skinparam rectangle {
+    StereotypeFontSize 12
+}
+
+skinparam Arrow {
+    Color #666666
+    FontColor #666666
+    FontSize 12
+}
+
+!definelong AWSEntityColoring(stereo)
+skinparam rectangle<<stereo>> {
+    BackgroundColor AWS_BG_COLOR
+    BorderColor AWS_BORDER_COLOR
+}
+skinparam participant<<stereo>> {
+    BackgroundColor AWS_BG_COLOR
+    BorderColor AWS_BORDER_COLOR
+}
+!enddefinelong
+
+' Layout
+' ##################################
+
+!definelong LAYOUT_AS_SKETCH
+skinparam backgroundColor #EEEBDC
+skinparam handwritten true
+skinparam defaultFontName "Comic Sans MS"
+center footer <font color=red>Warning:</font> Created for discussion, needs to be validated
+!enddefinelong
+
+!define LAYOUT_TOP_DOWN top to bottom direction
+!define LAYOUT_LEFT_RIGHT left to right direction
+
+' Elements
+' ##################################
+
+!definelong AWSEntity(e_alias, e_label, e_techn, e_color, e_sprite, e_stereo)
+rectangle "==e_label\n<color:e_color><$e_sprite></color>\n//<size:TECHN_FONT_SIZE>[e_techn]</size>//" <<e_stereo>> as e_alias
+!enddefinelong
+
+!definelong AWSEntity(e_alias, e_label, e_techn, e_descr, e_color, e_sprite, e_stereo)
+rectangle "==e_label\n<color:e_color><$e_sprite></color>\n//<size:TECHN_FONT_SIZE>[e_techn]</size>//\n\n e_descr" <<e_stereo>> as e_alias
+!enddefinelong
+
+!definelong AWSParticipant(p_alias, p_label, p_techn, p_color, p_sprite, p_stereo)
+participant "p_label\n<size:TECHN_FONT_SIZE>[p_techn]</size>" as p_alias << ($p_sprite, p_color) p_stereo>>
+!enddefinelong
+
+!definelong AWSParticipant(p_alias, p_label, p_techn, p_descr, p_color, p_sprite, p_stereo)
+participant "p_label\n<size:TECHN_FONT_SIZE>[p_techn]</size>\n\n p_descr" as p_alias << ($p_sprite, p_color) p_stereo>>
+!enddefinelong

--- a/awslib/AWSCostManagement/Budgets.puml
+++ b/awslib/AWSCostManagement/Budgets.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Budgets [64x64/16z] {
+xTI7cXqX20NW0m82x_--QOnVtEpec4qlvokt-SFORlnU-P__wRP8F_ECHVZC4zHkeg13Jv4t2JhtT_act-IRl8E-hV-tUk9Vwxbzc-_zpJu_v1lMtqL4_Utp
+Dm3mRpX_zbNU-vVZUFBTdpX9llGDJVZoARGja9sWBtoEMrzUGJqt7FXypzJg6v_NHO1r0GCqBfyAI3Z1SlQXW2rv3IQgnWHcwE2ZhgqAf00onZd1eW7jrRuA
+87dh5VYqF8o8Qgmp3_2d1GPqvQqUGIFQa5EqcjlQzpG2hnOuEuCi-yP7UWFqtYlGF6FhQnlONur8vrhuhPz7pfchxltyf2FJhCvyC40sDIU0uzmBU1ocSMGO
+Skm5vDcfxjhrnWbow1LroslEUXrY9-Y9p-BNj9bh8Qu2-UZJW9xJiZSVdpfWkVSJhrWrdmfi_JLaaIg-yuFl2coy4dJ3Qt5rxG7DXoYmyWAGFOOs_rzdMStH
+xJ0UlqV-vt_U0m
+}
+
+AWSEntityColoring(Budgets)
+!define Budgets(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, Budgets, Budgets)
+!define Budgets(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, Budgets, Budgets)
+!define BudgetsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, Budgets, Budgets)
+!define BudgetsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, Budgets, Budgets)

--- a/awslib/AWSCostManagement/CostExplorer.puml
+++ b/awslib/AWSCostManagement/CostExplorer.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CostExplorer [64x64/16z] {
+xTO7kjmW34NX8o64fFqlE1-Un-i5EpsPEytjvpBT-SVaddl6s5ZyE87c2f8hycRngZTeiU4_A5KG92xwwhFSQ5Uz4ZNNplaA8J8hEqIUzouWVZnScVy0Cn1e
+uyhhr_2gCNNMbVTFUFaIPfxpofZzkjRYf7Uakz0tVRtsmOpbZdTal9s_2IDtlAwc9r-6piKTR-XmmP_v6aZiUYIhdFRCX-2rwGFDTR-yOfKfRFKBeyfejNnr
+z41jopiq1MpviJxhDMzV-km2sWKTDNq8FbNq9g8zllGLQ5OqwFDERZCn005iz_FR3o4GXv1P7LtGg2rVSLGRLjccoimw5jDtVARmiEPebYlI8hFHivtpoYXR
+lpg1f6zvmo8Q5cWDP6HCLiR8tF4Xm37zNePN7gcvkkKp32ohuzMUIWTMftw_Pc6dvqFyh1-q2eWyKeRdAPz2bA_-kNRELwVbIXdqEjUVYkL3EYBqEkT3q34N
+HaF6c0ESyXaAeYg0Pgq1zdscjmExqcu3dFHL6P5PUHi0_3CVHpAGMB7P695h0FdOVnQDsm16VEJrqzWn0nVDwsaWupjFSV-Kt7FFDm
+}
+
+AWSEntityColoring(CostExplorer)
+!define CostExplorer(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, CostExplorer, CostExplorer)
+!define CostExplorer(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, CostExplorer, CostExplorer)
+!define CostExplorerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, CostExplorer, CostExplorer)
+!define CostExplorerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, CostExplorer, CostExplorer)

--- a/awslib/AWSCostManagement/CostManagement.puml
+++ b/awslib/AWSCostManagement/CostManagement.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CostManagement [64x64/16z] {
+xTO3jiH0443HilQ_tq5wxEfllEZeneAlwZ_SBn7Oj1i07RrLjpZpMjdic_j_NuUclAkPBfbFU8QJABfUmJQJvv83DtqnLSNUbs3RemWVFRNtduZm3RusnOcl
+bhSb1Q_zyTkIl-OTTdcC14RqglVzQiwWuAi-CglI3qLLPNLyg8WU4X5j-JB0yw3hyxIoQJ-Qy7LQtwlfCUEcTqGu3QdbyqRTxNDc4g9NRER8FHyYcfag4kN0
+sZp-vGdECTzVZydZd_9buw530Ay9ds5cuqqIEVmd7t_4PZRc3XRQFtuSnsyLi0bxFjsNxRkFkKV7UzxgTNypX1Tzckcjp5_qMRVxjVzF_pww-PcVwFqy4Cz4
+2FjmAlWDhG4
+}
+
+AWSEntityColoring(CostManagement)
+!define CostManagement(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, CostManagement, CostManagement)
+!define CostManagement(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, CostManagement, CostManagement)
+!define CostManagementParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, CostManagement, CostManagement)
+!define CostManagementParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, CostManagement, CostManagement)

--- a/awslib/AWSCostManagement/CostandUsageReport.puml
+++ b/awslib/AWSCostManagement/CostandUsageReport.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CostandUsageReport [64x64/16z] {
+xTQ5hjr030JGMJ2C__z_7qIoqYXrw9RxZk3YM5bU_Z6-V0c-mbNK-PWr0CtuLCEqYSRunDiC8o86Ximv9TiH6poWa608i50kP6mOQuREO8UQsSnymvO5ImDz
+TWoIeSXyyvMU5W26amnPysGAGpikuEPacQT1T2rGg_CpZWl4QNufm8AA7kVHMaTLm3k0xdNUsm9GVa_7q87EYD1zVYNGOluoE315T7oRtypUB7u-VpDlCmcf
+KvZvOlwAgiurJq5gZ05Go_PtwKkHJVlTaYyphCZN_Ryslcf_ChNz-Bj-ylKVcQ-5xDe_WsIs_rRUv9DnOQAy-VpR_J0OT_glTwOKryOlM8XBysVg3gaVZ2Vp
+j-I6JzGhwsV83bq-AFNI-er5phxr_S_g__FzwppFu6jvlfPty-VvFByUvi_FpoJGX-TtqeVtX-GFxo_fqVtf-VtjvzyVK_1lykNBEm
+}
+
+AWSEntityColoring(CostandUsageReport)
+!define CostandUsageReport(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, CostandUsageReport, CostandUsageReport)
+!define CostandUsageReport(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, CostandUsageReport, CostandUsageReport)
+!define CostandUsageReportParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, CostandUsageReport, CostandUsageReport)
+!define CostandUsageReportParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, CostandUsageReport, CostandUsageReport)

--- a/awslib/AWSCostManagement/ReservedInstanceReporting.puml
+++ b/awslib/AWSCostManagement/ReservedInstanceReporting.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ReservedInstanceReporting [64x64/16z] {
+xPO55W9134FJTlp-zyK9hrZtuRB19Udi7-sVgrcpIhdFB_96_-W5AAkNszII082aTbDf0v1gJG2iJcw4wQPq5a1oEtwlAV8hj5TpDSV-YwQm7WVior5i16m2
+DI5p3oG3qcDLu7mP1L1Zlo4hz9pT2YnkFcG3yTI-yWfQrEyPQHm2l7qav6WSx4emW7OsxgfuYIw0_Mue0JqYrfK_Aw1vzTxOEHRHyoD15H12YmXwG09hgnI3
+UBm1FVwL5ytGY61XEhFeOGlB9RE86w2WI-26jqYvrtzl--_dTt__tJz-fezVFHc_yVmnjwYw-HCJf9q10Jq7Y7OVCF8ERq2GTXyGqMDlEtkuVjw_Vj-_VyJx
+L-B-5Tdjslwf8JwBzkzOhCdp0u7SSNwvu_pqZUS_dby_LxDcBG4
+}
+
+AWSEntityColoring(ReservedInstanceReporting)
+!define ReservedInstanceReporting(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, ReservedInstanceReporting, ReservedInstanceReporting)
+!define ReservedInstanceReporting(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, ReservedInstanceReporting, ReservedInstanceReporting)
+!define ReservedInstanceReportingParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, ReservedInstanceReporting, ReservedInstanceReporting)
+!define ReservedInstanceReportingParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, ReservedInstanceReporting, ReservedInstanceReporting)

--- a/awslib/AWSCostManagement/all.puml
+++ b/awslib/AWSCostManagement/all.puml
@@ -1,0 +1,70 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $Budgets [64x64/16z] {
+xTI7cXqX20NW0m82x_--QOnVtEpec4qlvokt-SFORlnU-P__wRP8F_ECHVZC4zHkeg13Jv4t2JhtT_act-IRl8E-hV-tUk9Vwxbzc-_zpJu_v1lMtqL4_Utp
+Dm3mRpX_zbNU-vVZUFBTdpX9llGDJVZoARGja9sWBtoEMrzUGJqt7FXypzJg6v_NHO1r0GCqBfyAI3Z1SlQXW2rv3IQgnWHcwE2ZhgqAf00onZd1eW7jrRuA
+87dh5VYqF8o8Qgmp3_2d1GPqvQqUGIFQa5EqcjlQzpG2hnOuEuCi-yP7UWFqtYlGF6FhQnlONur8vrhuhPz7pfchxltyf2FJhCvyC40sDIU0uzmBU1ocSMGO
+Skm5vDcfxjhrnWbow1LroslEUXrY9-Y9p-BNj9bh8Qu2-UZJW9xJiZSVdpfWkVSJhrWrdmfi_JLaaIg-yuFl2coy4dJ3Qt5rxG7DXoYmyWAGFOOs_rzdMStH
+xJ0UlqV-vt_U0m
+}
+
+AWSEntityColoring(Budgets)
+!define Budgets(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, Budgets, Budgets)
+!define Budgets(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, Budgets, Budgets)
+!define BudgetsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, Budgets, Budgets)
+!define BudgetsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, Budgets, Budgets)
+
+sprite $CostExplorer [64x64/16z] {
+xTO7kjmW34NX8o64fFqlE1-Un-i5EpsPEytjvpBT-SVaddl6s5ZyE87c2f8hycRngZTeiU4_A5KG92xwwhFSQ5Uz4ZNNplaA8J8hEqIUzouWVZnScVy0Cn1e
+uyhhr_2gCNNMbVTFUFaIPfxpofZzkjRYf7Uakz0tVRtsmOpbZdTal9s_2IDtlAwc9r-6piKTR-XmmP_v6aZiUYIhdFRCX-2rwGFDTR-yOfKfRFKBeyfejNnr
+z41jopiq1MpviJxhDMzV-km2sWKTDNq8FbNq9g8zllGLQ5OqwFDERZCn005iz_FR3o4GXv1P7LtGg2rVSLGRLjccoimw5jDtVARmiEPebYlI8hFHivtpoYXR
+lpg1f6zvmo8Q5cWDP6HCLiR8tF4Xm37zNePN7gcvkkKp32ohuzMUIWTMftw_Pc6dvqFyh1-q2eWyKeRdAPz2bA_-kNRELwVbIXdqEjUVYkL3EYBqEkT3q34N
+HaF6c0ESyXaAeYg0Pgq1zdscjmExqcu3dFHL6P5PUHi0_3CVHpAGMB7P695h0FdOVnQDsm16VEJrqzWn0nVDwsaWupjFSV-Kt7FFDm
+}
+
+AWSEntityColoring(CostExplorer)
+!define CostExplorer(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, CostExplorer, CostExplorer)
+!define CostExplorer(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, CostExplorer, CostExplorer)
+!define CostExplorerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, CostExplorer, CostExplorer)
+!define CostExplorerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, CostExplorer, CostExplorer)
+
+sprite $CostManagement [64x64/16z] {
+xTO3jiH0443HilQ_tq5wxEfllEZeneAlwZ_SBn7Oj1i07RrLjpZpMjdic_j_NuUclAkPBfbFU8QJABfUmJQJvv83DtqnLSNUbs3RemWVFRNtduZm3RusnOcl
+bhSb1Q_zyTkIl-OTTdcC14RqglVzQiwWuAi-CglI3qLLPNLyg8WU4X5j-JB0yw3hyxIoQJ-Qy7LQtwlfCUEcTqGu3QdbyqRTxNDc4g9NRER8FHyYcfag4kN0
+sZp-vGdECTzVZydZd_9buw530Ay9ds5cuqqIEVmd7t_4PZRc3XRQFtuSnsyLi0bxFjsNxRkFkKV7UzxgTNypX1Tzckcjp5_qMRVxjVzF_pww-PcVwFqy4Cz4
+2FjmAlWDhG4
+}
+
+AWSEntityColoring(CostManagement)
+!define CostManagement(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, CostManagement, CostManagement)
+!define CostManagement(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, CostManagement, CostManagement)
+!define CostManagementParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, CostManagement, CostManagement)
+!define CostManagementParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, CostManagement, CostManagement)
+
+sprite $CostandUsageReport [64x64/16z] {
+xTQ5hjr030JGMJ2C__z_7qIoqYXrw9RxZk3YM5bU_Z6-V0c-mbNK-PWr0CtuLCEqYSRunDiC8o86Ximv9TiH6poWa608i50kP6mOQuREO8UQsSnymvO5ImDz
+TWoIeSXyyvMU5W26amnPysGAGpikuEPacQT1T2rGg_CpZWl4QNufm8AA7kVHMaTLm3k0xdNUsm9GVa_7q87EYD1zVYNGOluoE315T7oRtypUB7u-VpDlCmcf
+KvZvOlwAgiurJq5gZ05Go_PtwKkHJVlTaYyphCZN_Ryslcf_ChNz-Bj-ylKVcQ-5xDe_WsIs_rRUv9DnOQAy-VpR_J0OT_glTwOKryOlM8XBysVg3gaVZ2Vp
+j-I6JzGhwsV83bq-AFNI-er5phxr_S_g__FzwppFu6jvlfPty-VvFByUvi_FpoJGX-TtqeVtX-GFxo_fqVtf-VtjvzyVK_1lykNBEm
+}
+
+AWSEntityColoring(CostandUsageReport)
+!define CostandUsageReport(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, CostandUsageReport, CostandUsageReport)
+!define CostandUsageReport(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, CostandUsageReport, CostandUsageReport)
+!define CostandUsageReportParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, CostandUsageReport, CostandUsageReport)
+!define CostandUsageReportParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, CostandUsageReport, CostandUsageReport)
+
+sprite $ReservedInstanceReporting [64x64/16z] {
+xPO55W9134FJTlp-zyK9hrZtuRB19Udi7-sVgrcpIhdFB_96_-W5AAkNszII082aTbDf0v1gJG2iJcw4wQPq5a1oEtwlAV8hj5TpDSV-YwQm7WVior5i16m2
+DI5p3oG3qcDLu7mP1L1Zlo4hz9pT2YnkFcG3yTI-yWfQrEyPQHm2l7qav6WSx4emW7OsxgfuYIw0_Mue0JqYrfK_Aw1vzTxOEHRHyoD15H12YmXwG09hgnI3
+UBm1FVwL5ytGY61XEhFeOGlB9RE86w2WI-26jqYvrtzl--_dTt__tJz-fezVFHc_yVmnjwYw-HCJf9q10Jq7Y7OVCF8ERq2GTXyGqMDlEtkuVjw_Vj-_VyJx
+L-B-5Tdjslwf8JwBzkzOhCdp0u7SSNwvu_pqZUS_dby_LxDcBG4
+}
+
+AWSEntityColoring(ReservedInstanceReporting)
+!define ReservedInstanceReporting(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, ReservedInstanceReporting, ReservedInstanceReporting)
+!define ReservedInstanceReporting(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, ReservedInstanceReporting, ReservedInstanceReporting)
+!define ReservedInstanceReportingParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, ReservedInstanceReporting, ReservedInstanceReporting)
+!define ReservedInstanceReportingParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, ReservedInstanceReporting, ReservedInstanceReporting)
+

--- a/awslib/AWSRaw.puml
+++ b/awslib/AWSRaw.puml
@@ -1,0 +1,33 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+' Colors
+' ##################################
+!define AWS_COLOR #232F3E
+!define AWS_BG_COLOR #FFFFFF
+!define AWS_BORDER_COLOR #FF9900
+!define AWS_SYMBOL_COLOR AWS_COLOR
+
+' Styling
+' ##################################
+
+!define TECHN_FONT_SIZE 12
+
+!definelong AWSEntityColoring(e_stereo)
+skinparam rectangle<<e_stereo>> {
+    BackgroundColor AWS_BG_COLOR
+    BorderColor AWS_BORDER_COLOR
+    
+}
+!enddefinelong
+
+' Elements
+' ##################################
+
+!definelong AWSEntity(e_alias, e_label, e_techn, e_color, e_sprite, e_stereo)
+rectangle "==e_label\n<color:e_color><$e_sprite></color>\n//<size:TECHN_FONT_SIZE>[e_techn]</size>//" <<e_stereo>> as e_alias
+!enddefinelong
+
+!definelong AWSEntity(e_alias, e_label, e_techn, e_descr, e_color, e_sprite, e_stereo)
+rectangle "==e_label\n<color:e_color><$e_sprite></color>\n//<size:TECHN_FONT_SIZE>[e_techn]</size>//\n\n e_descr" <<e_stereo>> as e_alias
+!enddefinelong

--- a/awslib/AWSSimplified.puml
+++ b/awslib/AWSSimplified.puml
@@ -1,0 +1,26 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+' Styling
+' ##################################
+
+hide stereotype
+
+!definelong AWSEntityColoring(e_stereo)
+skinparam rectangle<<e_stereo>> {
+    BackgroundColor AWS_BG_COLOR
+    BorderColor transparent
+    Shadowing false
+}
+!enddefinelong
+
+' Overwriting Elements
+' ##################################
+
+!definelong AWSEntity(e_alias, e_label, e_techn, e_color, e_sprite, e_stereo)
+rectangle "<color:e_color><$e_sprite></color>\n\n==e_label" <<e_stereo>> as e_alias
+!enddefinelong
+
+!definelong AWSEntity(e_alias, e_label, e_techn, e_descr, e_color, e_sprite, e_stereo)
+rectangle "<color:e_color><$e_sprite></color>\n\n==e_label" <<e_stereo>> as e_alias
+!enddefinelong

--- a/awslib/Analytics/Analytics.puml
+++ b/awslib/Analytics/Analytics.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Analytics [64x64/16z] {
+xTK5WiGW38NXbn1WGkv_tjMwDwml__YqNrtmNRK8tISXfBj5W4UVhDpBTExBtVweRxvv5TfCz9eNnCqWrpo9bOrCwAelc_bzJYdNU0QWvlTAe0glJ14-tt7L
+w5d_h6yBJ-hR_W9wMCSTNf0OiUFtVCUj23f-smjojmbSNiR_7BwRkz-dN7l-k7pz-IyXWC9cX13ap3CuxCRWCwyGsqsWPxvaIDn9a2zilqYxnJzv_sg-UQlp
+KU_sc7b77-V1mHEFioLN-0iz0m
+}
+
+AWSEntityColoring(Analytics)
+!define Analytics(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, Analytics, Analytics)
+!define Analytics(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, Analytics, Analytics)
+!define AnalyticsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, Analytics, Analytics)
+!define AnalyticsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, Analytics, Analytics)

--- a/awslib/Analytics/Athena.puml
+++ b/awslib/Analytics/Athena.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Athena [64x64/16z] {
+xPJPkkGW28GBMKtU_tsd5TFC5h-SSpFhVzMBG54en-_9V_xJmytSurF1BWqBOkiVZBOHt4JDL9W0I7macW3sgXbAW3pLq7cK-p4b-QFm8BIABXJGP-5ouoX1
+7eHNbUwcgXRlxxHHyCCHPon8ulslxUFvaXWDQ6Bkheot-G5iv-XeRxEuT0_pyvkXxTNdCVbkM5skmWpRJLvMzPPw2ri98WLiST0CZ-6_UVz6EQEKxRe88IoQ
+zjcJPdBUXvyAcKuJgxqO_hTCEvKGzVi7FvZd36JhN2ppD0Kmudxw4vuo1zHQTj57zdJ0xYTW_89WwRCo3Hehw1YqcSOXs_OPaSNECNUjmeV0P-QzWUsoAQSk
+SGRup6jXbUr7d2Ov_4pJH_iio9dRitZqespkrjB0Yj_fhq25Ntb7XgZ-iVTFtsBBKU_bZDql4PCNBVFNcDBAR7ofk44mI0ClquzpnbLXmlx-Te7cTMVp2DUM
+XlKCZB9_lqMytjyqT4rHqfSTjjP7c8fS-zT0W9qzkziZF-uV1y815-XMUthBgRbGm6QIRVdgJjRAhXlaIuMUc_1Qy4P8_yDpaVdLXksz0yLH5p_XiCS9D4-c
+_y8iwdbhdoieYulJKGdysE64ziE9BkN1VWPvjbcUgHNShixEV44xWZ42F5wu2G5anxayEFDfxmbjU4FibpL-ZZqGnmEww_JVefUta7oFdoCV9VVZqtItE7uN
+_lEVBm
+}
+
+AWSEntityColoring(Athena)
+!define Athena(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, Athena, Athena)
+!define Athena(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, Athena, Athena)
+!define AthenaParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, Athena, Athena)
+!define AthenaParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, Athena, Athena)

--- a/awslib/Analytics/CloudSearch.puml
+++ b/awslib/Analytics/CloudSearch.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CloudSearch [64x64/16z] {
+xPK5bgH040L_kd3_yuxLU4CzP7qxdhMGaK99_u7SkLDFz5b2cG0GMvx8R2DMNXpiHtCJe553vGBmeHeKqEeFKW3ltGZeUpe7R7zshXvKkeysalPMu1_XHdX6
+yba0PE-Wtfyh1iJTUDGUu7tL-tkurDlRyALRzdIGe7UHVlm8aofGf_KSWtyNZV735a4KjASmwaFq0KjM1tGHv3AT7lT0a6j_EiYdxO_wIe1QAouPaCd2XutP
+WwE_CsfAdYn57rthUexHKu4cyJQUgEtu5jIy_e3DNWvlnoVahOiLYCOpt9iGrSY_AO_fJbJ4veGCtihpao1USiZgCYLK0XmzWv7THP2eBtGxk2khvmHuBA2l
+S1MDbJVbe_PG_eHa2upt28fWguELhbs2N16KWEkbBTqbuFn-dpo7xnMK0Ffkg12C9RTRq4u0gNcu2G5Ci6E23W46fD5vND2LRkQHuyjKCEUF5DWr0Q6k21P3
+z1M1m_kAG91zKg3TRU3kim9Y0cMVf9H0KdsUgke_XZjt7W4
+}
+
+AWSEntityColoring(CloudSearch)
+!define CloudSearch(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, CloudSearch, CloudSearch)
+!define CloudSearch(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, CloudSearch, CloudSearch)
+!define CloudSearchParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, CloudSearch, CloudSearch)
+!define CloudSearchParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, CloudSearch, CloudSearch)

--- a/awslib/Analytics/CloudSearchSearchDocuments.puml
+++ b/awslib/Analytics/CloudSearchSearchDocuments.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CloudSearchSearchDocuments [64x64/16z] {
+xPS5bWD120K_j07tl-yAgncXUIyk5HcjTiNfe3pOeAibqO4DXgMHRLzR2hMnuoE5FBBV9AJD_AvnpS_yEaBgGvO_oo0GCr8m4sW8uvTcfWLEcPMVKzIi7VW_
+rsrUV_x-shT10Ag4T00qREqtzJpCyRHhM_f4uc7EyBGAqT9de9iVOjZCkX-MFekP4YQGcWbl-DNyGMaXnQEnklB5q-MPY1ZVhyZI_odzfY7zfmPMlZ2SpCp1
+YxggdlOydeUAFse1Qcz8qNe5IiM2eOeKghBV_ubB0FDq_BIGSJu_d_w7dZyf9lRd_UVCzJSTFuuglzVwfx_MFxVc7rz-nzVVyUldL_qTltzB8sVOlnwnVpw6
+Tm
+}
+
+AWSEntityColoring(CloudSearchSearchDocuments)
+!define CloudSearchSearchDocuments(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, CloudSearchSearchDocuments, CloudSearchSearchDocuments)
+!define CloudSearchSearchDocuments(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, CloudSearchSearchDocuments, CloudSearchSearchDocuments)
+!define CloudSearchSearchDocumentsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, CloudSearchSearchDocuments, CloudSearchSearchDocuments)
+!define CloudSearchSearchDocumentsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, CloudSearchSearchDocuments, CloudSearchSearchDocuments)

--- a/awslib/Analytics/DataPipeline.puml
+++ b/awslib/Analytics/DataPipeline.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DataPipeline [64x64/16z] {
+xTG5WgHG30JGoeydzp_lIlj8s1qtNWjMXKDDThjTvelQ373Miosi1QxdYCXsS1SZEYEUlkDa334NiD5J3qEm13TuGUe9YBB2BhoAa4_OVL3TivxIhmMD1I80
+V_-N6rOzGG308j0w_060rrE4Y9N1knrMBXBrR-dkMLS6h_hRlufhv075NpRrhn4TZfbKzUOwzNd_-tuawX46xRyTopXAXMKQz7P6LoliqVvXeMEJTxLDVJOp
+nfBHEaM6_f7to74mzSNT1SGZEaKsZj-mwH0P-yV_79qZs_skGVzVlqQVlh_tNtxzQOte57cZ-ryZGc6LWslaRPv_LbK6wuXFaJTv_pcqgnKQ8pr57kqdmCn0
+ri7J8qu0oElawP6CoDgMSSdiThlV
+}
+
+AWSEntityColoring(DataPipeline)
+!define DataPipeline(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, DataPipeline, DataPipeline)
+!define DataPipeline(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, DataPipeline, DataPipeline)
+!define DataPipelineParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, DataPipeline, DataPipeline)
+!define DataPipelineParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, DataPipeline, DataPipeline)

--- a/awslib/Analytics/DenseComputeNodeResource.puml
+++ b/awslib/Analytics/DenseComputeNodeResource.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DenseComputeNodeResource [64x64/16z] {
+nPS7ZWCX34NNuFhlV-0DnD8qaUOjFxqyZIlWhzyMRVe4TsmAUXidxDK_uKtkqWzvphVjGrxoRGTQaTSY3wCQZ-WLFW1e9VuCmDiRl07Q-fIC_FLunmTodEkF
+x7KVUc2lpB-ycWS6OCDu1wpVD72oQLFuq4Cx5CZOKsojrx4NBMao87Ypn3VUrORK7_0jW6ZxDCYb2tZDS-nYb1wqSnVAafTBZj83wdRXrSyA0F1ZX1NGRW6S
+US93qLQzgIlljf0dJtdbC6PSUNvGGPJmb0qxZl7F3bt6KH8sRZ4R2EXqbnpuFagYJwofkoIVPbCk0FiuuC0ha5dZoKm-uLqEbhp0Y8Tp5B16BNcXusRK1GYv
+Y_lNZX_NjjiJ8sXHOGq8tyVxmDjuylbOLQXa5bOytrY5BVdXGT2lyOFzpFwCNq2omp-8dujFutmaoEZj_27tXkO0G6_M3xMRye-TUtkZVWlzK-hVmlfHNh_g
+wsTz_Qxk7-Nzgxv_LlVlulcXS7ufdP-AvxVQ-P5gvzT_F3_3w5_dXrQQd_vdVjkhL-VNulpy2_e6
+}
+
+AWSEntityColoring(DenseComputeNodeResource)
+!define DenseComputeNodeResource(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, DenseComputeNodeResource, DenseComputeNodeResource)
+!define DenseComputeNodeResource(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, DenseComputeNodeResource, DenseComputeNodeResource)
+!define DenseComputeNodeResourceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, DenseComputeNodeResource, DenseComputeNodeResource)
+!define DenseComputeNodeResourceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, DenseComputeNodeResource, DenseComputeNodeResource)

--- a/awslib/Analytics/DenseStorageNodeResource.puml
+++ b/awslib/Analytics/DenseStorageNodeResource.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DenseStorageNodeResource [64x64/16z] {
+nPS7Zjmm34L5YVNV_y1PUGYumSROJB9_UdamgoIsVorQzGPth0fwZ1Es6czuau_q9S_vjh_a9TyEe1TvBV8mgl68KU43W5RYpm2S7l06Q1-B11Xjn1CVo76i
+FxBlVHY1hJB_ycqU681DunsmyQE9apa0X4_Tsg50nfvYRRs1hQxD80E2LqjyvLrjIls6xm54twP1Jbt0rpp79aRfGJzseLpoSifHUa33JhpwKG40le-m0Zei
+W2DFk1MjrPiwysuNykGfhnp6Z3FFDnL42I-oQSSX_jcXLt6KX8rxB0q43Ff8TloO9R6OnkREoIFDfbm0jd70ZbTCwM9M899FUCt19IymukcSGnhrv26qtuo6
+024VyMXRNcUTQWjmkwYm3eGVuhtoDf-y6O8l-2QPXIkUuKlhU3_ogmT1ztmZ1O9UyGhBxkLdzcVy0fANaUVnS_5fd0eBC9xd3v-uUG3Gn_L3_KVBcy7SsuFw
+BVHFhNyBwqTv_Qgld_Nrkxf_bFUl-lvPtR-BvuV2-QLqVYgUtshdnruxl_xY-Hb6lpe_zDByz3lpsrQZEhyMv-T_e3y
+}
+
+AWSEntityColoring(DenseStorageNodeResource)
+!define DenseStorageNodeResource(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, DenseStorageNodeResource, DenseStorageNodeResource)
+!define DenseStorageNodeResource(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, DenseStorageNodeResource, DenseStorageNodeResource)
+!define DenseStorageNodeResourceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, DenseStorageNodeResource, DenseStorageNodeResource)
+!define DenseStorageNodeResourceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, DenseStorageNodeResource, DenseStorageNodeResource)

--- a/awslib/Analytics/EMR.puml
+++ b/awslib/Analytics/EMR.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EMR [64x64/16z] {
+xLQ7jfqm39CTx_p___OGxke8j-Hr5vt1b17UzGVZmeLqYrg7043BLNe3gJ9uqO3lJ86kglVjaE1LVknyMkChh5TLeAtn0-HLmV0rVXB0ZEVdNKNpJFWQ0mH-
+N6-mxwNhHioiTgC8s4Bnvcyot3p6toFlRhWTighxOJIZOO0qwA5q5s3GlbqnyYZVITHqM96NE5HrWzKnFndajrC5zCMiXXBQmzZKtq_J_jHVXWq4oGgU1a0_
+pxF0IDzq8G1a6SC6PAOUb3lHzwEXfJK090RA7Y2cvlDmwxDi1WY3x5bT8RqTHvuHN_0LfF58PGCV9plL5to7zAUwDucNmtmo4K14-cNXqhXOvpEaJklN_fe2
+KMVznvOF-S_qE1K_rgWHlsAeD8awaJ-XF4mu8RjZGEjK_eRna17Lq2ADu6Vh9nMuzx4Uut2gVhj2NG2hjVwHe9pqZtd_ocUXopYBcVvv_upN_hdxx-cMjx0l
+-dSoDkZo_2XhBB4slzRdPpBy5y_l-Vwmlh-ixqyD-l7zxUFxu_h--eVYmeLF
+}
+
+AWSEntityColoring(EMR)
+!define EMR(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, EMR, EMR)
+!define EMR(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, EMR, EMR)
+!define EMRParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, EMR, EMR)
+!define EMRParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, EMR, EMR)

--- a/awslib/Analytics/EMRCluster.puml
+++ b/awslib/Analytics/EMRCluster.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EMRCluster [64x64/16z] {
+nPS7SaCX30M_6fBU_G-SaOt73AHXKZR5TUb5kduRUlAA7dYIj5yxHkGLt-rEUz7N_fHVzAq_5O0F_NRem-dCHyg9dm3QoVWhWA0Dtu76SiDg_YHt-a21UVsH
+VxyFaXZfys_VdGS5uDNu0BnwK3fv0416yMax6XvZJ_dSUe8HkZgipQj4TrE-EGwaFbiIJp-Q5oqUFhV4I1Xn0idZDDYo2xJx3UXTyeX4aTCOKI9vteK6KDV3
+c1vVbPPOvgZtWCHddn8fwyZdEffDF8751-1o3P34wZCwgr-acmepYxPx9J7Ar6jELyNg9oOo4RDSUBLZ6dy2ZAr_fLT2ZfXaLywgMW2XExt-laE9HLNbFWyt
+VsmszGEWwX_ezLyJvK_oOmw-wsEMYm34WBGxAjU7Vb7oF8aPlR-T3_sI5wpFmjT-V7YT9XtxlzR-y_4xdx_pzNE-VZVspmV-rlvT_QtpGp_mltj-sUf___oy
+4ZarW6pZ_Au7P5EccqgiLSl6_N5PeiWRk96sSNzTP861TAMT-xCWqTRgJLEXZVlxF7uuZr_EuwVp-EqyVZoFNty_VeRJl-OFV9G__K_-DYAd-UjX_lmBl04
+}
+
+AWSEntityColoring(EMRCluster)
+!define EMRCluster(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, EMRCluster, EMRCluster)
+!define EMRCluster(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, EMRCluster, EMRCluster)
+!define EMRClusterParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, EMRCluster, EMRCluster)
+!define EMRClusterParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, EMRCluster, EMRCluster)

--- a/awslib/Analytics/EMREngine.puml
+++ b/awslib/Analytics/EMREngine.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EMREngine [64x64/16z] {
+xTPbOeGm40NWYOoz-n-uXM5fo2fIvrlvnICkTB3JIMr9Q9M4Zj4wekz47IuwODh48BI7GRydppO2t4QLLb7qc5R8W6kOnu5MA42X5WFffO83z_aAb3n8T946
+j50Tixxy2yjHa3e0r_6nf5QYa0-vAt_cQOXxMqwAxdKurqccfLA3ngCAA3ChO7C-0K9FENJyDne8a9fyfQSCbdDnA0tgCi-lb1yYpwlpXY0Rywa6Mfdl_R1y
+_URotSptvCFsl8dej_RVBycV-HIc_EhzJnm3hv4_QF_pQVzNqPPawXciCY_tNn8fyRAUtBdHM5l-hDeIe7VE3mMub58T_lYieCvqI9MNxXLoFI8CrEQeTdvs
+3Qbzt6cKSYabfwVJgnaJKGTGQ0LsB7cXLR9OYnCTwtHw0m
+}
+
+AWSEntityColoring(EMREngine)
+!define EMREngine(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, EMREngine, EMREngine)
+!define EMREngine(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, EMREngine, EMREngine)
+!define EMREngineParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, EMREngine, EMREngine)
+!define EMREngineParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, EMREngine, EMREngine)

--- a/awslib/Analytics/EMREngineMapRM3.puml
+++ b/awslib/Analytics/EMREngineMapRM3.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EMREngineMapRM3 [64x64/16z] {
+xTQ9akew38JXbYLPwdx_1xx7E5Gb51IptVryC-pyYDK9VjXllrLVJNoAwK7ZSsRzCelYh2Nn9Qs9xsZLtzDdtqZSPmAVKdgK-8GXiGxtpm6Vu9BZB2NxqE0j
+7_kGV2o6Erjm4TJXoVn3ZpseA8db-CMgVUKw6O_pxsWhvtcExRUNOiPXuCfZgttNaYepI-fxluudtgBgTjnOfcIdFl1MgyTmgh34jS-FpDzsdv_kMzlyOc-n
+uTFzrJ-iZti_SfrTHoUPCsoVCI3IRCxCf_E3t4TdrB4GaG6ZV93IkMStToyvMWsBT2161C36rDWFTFouNN7gjzspXjZ8fjn4AbUVkwUiA8UnSEvxpZhwoUeY
+05EQveh9oSRgYyKfNsFowViN6cGKCQfttpII6hT-9jlN_54QJzy_MPOLqVHx3_PGxjugXlPguIzw0BMQM7tdVWbDk_K0N3uoI7lMUnk0MGXMXObiGnMyrz1A
+0AF7QBNZMNzbcdZfB-ZXutFzUxOzxGDlJMfXxFw7rZyUwt_DEflZsVeRcTVr5tCU7-QZ-MAFfY_pxwAlf7gn_IWftJqeuhLMu-g-aV8FxLTCAN2LKfmsrSnt
+ko7nc1CtDjnzsDlbzVIPpA8anoSaTKN7fupPPsduMR_zzWS
+}
+
+AWSEntityColoring(EMREngineMapRM3)
+!define EMREngineMapRM3(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, EMREngineMapRM3, EMREngineMapRM3)
+!define EMREngineMapRM3(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, EMREngineMapRM3, EMREngineMapRM3)
+!define EMREngineMapRM3Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, EMREngineMapRM3, EMREngineMapRM3)
+!define EMREngineMapRM3Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, EMREngineMapRM3, EMREngineMapRM3)

--- a/awslib/Analytics/EMREngineMapRM5.puml
+++ b/awslib/Analytics/EMREngineMapRM5.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EMREngineMapRM5 [64x64/16z] {
+xTO7Sfr048JXtidJzp-m2nPAGA60v6n_BuUVdF3R-MzSuPdcMUAHSUqBp_ZKB5yPFgMO-8fYV6K5I3F7wccTpQCEF5Ay2ZoWPFfHiyUpNd3av4TwiIb8nP6H
+RWiTsCXY-pJcQt1txPsxdZzOpq-svjrs-XEliwjy8QVFIpX81z1ibSt0cMnyhecSy-FDtllv_AvcpkTzZiUpljZhU0CBUzptwO3WZ_lWv9_i8HCUzsU_MMzx
+h-d0oC1HP8RCDmFm54HcZaCVO-ZQ6tl0kt7K7UpvnZ58HNV4ePzcJqEp894Ek4KCTC4fmFg3hRq3kEyxbLsmJDfW9sFfO_PDgQ8EfezZd-wnzTwLENSB7mnK
+exaTo3khsgWZYptkbfzHkZKRshttexieQn_M9LG0HhrRVyQXWMnqoTRN-ZvcFqBttd3V0qjV7KlVIKStaWA02K2eaj4zxdg9fJU7PhWELWRW3Wa5u0PWn1XH
+ARZhpmO3RtY_xw_r6Dzx_nawtVQ6T-LRnv_uxF6lVVxKPwMuAfQgzjRRsiDiEwbSvKqVSoY7u_zE8a_k-Zdcd2Vu8EljSmKkP2uaQMxqxRNhECkjaEobBdtl
+AZ86fbcHXMaiy3ObJ-ja-IHuG8jd9NZ68b-4uY_ptt_V
+}
+
+AWSEntityColoring(EMREngineMapRM5)
+!define EMREngineMapRM5(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, EMREngineMapRM5, EMREngineMapRM5)
+!define EMREngineMapRM5(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, EMREngineMapRM5, EMREngineMapRM5)
+!define EMREngineMapRM5Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, EMREngineMapRM5, EMREngineMapRM5)
+!define EMREngineMapRM5Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, EMREngineMapRM5, EMREngineMapRM5)

--- a/awslib/Analytics/EMREngineMapRM7.puml
+++ b/awslib/Analytics/EMREngineMapRM7.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EMREngineMapRM7 [64x64/16z] {
+xTQ7ql8s58JXbKxTlVyBJeJmZ4rW-5hw_z3BEuSg6p_ibr-ghnAVClIWyJbPlykYcBK4lgIL-8vM_Jrzz8t4ld5yIkbHu1EcnBexlWTyWac6iv36XmPlyTYx
+P7CPE8m55qxTFPb_rtCFAafYtPusgctbEfcFymySA-TvpjWVByNmkuahywtsKqkgY2YfZtwT9zwYwdRUM58QfzxnLgldDAgm-BKFl4LjkuzFzwqjlzWFt_3f
+_keVrllHprXNrzb9HFhOLmRWCMPcndmstybzTaRT5oBICIXpaefJpsxkNZAq6iF309_k01kfkNhryUSEdUPlksTDiH5DsT2Qi_hOFJMAjxw9Kz-PTU-JrKK0
+Gp6KAoQJZTKNYxdwgNpw-RacwKNCwjqt1qdDMv_1jjM79fv-VXfHeuYc7JtOKx7xKJvNtyIh7a2jnbVViTz2Sznw06l-L3xlhGU0B3YhV8ZiWIfO6u0A0BCd
+lEVp_ceeySfVqSFcv_htnlQqTxoLr4BV_G-jVxol_vLrblFP-kiHr_KNcViVzGVvOe-cB_CFtbTIlTX-b1HcvXJnMgjnTMoax4Fx5IavhaBoqwQQyMutn1zp
+ucPCCvlZxV9w-awoACdm2K5TqV0fC_ii1dxMBx_y1W
+}
+
+AWSEntityColoring(EMREngineMapRM7)
+!define EMREngineMapRM7(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, EMREngineMapRM7, EMREngineMapRM7)
+!define EMREngineMapRM7(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, EMREngineMapRM7, EMREngineMapRM7)
+!define EMREngineMapRM7Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, EMREngineMapRM7, EMREngineMapRM7)
+!define EMREngineMapRM7Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, EMREngineMapRM7, EMREngineMapRM7)

--- a/awslib/Analytics/EMRHDFSCluster.puml
+++ b/awslib/Analytics/EMRHDFSCluster.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EMRHDFSCluster [64x64/16z] {
+nPU7pi8m38HnbkDx_mV-LJ1gvFmfq6ES1lDJFHAFowSbkyxW7RjCNiO5e_8PNkjDxIHV_6qwoLT_cu54yetaeSBniCpm1g0nyIy0-YjHLA2bV5NTyfVj5H-a
+8vu_qUTzo8PHdl_wR1uA0DsCxu1k7couwDKcwviExMYunrviltePesJjkW9MTalwplUccre_u9C1biOqrEaMb3LVR8YHUv3YBQnBlauvSWyawyIt7cNkUeXc
+osf0v0N_IQU0uAwPxnfaWHT_icafcFao5rsTOBSgnVZx3OryXBKakruW8CjDzOWFPeiNW34EEE1RXEyvU9Bl4VRlaIjWzQQIBolUVPOfYTP3l1Uymq4rdesb
+_R9ifoOVu0dxgVYn-QFE3tj-oVj3tr-YVj3rYw-VVFrc-mVTl_Z-oVPlSduWvXTgVYBdDsv-56v-_U7y39MVxW-9sfz-ix-Dokp-IkxF7z0V
+}
+
+AWSEntityColoring(EMRHDFSCluster)
+!define EMRHDFSCluster(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, EMRHDFSCluster, EMRHDFSCluster)
+!define EMRHDFSCluster(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, EMRHDFSCluster, EMRHDFSCluster)
+!define EMRHDFSClusterParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, EMRHDFSCluster, EMRHDFSCluster)
+!define EMRHDFSClusterParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, EMRHDFSCluster, EMRHDFSCluster)

--- a/awslib/Analytics/ElasticsearchService.puml
+++ b/awslib/Analytics/ElasticsearchService.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ElasticsearchService [64x64/16z] {
+xTQ7hkKW38JX0Opj6Tx_VLS9X-ZcRWdQtdwrj2-zwI_kV_-ZjLVyAfzOnLTwur7_UZyaZM_mEZgyh_WrFebLVAMlSMJm1yHQPfKttyvJuOy-W9C3UVSwsl5T
+H_RjdkPVxoEaePUF1v-jpkpoWsx71AVOyi4xLipfQLWPfKVl8gcsV1IK7YIp5y0t_7cioplGgLSTwAC_ULtUHznlqom8-QQFGfMJqytcun8erAwtqM7p500e
+EG_1Tdsc2YW5O95zEXPmqrDvdkk26BeonAP_ZGJitLsvw-Usthsp4krd-Ka3xUvjs_jvhEMsf6yVFqdKTSQk6dBJHwYU2-TjzujsVHk1gdiDY5sFL8FfRHq5
+Y3sVw8C5TkSC87Qzn88QcaL5IIc0sFPY0ufvk5K0JPeh6B7ffMYODI-mQmLzrsiml7jGr-bm8CHDturQtLQmwGt9CWVppGeAz_tr_Qjh1SCGNtX_Z-dFmUdN
+_ylh78p-ET-yz-uLZ3Lu-7eEDiGy1uo2_9GFh9XOaLWTYFKOwlfayIflWxc6TSJUMkWlwN__-m
+}
+
+AWSEntityColoring(ElasticsearchService)
+!define ElasticsearchService(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, ElasticsearchService, ElasticsearchService)
+!define ElasticsearchService(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, ElasticsearchService, ElasticsearchService)
+!define ElasticsearchServiceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, ElasticsearchService, ElasticsearchService)
+!define ElasticsearchServiceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, ElasticsearchService, ElasticsearchService)

--- a/awslib/Analytics/Glue.puml
+++ b/awslib/Analytics/Glue.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Glue [64x64/16z] {
+xT57ejim38JX0L48ZEv_trWbJIiABpt-R4chdvL_hhUtZ8Z9Fi7BP9j8wCTwUg-l5r8WlVKRNe8sNehFANJ0sQPWtlhM_6Mgwitzpus9NV6nofTYmZWUzZLT
+XmXUCg4vm6a-Qx5smOl8KDLAxEW0n6fnvpQpU0btdsHE0umB71WMCwkAbyePDW3d2iL5BhWeboGGuQP3BaFD8zPlqQ4RRpQ5SzL0y2Omk2mXjxMM8BdEOVTB
+TJuXcFp6XF29Uo2OVCRWj-qyKuAy7UUo-uKDJ3wdS1uSoeO2ybmzYXq1FTSHxBZsFJ7O59ZRDX7ztZFz8_qXs9LkvicsIZABROPC6Bksiz_Ougg2J8Ygiq40
+IDNnOKCEI1wVaUmeXMGEQB79yMBi2y3v4PdySxszVG8
+}
+
+AWSEntityColoring(Glue)
+!define Glue(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, Glue, Glue)
+!define Glue(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, Glue, Glue)
+!define GlueParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, Glue, Glue)
+!define GlueParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, Glue, Glue)

--- a/awslib/Analytics/GlueCrawlers.puml
+++ b/awslib/Analytics/GlueCrawlers.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $GlueCrawlers [64x64/16z] {
+xPM7aYKX20055QJ__tylKCoLMpUtxbnENS7O1kJDctmBtXRVGiWYp6o1ssDM-gkrra7ROspt-v_fV_lzGqG6T7bC-X0H0F4OqlyU-UDx_YpufloP8D_oVi_z
+__wtntzz8gfn93R_gzZz-8Rzp_4RDbiXq_Hf_2RWfGUW3zyluEeS0FwDlZtqPpg9B0Xzw3SdhhuEeptrPyPCLF82sX9HRQVuRvls1U5gn3Py-Sn-uP2bRjC4
+WYHWjHl_Xha70C165kE1hwFdF8NeUJaYEwGF-UBvHrO-ZbiWzUmpFQzGLSXFyPiric0EQJeCvZPmUZy5kpAGSBYoTn7ju2Shzr4sLavYlidl44C3OWo8FW5J
+Wv2ZNyt4fRN0MjCWIU4j-JVYkdDaeG6icd_p_s-W8Y-JDwJyhPtS_F-JZGoIPwfP7hRylSCo8M_9rucyd6In-m9UXKwxP-O-QARUUEatpn3D77W5XLNVZjsl
+RuX63ho6WsiTV_S5hCTX-_hO0RRxILJ_2N60-Pc_THzGWt7dJsrlGk_zQEtd-7B5IHt2PFlPdDXt5IE9aIc9dSNzh3C07mjOlVKA_XcP2x3ohX-p0sksCprW
+EtVTerXwr7EVLN4hr06R0I77q37hPxIX49cQfo2Ecc7iCsLLHYoGG-wwf15Rl7LTgtMtyazeW6UqP0PuUqXzSyqyIFqnuYyVyZbg0R66j9tt
+}
+
+AWSEntityColoring(GlueCrawlers)
+!define GlueCrawlers(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, GlueCrawlers, GlueCrawlers)
+!define GlueCrawlers(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, GlueCrawlers, GlueCrawlers)
+!define GlueCrawlersParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, GlueCrawlers, GlueCrawlers)
+!define GlueCrawlersParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, GlueCrawlers, GlueCrawlers)

--- a/awslib/Analytics/GlueDataCatalog.puml
+++ b/awslib/Analytics/GlueDataCatalog.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $GlueDatacatalog [64x64/16z] {
+rPU5aYj124M1nl__VoDTFDbUQJQUKn8zTIz4PWPEIEG90epy5K5mHdD2GFbB-AnJPgY8uFcUIHijdpC7JAZkzS1_FhwMFtI7_EXBv0xyoUVOuVZA-oEM3NoN
+_VNz-D47tFAmxoyYqXd4N_l4wX5PHBZ9mAwFNoynRBHycdQugGYV457po3FIyJtJXTQPYIqpgUVRG5WXRVfSqwhmc31B3M2j_VaFNxsEpvck5l6_wUgPslpy
+VIOXqPWGOJtPzCSvQe7hkOuF_dVJIwUMNmNMU86T_qE1oC2sNmNM-AvV1N29x_jLO8bl--i6AhxlLm5Rufl-Mg3Y-_vQG9RudWzM1R3YU_vQeEBR_bfWniCb
+VXNWJBxC1qy7q0oyqBVouMtzD8tBVSc9NUh3i0WNwFeDNjrdts7tFN-sBIz-_M4RzBxxyostdNzSvbz__NhzzVErr-z7
+}
+
+AWSEntityColoring(GlueDatacatalog)
+!define GlueDatacatalog(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, GlueDatacatalog, GlueDatacatalog)
+!define GlueDatacatalog(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, GlueDatacatalog, GlueDatacatalog)
+!define GlueDatacatalogParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, GlueDatacatalog, GlueDatacatalog)
+!define GlueDatacatalogParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, GlueDatacatalog, GlueDatacatalog)

--- a/awslib/Analytics/Kinesis.puml
+++ b/awslib/Analytics/Kinesis.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Kinesis [64x64/16z] {
+xLPNWkKm21CTykv_tYs9_Sfqa-qx-ae3IuIs_H7un2VASro5LyFUOUEAqR6Fa_O96LU2wEWdggb4jmOKFZoXAM0ICF3MW5qZmFDg3Jo55uEp4SAR0m6iEWxc
+kGRGOXxESyUb0j1OJsEG7vUf191whb7G6_Do0G0IyyXtnBZDgvIT-N0HneGTH7mWNYQkyuJ9_3kBo-MoLOQfC14E-8lfHqFuE5PeP-vHXvVB_dZ76y8jxrmO
+7xnPrCmz9bvqC8MptKMgqdNAly5V3xxn4Uyzt9DtLOQxNV7c3qqNEcYBcaTcrNeQXYdZ1df4VC1UklQJF_4I_vVZjot5BnM0U6wj_rSAi5StVuh1yJn_xQFv
+E-VNhNvagNx2FrQ_8XAz_j7iNr7j_acQlx9_5ztD3_9JyqkgCS3bvkZS_9Pp-mEjaPzMTvcyZhXg5kHlsFySth3lxw-_7v_un5S
+}
+
+AWSEntityColoring(Kinesis)
+!define Kinesis(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, Kinesis, Kinesis)
+!define Kinesis(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, Kinesis, Kinesis)
+!define KinesisParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, Kinesis, Kinesis)
+!define KinesisParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, Kinesis, Kinesis)

--- a/awslib/Analytics/KinesisDataAnalytics.puml
+++ b/awslib/Analytics/KinesisDataAnalytics.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $KinesisDataAnalytics [64x64/16z] {
+xPO73kCm30INdPJ-_zz32W4XiPBuUXkKrA6NibN6Ry5__bEUztSHzHM-m-_l65_ZnpVw2Rs_4-HN-0MwlpFe-0eKtfM-iW6g3Y1V5w0r_he2t8qNW_EyNuGk
+882TzjVh6a1U9_trkga0QPn_ZC7U5GWWzJmTWU_9omK0ICmZtpGJtk_o8dNo2cF25IA-4SV1RJITlCQOSuxAC1Kcmer3FmbBuGeXN6j4rPWNhbzVUTzu9yS5
+Ob4pZsQxl8G0a7MyArsPy82F7Mbq6-_8Mgjak9irELwGBeGBEhwQ31EIhzQh_JpcfPnsoqyw3SV4NjOUlwhhWgBFCFp3-wUeEHwP3d_x_BH_rEh6Ju1ZpIBp
+qKyY8blyxVmn0fvz1n6u_NVpjyQpxwFzBQMzyYs-crbyv3k1_77y4XSs_cxzzDMNf8s_NRzvAbA8Y2jXaz_xnSl-GJuL0J1G2Ttus_rBQeoBBrC_zGso5ZhX
+R_RlhV_k_41rtY-YvKa-uU_FJufitov-80OT-Blpcq91pZ23EC4LwY0zzlt8FsJJlrSdYMx9ZwdnM_2V_tm1
+}
+
+AWSEntityColoring(KinesisDataAnalytics)
+!define KinesisDataAnalytics(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, KinesisDataAnalytics, KinesisDataAnalytics)
+!define KinesisDataAnalytics(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, KinesisDataAnalytics, KinesisDataAnalytics)
+!define KinesisDataAnalyticsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, KinesisDataAnalytics, KinesisDataAnalytics)
+!define KinesisDataAnalyticsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, KinesisDataAnalytics, KinesisDataAnalytics)

--- a/awslib/Analytics/KinesisDataFirehose.puml
+++ b/awslib/Analytics/KinesisDataFirehose.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $KinesisDataFirehose [64x64/16z] {
+xPPNOYGn24GBX812zx_lTf3NsUvndl3-51xAeVu4DsxGyrE-et_AZpFt4_Ofdz3w509-ok-Vd03YqntGpmLedmp01lX7vOnj292USpYsS3oSesMDD01Y7fLO
+aSC-5L3de2iMacYP0cST9LQnUPBfniKV9G1apQf3P5Sig7MlHAl5DvKzAsg7sRDUOrIwpVvllgo2cm0WUxScU6MDGioJDSOePZXpz_b_QJEn86h15_rPsZsI
+h7hi3qFI8tBXPRyOlGacadpabo5JP2_tUYs0uewNV5MHL_sK1mD8djn_bzRNaZ6gcC77VkgSFwZvYpwvhH_TL1wltvmNqhrlXLwlmBb_siFzWmLfFT_TFz5M
+joVd-i_zg-PvyF1hvnfczbyp1C73vrUZ1ctlhPzyViFd_N6tFzqMuiGB49sVkZ_pz-vl0lpDzql0tto_0tRL_oV_f4zddHStRlm3
+}
+
+AWSEntityColoring(KinesisDataFirehose)
+!define KinesisDataFirehose(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, KinesisDataFirehose, KinesisDataFirehose)
+!define KinesisDataFirehose(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, KinesisDataFirehose, KinesisDataFirehose)
+!define KinesisDataFirehoseParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, KinesisDataFirehose, KinesisDataFirehose)
+!define KinesisDataFirehoseParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, KinesisDataFirehose, KinesisDataFirehose)

--- a/awslib/Analytics/KinesisDataStreams.puml
+++ b/awslib/Analytics/KinesisDataStreams.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $KinesisDataStreams [64x64/16z] {
+xTO5mkCu30NW9zcYv_lVTnEdTHTAwV9Cln-AJYGP-P_mzLMUF4Jm0mxdGL4yB_va-qJdeI5vNa5M9iOFTFYwqaS9h6Q6zba0jmfqVa2lpKgXnTDArWKQu3oj
+59gS710ldl2x-rO7f2TFSa23Kva0qgDEXw2No2kQ091cdbLyAfmNsUPjELLO4qmYgcsNzmCtNcM_HJu6cU6zgGWEmJjILkAyHTuzYXmxRcfwbVYANB4JRTtS
+OodU5mr0y-HIwLq5l-Dy9ErIxyZYvWYxAYDyOuVa4tcjzupw23QijTQznk1RyjPfdJJ1XGQhYGIVgrjx6wb0ZwnAtv-nLE9L_AlgmG1wNVilNythxDVwrL6_
+1FIecnVT3MXSNlSV5Kib9kExuoU6eSKL4oq3GF6UdELTeWkSWfgPp_mJDYX0vylvSyny1ZGtvFoVw9aGo1lp5tFosSfy_OU-s9wgtrQ-XhwhslvPqVec3C77
+N23EgQYemTyP3d-wUDarYpxkXchmDzPl0_hea4rIPTCOiWFYSVE-uX0_5cFLB40LOEWEg3VshrOa4yfDeQrJnNplFaFx_OKKCMRxCIxjHuU_lty7fBMi_J_0
+R1l8cVD31n0KR9IENV2kahld5uNMg8ai0-pS-MdsH5qcK0VizFdD03HpwmfeV71-B1DCwdoil1wVNpFSe_ZVylNr2m
+}
+
+AWSEntityColoring(KinesisDataStreams)
+!define KinesisDataStreams(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, KinesisDataStreams, KinesisDataStreams)
+!define KinesisDataStreams(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, KinesisDataStreams, KinesisDataStreams)
+!define KinesisDataStreamsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, KinesisDataStreams, KinesisDataStreams)
+!define KinesisDataStreamsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, KinesisDataStreams, KinesisDataStreams)

--- a/awslib/Analytics/KinesisVideoStreams.puml
+++ b/awslib/Analytics/KinesisVideoStreams.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $KinesisVideoStreams [64x64/16z] {
+xPO7bkCm34F10bBtl_0MFpcKF0vdixqXlNmOL1-_XVxhlv8ntv7v5JpXyvqWVW4ViFbElufFo2pROUChPE2P1FbL1KYUJffV5K1dAVfL1YcmnpkDhpF8Cm7y
+nGZxTHsG5ntswuO1i7ZLmW7XuY36B_F8yzKgUL81GDGOaTdwqCTKw98ywOef4JqKj_ni-pLvJe-WcufWYdTyo2nyIsuU5JjFxUHMU6LBcW2pVdUMRlWgN3so
+FC9D1HTnF5EuuF1WvEeIf9TYD0fNUQGc8ouLzwhstbBB9lv0Viz_6xyf9bqEqkUW3z_LjrxOfVyST-9uFdwOIqn2-4OEv2qka79EgWq3ktLw5-5B8GBeCCJX
+jLVC9potPZ3coIiqxlb-_IWUK6R7brYDM3nrUkvyltvwyJcYKZLy2kInVil2pxh0ZU_t3-xyaI0wFdNTltAiFFNz_0RTZ8ftgHueljk_nxN_Ok__Rbmc95VU
+O3VZfpk_-5Zvp6RyDkUdhvq_YZmjuRpAWEnvGNRhXyGxvzTWROHygno_YVxhlpu2
+}
+
+AWSEntityColoring(KinesisVideoStreams)
+!define KinesisVideoStreams(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, KinesisVideoStreams, KinesisVideoStreams)
+!define KinesisVideoStreams(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, KinesisVideoStreams, KinesisVideoStreams)
+!define KinesisVideoStreamsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, KinesisVideoStreams, KinesisVideoStreams)
+!define KinesisVideoStreamsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, KinesisVideoStreams, KinesisVideoStreams)

--- a/awslib/Analytics/LakeFormation.puml
+++ b/awslib/Analytics/LakeFormation.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $LakeFormation [64x64/16z] {
+xTP7ckCm34JX1p01fVlVTqQKGqVAxLs7Vr6Ee81FKJ_Ddp_fParFsm9mFIaY1i_NTw0PD4cP4PbFr2j6Q3YJrvwFpzw1BeCwyFAV0zJGOx83PG2UeMr-5SsW
+faxTMcwpRUnMr0qREfE0rTP75lTMWQQh1ard7C3CtStO3TqCEryWeBZRvELDGJomGAFEGN8kPczMDuPE-FqlnjZqoi1IItd_IwDksKEAMwXIr-NKwry2InLS
+AfHBA8tKGgNfCgJJvO3PDJobHjE2aTl0P_T5wIMgMJsYM4g9wNDZDbbe2Zvfj31MUw_F8Ms--r1V3L28O_JcX3uKbCNunxwhyDcEdirDYz-orZfMs_X4ulEb
+KoYfgNXkSjUMNlQepadz00fGPoTGOqOvOjOl-m-3xj3c3Z47V8RjaOl-TQoTZd7ilz4pUpr2H-2d-qy56tfY_tMwfX6hltmgS9rmulpNfxVGgLggT2satHl8
+U1NtYyfAfzndwPlkCHMwrfocNJfGzgWEboyRhXDfzCj-xiOjPbt7KcS6zClC6VUOvGoT6z3qWNQKdnk6Xzu8nuOUa-Nj0qDKAAc7TGDl8rFA7Ct1khwaEpip
+TjxrPTbhSJCljQT-f3z__W4
+}
+
+AWSEntityColoring(LakeFormation)
+!define LakeFormation(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, LakeFormation, LakeFormation)
+!define LakeFormation(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, LakeFormation, LakeFormation)
+!define LakeFormationParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, LakeFormation, LakeFormation)
+!define LakeFormationParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, LakeFormation, LakeFormation)

--- a/awslib/Analytics/ManagedStreamingforKafka.puml
+++ b/awslib/Analytics/ManagedStreamingforKafka.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ManagedStreamingforKafka [64x64/16z] {
+xLO5kYCn68Bazxd_UTUIlgbBrdTBlOK94FbQVohUU2FTijRX163henEgG2mF3zasWwxg3RfjlgvFmeo8TJq0hEi5Ogfeg_KDPOUkklVv6elklxrkjfJ0mKhF
+SXy95jnlXWZ8IB3Ytk2DMVLw0iVGTVYSWvNk3U3u3CH2zuO-jkzh2RRXVkH7raXWsvFHrGYlgOyvS02c_fHr0Bs6IBDSyvid1O2MZ_TySxaMLj2zGnxfEsAh
+3bu0h2t9xzE3Z_tJRlct1dcgFqPT81k0dlKGOPvNfdehDtzo_QIhMfnULDNhoHMan5Vq-51tV0NrhYnpl7H0tAq1qwy3pTnbv9_CIrZph7GULfa26bKXW1qg
+d1IxlkS10liSEG4Ie1ySogHSBzAbiKaS9T9ETijpYZ-UG_Cy-oDWKK_2Hl-ITUmReDtlVr-1tKpuiGo3e9hrlPhh_N-Ry6W7dG1VewS2UhZEfDpgdur7Yzm0
+j0RWGCy-ALxN3H3ilg-Ga4OsoV7DJh7x7QGsWXAxp8LWqnoK1t0Eb_j2ala5uwvksB8nS-b4pvcQFcTnKlp6qQcc3R3zn10psHirJ8fTpTxEjcqfpxPjTDmx
+niFDutpPUbvI_X2yySPd
+}
+
+AWSEntityColoring(ManagedStreamingforKafka)
+!define ManagedStreamingforKafka(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, ManagedStreamingforKafka, ManagedStreamingforKafka)
+!define ManagedStreamingforKafka(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, ManagedStreamingforKafka, ManagedStreamingforKafka)
+!define ManagedStreamingforKafkaParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, ManagedStreamingforKafka, ManagedStreamingforKafka)
+!define ManagedStreamingforKafkaParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, ManagedStreamingforKafka, ManagedStreamingforKafka)

--- a/awslib/Analytics/QuickSight.puml
+++ b/awslib/Analytics/QuickSight.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $QuickSight [64x64/16z] {
+xTOtZaGX44NH1vHd_-iTNnhHjlI9sjmKdGGVpz6xTyx5_B9d5EFBdY2cTpE-xct6tMQ8NVCQzpCMF-fpalImDpHXD3_g6JBdW1tr0fwnvJ4wUXIzZ24hHmEw
+5pq104La2cXOwhlUqCmQRE7X90MVapKP-i-_fOABNZ4YEcpXTMyDQ0rZuIMVd0WWNtZ99uzeBHPUzCdJM_AQJvvUazTyylIMlEIJfqzUyiav8hsrv1M_SaMJ
+v2M_SixhkkfNRcYg3LxsbdmzFqLl5jC0Ni_FA7kbmMqPxEWTFMfUpYVB1p2yvXrDhSDYoLFVzGQQyyfOpNSFWXprCT0QcX_sGIqdwu3FoThmt6tB4xJaD_yl
+klz_sls_RVyVdwDtxpu1
+}
+
+AWSEntityColoring(QuickSight)
+!define QuickSight(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, QuickSight, QuickSight)
+!define QuickSight(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, QuickSight, QuickSight)
+!define QuickSightParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, QuickSight, QuickSight)
+!define QuickSightParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, QuickSight, QuickSight)

--- a/awslib/Analytics/Redshift.puml
+++ b/awslib/Analytics/Redshift.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Redshift [64x64/16z] {
+xPO5jkH024KVKW9l__kTId_t8ZbpDBTTRf0MoF_3pGrVEQDcnXmFPZoUgDWnN0MlYFe8SbUVZeMQjxveReA5JsxPwO2q6U_hZza4yDmvWa77uNxknr3OHlW1
+-puCqz3vfzym-EEXsux_S_mz7_9z_OBD-83u-DZ_uGBedZ_3iH3prdflRv__tFJ97EtZzw-D9BVzfu9Zph6Opr-bhFW7_F05BCN_Z04QftqwrA3duuia5N7U
+nmn1dlNPiV3p-LCXBMi-doyB1YHPyzb5BFYS_o6MV0v07b7NEHHHzGs3Zfxa440po_vSFiIQm0IzdhyeP9bOqeJL_8K2EfdHO3dWrVW1ZJpkf68nQpxJqPa7
+31SRp9Bl0iJhty1nBla6aI_ltVS3cW792pwl-3JebVmP1dYUZy-Cv0K_d-swVtr-T-XFyrlHcN-YFyzltTwVlixlxVs9dFOwlm-UvxTDih8_uXs5_R6mlrxR
+dwzpS_CF
+}
+
+AWSEntityColoring(Redshift)
+!define Redshift(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, Redshift, Redshift)
+!define Redshift(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, Redshift, Redshift)
+!define RedshiftParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, Redshift, Redshift)
+!define RedshiftParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, Redshift, Redshift)

--- a/awslib/Analytics/all.puml
+++ b/awslib/Analytics/all.puml
@@ -1,0 +1,379 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $Analytics [64x64/16z] {
+xTK5WiGW38NXbn1WGkv_tjMwDwml__YqNrtmNRK8tISXfBj5W4UVhDpBTExBtVweRxvv5TfCz9eNnCqWrpo9bOrCwAelc_bzJYdNU0QWvlTAe0glJ14-tt7L
+w5d_h6yBJ-hR_W9wMCSTNf0OiUFtVCUj23f-smjojmbSNiR_7BwRkz-dN7l-k7pz-IyXWC9cX13ap3CuxCRWCwyGsqsWPxvaIDn9a2zilqYxnJzv_sg-UQlp
+KU_sc7b77-V1mHEFioLN-0iz0m
+}
+
+AWSEntityColoring(Analytics)
+!define Analytics(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, Analytics, Analytics)
+!define Analytics(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, Analytics, Analytics)
+!define AnalyticsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, Analytics, Analytics)
+!define AnalyticsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, Analytics, Analytics)
+
+sprite $Athena [64x64/16z] {
+xPJPkkGW28GBMKtU_tsd5TFC5h-SSpFhVzMBG54en-_9V_xJmytSurF1BWqBOkiVZBOHt4JDL9W0I7macW3sgXbAW3pLq7cK-p4b-QFm8BIABXJGP-5ouoX1
+7eHNbUwcgXRlxxHHyCCHPon8ulslxUFvaXWDQ6Bkheot-G5iv-XeRxEuT0_pyvkXxTNdCVbkM5skmWpRJLvMzPPw2ri98WLiST0CZ-6_UVz6EQEKxRe88IoQ
+zjcJPdBUXvyAcKuJgxqO_hTCEvKGzVi7FvZd36JhN2ppD0Kmudxw4vuo1zHQTj57zdJ0xYTW_89WwRCo3Hehw1YqcSOXs_OPaSNECNUjmeV0P-QzWUsoAQSk
+SGRup6jXbUr7d2Ov_4pJH_iio9dRitZqespkrjB0Yj_fhq25Ntb7XgZ-iVTFtsBBKU_bZDql4PCNBVFNcDBAR7ofk44mI0ClquzpnbLXmlx-Te7cTMVp2DUM
+XlKCZB9_lqMytjyqT4rHqfSTjjP7c8fS-zT0W9qzkziZF-uV1y815-XMUthBgRbGm6QIRVdgJjRAhXlaIuMUc_1Qy4P8_yDpaVdLXksz0yLH5p_XiCS9D4-c
+_y8iwdbhdoieYulJKGdysE64ziE9BkN1VWPvjbcUgHNShixEV44xWZ42F5wu2G5anxayEFDfxmbjU4FibpL-ZZqGnmEww_JVefUta7oFdoCV9VVZqtItE7uN
+_lEVBm
+}
+
+AWSEntityColoring(Athena)
+!define Athena(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, Athena, Athena)
+!define Athena(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, Athena, Athena)
+!define AthenaParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, Athena, Athena)
+!define AthenaParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, Athena, Athena)
+
+sprite $CloudSearch [64x64/16z] {
+xPK5bgH040L_kd3_yuxLU4CzP7qxdhMGaK99_u7SkLDFz5b2cG0GMvx8R2DMNXpiHtCJe553vGBmeHeKqEeFKW3ltGZeUpe7R7zshXvKkeysalPMu1_XHdX6
+yba0PE-Wtfyh1iJTUDGUu7tL-tkurDlRyALRzdIGe7UHVlm8aofGf_KSWtyNZV735a4KjASmwaFq0KjM1tGHv3AT7lT0a6j_EiYdxO_wIe1QAouPaCd2XutP
+WwE_CsfAdYn57rthUexHKu4cyJQUgEtu5jIy_e3DNWvlnoVahOiLYCOpt9iGrSY_AO_fJbJ4veGCtihpao1USiZgCYLK0XmzWv7THP2eBtGxk2khvmHuBA2l
+S1MDbJVbe_PG_eHa2upt28fWguELhbs2N16KWEkbBTqbuFn-dpo7xnMK0Ffkg12C9RTRq4u0gNcu2G5Ci6E23W46fD5vND2LRkQHuyjKCEUF5DWr0Q6k21P3
+z1M1m_kAG91zKg3TRU3kim9Y0cMVf9H0KdsUgke_XZjt7W4
+}
+
+AWSEntityColoring(CloudSearch)
+!define CloudSearch(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, CloudSearch, CloudSearch)
+!define CloudSearch(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, CloudSearch, CloudSearch)
+!define CloudSearchParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, CloudSearch, CloudSearch)
+!define CloudSearchParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, CloudSearch, CloudSearch)
+
+sprite $CloudSearchSearchDocuments [64x64/16z] {
+xPS5bWD120K_j07tl-yAgncXUIyk5HcjTiNfe3pOeAibqO4DXgMHRLzR2hMnuoE5FBBV9AJD_AvnpS_yEaBgGvO_oo0GCr8m4sW8uvTcfWLEcPMVKzIi7VW_
+rsrUV_x-shT10Ag4T00qREqtzJpCyRHhM_f4uc7EyBGAqT9de9iVOjZCkX-MFekP4YQGcWbl-DNyGMaXnQEnklB5q-MPY1ZVhyZI_odzfY7zfmPMlZ2SpCp1
+YxggdlOydeUAFse1Qcz8qNe5IiM2eOeKghBV_ubB0FDq_BIGSJu_d_w7dZyf9lRd_UVCzJSTFuuglzVwfx_MFxVc7rz-nzVVyUldL_qTltzB8sVOlnwnVpw6
+Tm
+}
+
+AWSEntityColoring(CloudSearchSearchDocuments)
+!define CloudSearchSearchDocuments(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, CloudSearchSearchDocuments, CloudSearchSearchDocuments)
+!define CloudSearchSearchDocuments(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, CloudSearchSearchDocuments, CloudSearchSearchDocuments)
+!define CloudSearchSearchDocumentsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, CloudSearchSearchDocuments, CloudSearchSearchDocuments)
+!define CloudSearchSearchDocumentsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, CloudSearchSearchDocuments, CloudSearchSearchDocuments)
+
+sprite $DataPipeline [64x64/16z] {
+xTG5WgHG30JGoeydzp_lIlj8s1qtNWjMXKDDThjTvelQ373Miosi1QxdYCXsS1SZEYEUlkDa334NiD5J3qEm13TuGUe9YBB2BhoAa4_OVL3TivxIhmMD1I80
+V_-N6rOzGG308j0w_060rrE4Y9N1knrMBXBrR-dkMLS6h_hRlufhv075NpRrhn4TZfbKzUOwzNd_-tuawX46xRyTopXAXMKQz7P6LoliqVvXeMEJTxLDVJOp
+nfBHEaM6_f7to74mzSNT1SGZEaKsZj-mwH0P-yV_79qZs_skGVzVlqQVlh_tNtxzQOte57cZ-ryZGc6LWslaRPv_LbK6wuXFaJTv_pcqgnKQ8pr57kqdmCn0
+ri7J8qu0oElawP6CoDgMSSdiThlV
+}
+
+AWSEntityColoring(DataPipeline)
+!define DataPipeline(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, DataPipeline, DataPipeline)
+!define DataPipeline(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, DataPipeline, DataPipeline)
+!define DataPipelineParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, DataPipeline, DataPipeline)
+!define DataPipelineParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, DataPipeline, DataPipeline)
+
+sprite $DenseComputeNodeResource [64x64/16z] {
+nPS7ZWCX34NNuFhlV-0DnD8qaUOjFxqyZIlWhzyMRVe4TsmAUXidxDK_uKtkqWzvphVjGrxoRGTQaTSY3wCQZ-WLFW1e9VuCmDiRl07Q-fIC_FLunmTodEkF
+x7KVUc2lpB-ycWS6OCDu1wpVD72oQLFuq4Cx5CZOKsojrx4NBMao87Ypn3VUrORK7_0jW6ZxDCYb2tZDS-nYb1wqSnVAafTBZj83wdRXrSyA0F1ZX1NGRW6S
+US93qLQzgIlljf0dJtdbC6PSUNvGGPJmb0qxZl7F3bt6KH8sRZ4R2EXqbnpuFagYJwofkoIVPbCk0FiuuC0ha5dZoKm-uLqEbhp0Y8Tp5B16BNcXusRK1GYv
+Y_lNZX_NjjiJ8sXHOGq8tyVxmDjuylbOLQXa5bOytrY5BVdXGT2lyOFzpFwCNq2omp-8dujFutmaoEZj_27tXkO0G6_M3xMRye-TUtkZVWlzK-hVmlfHNh_g
+wsTz_Qxk7-Nzgxv_LlVlulcXS7ufdP-AvxVQ-P5gvzT_F3_3w5_dXrQQd_vdVjkhL-VNulpy2_e6
+}
+
+AWSEntityColoring(DenseComputeNodeResource)
+!define DenseComputeNodeResource(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, DenseComputeNodeResource, DenseComputeNodeResource)
+!define DenseComputeNodeResource(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, DenseComputeNodeResource, DenseComputeNodeResource)
+!define DenseComputeNodeResourceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, DenseComputeNodeResource, DenseComputeNodeResource)
+!define DenseComputeNodeResourceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, DenseComputeNodeResource, DenseComputeNodeResource)
+
+sprite $DenseStorageNodeResource [64x64/16z] {
+nPS7Zjmm34L5YVNV_y1PUGYumSROJB9_UdamgoIsVorQzGPth0fwZ1Es6czuau_q9S_vjh_a9TyEe1TvBV8mgl68KU43W5RYpm2S7l06Q1-B11Xjn1CVo76i
+FxBlVHY1hJB_ycqU681DunsmyQE9apa0X4_Tsg50nfvYRRs1hQxD80E2LqjyvLrjIls6xm54twP1Jbt0rpp79aRfGJzseLpoSifHUa33JhpwKG40le-m0Zei
+W2DFk1MjrPiwysuNykGfhnp6Z3FFDnL42I-oQSSX_jcXLt6KX8rxB0q43Ff8TloO9R6OnkREoIFDfbm0jd70ZbTCwM9M899FUCt19IymukcSGnhrv26qtuo6
+024VyMXRNcUTQWjmkwYm3eGVuhtoDf-y6O8l-2QPXIkUuKlhU3_ogmT1ztmZ1O9UyGhBxkLdzcVy0fANaUVnS_5fd0eBC9xd3v-uUG3Gn_L3_KVBcy7SsuFw
+BVHFhNyBwqTv_Qgld_Nrkxf_bFUl-lvPtR-BvuV2-QLqVYgUtshdnruxl_xY-Hb6lpe_zDByz3lpsrQZEhyMv-T_e3y
+}
+
+AWSEntityColoring(DenseStorageNodeResource)
+!define DenseStorageNodeResource(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, DenseStorageNodeResource, DenseStorageNodeResource)
+!define DenseStorageNodeResource(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, DenseStorageNodeResource, DenseStorageNodeResource)
+!define DenseStorageNodeResourceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, DenseStorageNodeResource, DenseStorageNodeResource)
+!define DenseStorageNodeResourceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, DenseStorageNodeResource, DenseStorageNodeResource)
+
+sprite $EMR [64x64/16z] {
+xLQ7jfqm39CTx_p___OGxke8j-Hr5vt1b17UzGVZmeLqYrg7043BLNe3gJ9uqO3lJ86kglVjaE1LVknyMkChh5TLeAtn0-HLmV0rVXB0ZEVdNKNpJFWQ0mH-
+N6-mxwNhHioiTgC8s4Bnvcyot3p6toFlRhWTighxOJIZOO0qwA5q5s3GlbqnyYZVITHqM96NE5HrWzKnFndajrC5zCMiXXBQmzZKtq_J_jHVXWq4oGgU1a0_
+pxF0IDzq8G1a6SC6PAOUb3lHzwEXfJK090RA7Y2cvlDmwxDi1WY3x5bT8RqTHvuHN_0LfF58PGCV9plL5to7zAUwDucNmtmo4K14-cNXqhXOvpEaJklN_fe2
+KMVznvOF-S_qE1K_rgWHlsAeD8awaJ-XF4mu8RjZGEjK_eRna17Lq2ADu6Vh9nMuzx4Uut2gVhj2NG2hjVwHe9pqZtd_ocUXopYBcVvv_upN_hdxx-cMjx0l
+-dSoDkZo_2XhBB4slzRdPpBy5y_l-Vwmlh-ixqyD-l7zxUFxu_h--eVYmeLF
+}
+
+AWSEntityColoring(EMR)
+!define EMR(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, EMR, EMR)
+!define EMR(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, EMR, EMR)
+!define EMRParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, EMR, EMR)
+!define EMRParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, EMR, EMR)
+
+sprite $EMRCluster [64x64/16z] {
+nPS7SaCX30M_6fBU_G-SaOt73AHXKZR5TUb5kduRUlAA7dYIj5yxHkGLt-rEUz7N_fHVzAq_5O0F_NRem-dCHyg9dm3QoVWhWA0Dtu76SiDg_YHt-a21UVsH
+VxyFaXZfys_VdGS5uDNu0BnwK3fv0416yMax6XvZJ_dSUe8HkZgipQj4TrE-EGwaFbiIJp-Q5oqUFhV4I1Xn0idZDDYo2xJx3UXTyeX4aTCOKI9vteK6KDV3
+c1vVbPPOvgZtWCHddn8fwyZdEffDF8751-1o3P34wZCwgr-acmepYxPx9J7Ar6jELyNg9oOo4RDSUBLZ6dy2ZAr_fLT2ZfXaLywgMW2XExt-laE9HLNbFWyt
+VsmszGEWwX_ezLyJvK_oOmw-wsEMYm34WBGxAjU7Vb7oF8aPlR-T3_sI5wpFmjT-V7YT9XtxlzR-y_4xdx_pzNE-VZVspmV-rlvT_QtpGp_mltj-sUf___oy
+4ZarW6pZ_Au7P5EccqgiLSl6_N5PeiWRk96sSNzTP861TAMT-xCWqTRgJLEXZVlxF7uuZr_EuwVp-EqyVZoFNty_VeRJl-OFV9G__K_-DYAd-UjX_lmBl04
+}
+
+AWSEntityColoring(EMRCluster)
+!define EMRCluster(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, EMRCluster, EMRCluster)
+!define EMRCluster(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, EMRCluster, EMRCluster)
+!define EMRClusterParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, EMRCluster, EMRCluster)
+!define EMRClusterParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, EMRCluster, EMRCluster)
+
+sprite $EMREngine [64x64/16z] {
+xTPbOeGm40NWYOoz-n-uXM5fo2fIvrlvnICkTB3JIMr9Q9M4Zj4wekz47IuwODh48BI7GRydppO2t4QLLb7qc5R8W6kOnu5MA42X5WFffO83z_aAb3n8T946
+j50Tixxy2yjHa3e0r_6nf5QYa0-vAt_cQOXxMqwAxdKurqccfLA3ngCAA3ChO7C-0K9FENJyDne8a9fyfQSCbdDnA0tgCi-lb1yYpwlpXY0Rywa6Mfdl_R1y
+_URotSptvCFsl8dej_RVBycV-HIc_EhzJnm3hv4_QF_pQVzNqPPawXciCY_tNn8fyRAUtBdHM5l-hDeIe7VE3mMub58T_lYieCvqI9MNxXLoFI8CrEQeTdvs
+3Qbzt6cKSYabfwVJgnaJKGTGQ0LsB7cXLR9OYnCTwtHw0m
+}
+
+AWSEntityColoring(EMREngine)
+!define EMREngine(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, EMREngine, EMREngine)
+!define EMREngine(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, EMREngine, EMREngine)
+!define EMREngineParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, EMREngine, EMREngine)
+!define EMREngineParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, EMREngine, EMREngine)
+
+sprite $EMREngineMapRM3 [64x64/16z] {
+xTQ9akew38JXbYLPwdx_1xx7E5Gb51IptVryC-pyYDK9VjXllrLVJNoAwK7ZSsRzCelYh2Nn9Qs9xsZLtzDdtqZSPmAVKdgK-8GXiGxtpm6Vu9BZB2NxqE0j
+7_kGV2o6Erjm4TJXoVn3ZpseA8db-CMgVUKw6O_pxsWhvtcExRUNOiPXuCfZgttNaYepI-fxluudtgBgTjnOfcIdFl1MgyTmgh34jS-FpDzsdv_kMzlyOc-n
+uTFzrJ-iZti_SfrTHoUPCsoVCI3IRCxCf_E3t4TdrB4GaG6ZV93IkMStToyvMWsBT2161C36rDWFTFouNN7gjzspXjZ8fjn4AbUVkwUiA8UnSEvxpZhwoUeY
+05EQveh9oSRgYyKfNsFowViN6cGKCQfttpII6hT-9jlN_54QJzy_MPOLqVHx3_PGxjugXlPguIzw0BMQM7tdVWbDk_K0N3uoI7lMUnk0MGXMXObiGnMyrz1A
+0AF7QBNZMNzbcdZfB-ZXutFzUxOzxGDlJMfXxFw7rZyUwt_DEflZsVeRcTVr5tCU7-QZ-MAFfY_pxwAlf7gn_IWftJqeuhLMu-g-aV8FxLTCAN2LKfmsrSnt
+ko7nc1CtDjnzsDlbzVIPpA8anoSaTKN7fupPPsduMR_zzWS
+}
+
+AWSEntityColoring(EMREngineMapRM3)
+!define EMREngineMapRM3(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, EMREngineMapRM3, EMREngineMapRM3)
+!define EMREngineMapRM3(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, EMREngineMapRM3, EMREngineMapRM3)
+!define EMREngineMapRM3Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, EMREngineMapRM3, EMREngineMapRM3)
+!define EMREngineMapRM3Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, EMREngineMapRM3, EMREngineMapRM3)
+
+sprite $EMREngineMapRM5 [64x64/16z] {
+xTO7Sfr048JXtidJzp-m2nPAGA60v6n_BuUVdF3R-MzSuPdcMUAHSUqBp_ZKB5yPFgMO-8fYV6K5I3F7wccTpQCEF5Ay2ZoWPFfHiyUpNd3av4TwiIb8nP6H
+RWiTsCXY-pJcQt1txPsxdZzOpq-svjrs-XEliwjy8QVFIpX81z1ibSt0cMnyhecSy-FDtllv_AvcpkTzZiUpljZhU0CBUzptwO3WZ_lWv9_i8HCUzsU_MMzx
+h-d0oC1HP8RCDmFm54HcZaCVO-ZQ6tl0kt7K7UpvnZ58HNV4ePzcJqEp894Ek4KCTC4fmFg3hRq3kEyxbLsmJDfW9sFfO_PDgQ8EfezZd-wnzTwLENSB7mnK
+exaTo3khsgWZYptkbfzHkZKRshttexieQn_M9LG0HhrRVyQXWMnqoTRN-ZvcFqBttd3V0qjV7KlVIKStaWA02K2eaj4zxdg9fJU7PhWELWRW3Wa5u0PWn1XH
+ARZhpmO3RtY_xw_r6Dzx_nawtVQ6T-LRnv_uxF6lVVxKPwMuAfQgzjRRsiDiEwbSvKqVSoY7u_zE8a_k-Zdcd2Vu8EljSmKkP2uaQMxqxRNhECkjaEobBdtl
+AZ86fbcHXMaiy3ObJ-ja-IHuG8jd9NZ68b-4uY_ptt_V
+}
+
+AWSEntityColoring(EMREngineMapRM5)
+!define EMREngineMapRM5(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, EMREngineMapRM5, EMREngineMapRM5)
+!define EMREngineMapRM5(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, EMREngineMapRM5, EMREngineMapRM5)
+!define EMREngineMapRM5Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, EMREngineMapRM5, EMREngineMapRM5)
+!define EMREngineMapRM5Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, EMREngineMapRM5, EMREngineMapRM5)
+
+sprite $EMREngineMapRM7 [64x64/16z] {
+xTQ7ql8s58JXbKxTlVyBJeJmZ4rW-5hw_z3BEuSg6p_ibr-ghnAVClIWyJbPlykYcBK4lgIL-8vM_Jrzz8t4ld5yIkbHu1EcnBexlWTyWac6iv36XmPlyTYx
+P7CPE8m55qxTFPb_rtCFAafYtPusgctbEfcFymySA-TvpjWVByNmkuahywtsKqkgY2YfZtwT9zwYwdRUM58QfzxnLgldDAgm-BKFl4LjkuzFzwqjlzWFt_3f
+_keVrllHprXNrzb9HFhOLmRWCMPcndmstybzTaRT5oBICIXpaefJpsxkNZAq6iF309_k01kfkNhryUSEdUPlksTDiH5DsT2Qi_hOFJMAjxw9Kz-PTU-JrKK0
+Gp6KAoQJZTKNYxdwgNpw-RacwKNCwjqt1qdDMv_1jjM79fv-VXfHeuYc7JtOKx7xKJvNtyIh7a2jnbVViTz2Sznw06l-L3xlhGU0B3YhV8ZiWIfO6u0A0BCd
+lEVp_ceeySfVqSFcv_htnlQqTxoLr4BV_G-jVxol_vLrblFP-kiHr_KNcViVzGVvOe-cB_CFtbTIlTX-b1HcvXJnMgjnTMoax4Fx5IavhaBoqwQQyMutn1zp
+ucPCCvlZxV9w-awoACdm2K5TqV0fC_ii1dxMBx_y1W
+}
+
+AWSEntityColoring(EMREngineMapRM7)
+!define EMREngineMapRM7(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, EMREngineMapRM7, EMREngineMapRM7)
+!define EMREngineMapRM7(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, EMREngineMapRM7, EMREngineMapRM7)
+!define EMREngineMapRM7Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, EMREngineMapRM7, EMREngineMapRM7)
+!define EMREngineMapRM7Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, EMREngineMapRM7, EMREngineMapRM7)
+
+sprite $EMRHDFSCluster [64x64/16z] {
+nPU7pi8m38HnbkDx_mV-LJ1gvFmfq6ES1lDJFHAFowSbkyxW7RjCNiO5e_8PNkjDxIHV_6qwoLT_cu54yetaeSBniCpm1g0nyIy0-YjHLA2bV5NTyfVj5H-a
+8vu_qUTzo8PHdl_wR1uA0DsCxu1k7couwDKcwviExMYunrviltePesJjkW9MTalwplUccre_u9C1biOqrEaMb3LVR8YHUv3YBQnBlauvSWyawyIt7cNkUeXc
+osf0v0N_IQU0uAwPxnfaWHT_icafcFao5rsTOBSgnVZx3OryXBKakruW8CjDzOWFPeiNW34EEE1RXEyvU9Bl4VRlaIjWzQQIBolUVPOfYTP3l1Uymq4rdesb
+_R9ifoOVu0dxgVYn-QFE3tj-oVj3tr-YVj3rYw-VVFrc-mVTl_Z-oVPlSduWvXTgVYBdDsv-56v-_U7y39MVxW-9sfz-ix-Dokp-IkxF7z0V
+}
+
+AWSEntityColoring(EMRHDFSCluster)
+!define EMRHDFSCluster(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, EMRHDFSCluster, EMRHDFSCluster)
+!define EMRHDFSCluster(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, EMRHDFSCluster, EMRHDFSCluster)
+!define EMRHDFSClusterParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, EMRHDFSCluster, EMRHDFSCluster)
+!define EMRHDFSClusterParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, EMRHDFSCluster, EMRHDFSCluster)
+
+sprite $ElasticsearchService [64x64/16z] {
+xTQ7hkKW38JX0Opj6Tx_VLS9X-ZcRWdQtdwrj2-zwI_kV_-ZjLVyAfzOnLTwur7_UZyaZM_mEZgyh_WrFebLVAMlSMJm1yHQPfKttyvJuOy-W9C3UVSwsl5T
+H_RjdkPVxoEaePUF1v-jpkpoWsx71AVOyi4xLipfQLWPfKVl8gcsV1IK7YIp5y0t_7cioplGgLSTwAC_ULtUHznlqom8-QQFGfMJqytcun8erAwtqM7p500e
+EG_1Tdsc2YW5O95zEXPmqrDvdkk26BeonAP_ZGJitLsvw-Usthsp4krd-Ka3xUvjs_jvhEMsf6yVFqdKTSQk6dBJHwYU2-TjzujsVHk1gdiDY5sFL8FfRHq5
+Y3sVw8C5TkSC87Qzn88QcaL5IIc0sFPY0ufvk5K0JPeh6B7ffMYODI-mQmLzrsiml7jGr-bm8CHDturQtLQmwGt9CWVppGeAz_tr_Qjh1SCGNtX_Z-dFmUdN
+_ylh78p-ET-yz-uLZ3Lu-7eEDiGy1uo2_9GFh9XOaLWTYFKOwlfayIflWxc6TSJUMkWlwN__-m
+}
+
+AWSEntityColoring(ElasticsearchService)
+!define ElasticsearchService(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, ElasticsearchService, ElasticsearchService)
+!define ElasticsearchService(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, ElasticsearchService, ElasticsearchService)
+!define ElasticsearchServiceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, ElasticsearchService, ElasticsearchService)
+!define ElasticsearchServiceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, ElasticsearchService, ElasticsearchService)
+
+sprite $Glue [64x64/16z] {
+xT57ejim38JX0L48ZEv_trWbJIiABpt-R4chdvL_hhUtZ8Z9Fi7BP9j8wCTwUg-l5r8WlVKRNe8sNehFANJ0sQPWtlhM_6Mgwitzpus9NV6nofTYmZWUzZLT
+XmXUCg4vm6a-Qx5smOl8KDLAxEW0n6fnvpQpU0btdsHE0umB71WMCwkAbyePDW3d2iL5BhWeboGGuQP3BaFD8zPlqQ4RRpQ5SzL0y2Omk2mXjxMM8BdEOVTB
+TJuXcFp6XF29Uo2OVCRWj-qyKuAy7UUo-uKDJ3wdS1uSoeO2ybmzYXq1FTSHxBZsFJ7O59ZRDX7ztZFz8_qXs9LkvicsIZABROPC6Bksiz_Ougg2J8Ygiq40
+IDNnOKCEI1wVaUmeXMGEQB79yMBi2y3v4PdySxszVG8
+}
+
+AWSEntityColoring(Glue)
+!define Glue(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, Glue, Glue)
+!define Glue(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, Glue, Glue)
+!define GlueParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, Glue, Glue)
+!define GlueParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, Glue, Glue)
+
+sprite $GlueCrawlers [64x64/16z] {
+xPM7aYKX20055QJ__tylKCoLMpUtxbnENS7O1kJDctmBtXRVGiWYp6o1ssDM-gkrra7ROspt-v_fV_lzGqG6T7bC-X0H0F4OqlyU-UDx_YpufloP8D_oVi_z
+__wtntzz8gfn93R_gzZz-8Rzp_4RDbiXq_Hf_2RWfGUW3zyluEeS0FwDlZtqPpg9B0Xzw3SdhhuEeptrPyPCLF82sX9HRQVuRvls1U5gn3Py-Sn-uP2bRjC4
+WYHWjHl_Xha70C165kE1hwFdF8NeUJaYEwGF-UBvHrO-ZbiWzUmpFQzGLSXFyPiric0EQJeCvZPmUZy5kpAGSBYoTn7ju2Shzr4sLavYlidl44C3OWo8FW5J
+Wv2ZNyt4fRN0MjCWIU4j-JVYkdDaeG6icd_p_s-W8Y-JDwJyhPtS_F-JZGoIPwfP7hRylSCo8M_9rucyd6In-m9UXKwxP-O-QARUUEatpn3D77W5XLNVZjsl
+RuX63ho6WsiTV_S5hCTX-_hO0RRxILJ_2N60-Pc_THzGWt7dJsrlGk_zQEtd-7B5IHt2PFlPdDXt5IE9aIc9dSNzh3C07mjOlVKA_XcP2x3ohX-p0sksCprW
+EtVTerXwr7EVLN4hr06R0I77q37hPxIX49cQfo2Ecc7iCsLLHYoGG-wwf15Rl7LTgtMtyazeW6UqP0PuUqXzSyqyIFqnuYyVyZbg0R66j9tt
+}
+
+AWSEntityColoring(GlueCrawlers)
+!define GlueCrawlers(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, GlueCrawlers, GlueCrawlers)
+!define GlueCrawlers(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, GlueCrawlers, GlueCrawlers)
+!define GlueCrawlersParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, GlueCrawlers, GlueCrawlers)
+!define GlueCrawlersParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, GlueCrawlers, GlueCrawlers)
+
+sprite $GlueDatacatalog [64x64/16z] {
+rPU5aYj124M1nl__VoDTFDbUQJQUKn8zTIz4PWPEIEG90epy5K5mHdD2GFbB-AnJPgY8uFcUIHijdpC7JAZkzS1_FhwMFtI7_EXBv0xyoUVOuVZA-oEM3NoN
+_VNz-D47tFAmxoyYqXd4N_l4wX5PHBZ9mAwFNoynRBHycdQugGYV457po3FIyJtJXTQPYIqpgUVRG5WXRVfSqwhmc31B3M2j_VaFNxsEpvck5l6_wUgPslpy
+VIOXqPWGOJtPzCSvQe7hkOuF_dVJIwUMNmNMU86T_qE1oC2sNmNM-AvV1N29x_jLO8bl--i6AhxlLm5Rufl-Mg3Y-_vQG9RudWzM1R3YU_vQeEBR_bfWniCb
+VXNWJBxC1qy7q0oyqBVouMtzD8tBVSc9NUh3i0WNwFeDNjrdts7tFN-sBIz-_M4RzBxxyostdNzSvbz__NhzzVErr-z7
+}
+
+AWSEntityColoring(GlueDatacatalog)
+!define GlueDatacatalog(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, GlueDatacatalog, GlueDatacatalog)
+!define GlueDatacatalog(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, GlueDatacatalog, GlueDatacatalog)
+!define GlueDatacatalogParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, GlueDatacatalog, GlueDatacatalog)
+!define GlueDatacatalogParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, GlueDatacatalog, GlueDatacatalog)
+
+sprite $Kinesis [64x64/16z] {
+xLPNWkKm21CTykv_tYs9_Sfqa-qx-ae3IuIs_H7un2VASro5LyFUOUEAqR6Fa_O96LU2wEWdggb4jmOKFZoXAM0ICF3MW5qZmFDg3Jo55uEp4SAR0m6iEWxc
+kGRGOXxESyUb0j1OJsEG7vUf191whb7G6_Do0G0IyyXtnBZDgvIT-N0HneGTH7mWNYQkyuJ9_3kBo-MoLOQfC14E-8lfHqFuE5PeP-vHXvVB_dZ76y8jxrmO
+7xnPrCmz9bvqC8MptKMgqdNAly5V3xxn4Uyzt9DtLOQxNV7c3qqNEcYBcaTcrNeQXYdZ1df4VC1UklQJF_4I_vVZjot5BnM0U6wj_rSAi5StVuh1yJn_xQFv
+E-VNhNvagNx2FrQ_8XAz_j7iNr7j_acQlx9_5ztD3_9JyqkgCS3bvkZS_9Pp-mEjaPzMTvcyZhXg5kHlsFySth3lxw-_7v_un5S
+}
+
+AWSEntityColoring(Kinesis)
+!define Kinesis(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, Kinesis, Kinesis)
+!define Kinesis(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, Kinesis, Kinesis)
+!define KinesisParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, Kinesis, Kinesis)
+!define KinesisParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, Kinesis, Kinesis)
+
+sprite $KinesisDataAnalytics [64x64/16z] {
+xPO73kCm30INdPJ-_zz32W4XiPBuUXkKrA6NibN6Ry5__bEUztSHzHM-m-_l65_ZnpVw2Rs_4-HN-0MwlpFe-0eKtfM-iW6g3Y1V5w0r_he2t8qNW_EyNuGk
+882TzjVh6a1U9_trkga0QPn_ZC7U5GWWzJmTWU_9omK0ICmZtpGJtk_o8dNo2cF25IA-4SV1RJITlCQOSuxAC1Kcmer3FmbBuGeXN6j4rPWNhbzVUTzu9yS5
+Ob4pZsQxl8G0a7MyArsPy82F7Mbq6-_8Mgjak9irELwGBeGBEhwQ31EIhzQh_JpcfPnsoqyw3SV4NjOUlwhhWgBFCFp3-wUeEHwP3d_x_BH_rEh6Ju1ZpIBp
+qKyY8blyxVmn0fvz1n6u_NVpjyQpxwFzBQMzyYs-crbyv3k1_77y4XSs_cxzzDMNf8s_NRzvAbA8Y2jXaz_xnSl-GJuL0J1G2Ttus_rBQeoBBrC_zGso5ZhX
+R_RlhV_k_41rtY-YvKa-uU_FJufitov-80OT-Blpcq91pZ23EC4LwY0zzlt8FsJJlrSdYMx9ZwdnM_2V_tm1
+}
+
+AWSEntityColoring(KinesisDataAnalytics)
+!define KinesisDataAnalytics(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, KinesisDataAnalytics, KinesisDataAnalytics)
+!define KinesisDataAnalytics(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, KinesisDataAnalytics, KinesisDataAnalytics)
+!define KinesisDataAnalyticsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, KinesisDataAnalytics, KinesisDataAnalytics)
+!define KinesisDataAnalyticsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, KinesisDataAnalytics, KinesisDataAnalytics)
+
+sprite $KinesisDataFirehose [64x64/16z] {
+xPPNOYGn24GBX812zx_lTf3NsUvndl3-51xAeVu4DsxGyrE-et_AZpFt4_Ofdz3w509-ok-Vd03YqntGpmLedmp01lX7vOnj292USpYsS3oSesMDD01Y7fLO
+aSC-5L3de2iMacYP0cST9LQnUPBfniKV9G1apQf3P5Sig7MlHAl5DvKzAsg7sRDUOrIwpVvllgo2cm0WUxScU6MDGioJDSOePZXpz_b_QJEn86h15_rPsZsI
+h7hi3qFI8tBXPRyOlGacadpabo5JP2_tUYs0uewNV5MHL_sK1mD8djn_bzRNaZ6gcC77VkgSFwZvYpwvhH_TL1wltvmNqhrlXLwlmBb_siFzWmLfFT_TFz5M
+joVd-i_zg-PvyF1hvnfczbyp1C73vrUZ1ctlhPzyViFd_N6tFzqMuiGB49sVkZ_pz-vl0lpDzql0tto_0tRL_oV_f4zddHStRlm3
+}
+
+AWSEntityColoring(KinesisDataFirehose)
+!define KinesisDataFirehose(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, KinesisDataFirehose, KinesisDataFirehose)
+!define KinesisDataFirehose(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, KinesisDataFirehose, KinesisDataFirehose)
+!define KinesisDataFirehoseParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, KinesisDataFirehose, KinesisDataFirehose)
+!define KinesisDataFirehoseParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, KinesisDataFirehose, KinesisDataFirehose)
+
+sprite $KinesisDataStreams [64x64/16z] {
+xTO5mkCu30NW9zcYv_lVTnEdTHTAwV9Cln-AJYGP-P_mzLMUF4Jm0mxdGL4yB_va-qJdeI5vNa5M9iOFTFYwqaS9h6Q6zba0jmfqVa2lpKgXnTDArWKQu3oj
+59gS710ldl2x-rO7f2TFSa23Kva0qgDEXw2No2kQ091cdbLyAfmNsUPjELLO4qmYgcsNzmCtNcM_HJu6cU6zgGWEmJjILkAyHTuzYXmxRcfwbVYANB4JRTtS
+OodU5mr0y-HIwLq5l-Dy9ErIxyZYvWYxAYDyOuVa4tcjzupw23QijTQznk1RyjPfdJJ1XGQhYGIVgrjx6wb0ZwnAtv-nLE9L_AlgmG1wNVilNythxDVwrL6_
+1FIecnVT3MXSNlSV5Kib9kExuoU6eSKL4oq3GF6UdELTeWkSWfgPp_mJDYX0vylvSyny1ZGtvFoVw9aGo1lp5tFosSfy_OU-s9wgtrQ-XhwhslvPqVec3C77
+N23EgQYemTyP3d-wUDarYpxkXchmDzPl0_hea4rIPTCOiWFYSVE-uX0_5cFLB40LOEWEg3VshrOa4yfDeQrJnNplFaFx_OKKCMRxCIxjHuU_lty7fBMi_J_0
+R1l8cVD31n0KR9IENV2kahld5uNMg8ai0-pS-MdsH5qcK0VizFdD03HpwmfeV71-B1DCwdoil1wVNpFSe_ZVylNr2m
+}
+
+AWSEntityColoring(KinesisDataStreams)
+!define KinesisDataStreams(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, KinesisDataStreams, KinesisDataStreams)
+!define KinesisDataStreams(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, KinesisDataStreams, KinesisDataStreams)
+!define KinesisDataStreamsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, KinesisDataStreams, KinesisDataStreams)
+!define KinesisDataStreamsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, KinesisDataStreams, KinesisDataStreams)
+
+sprite $KinesisVideoStreams [64x64/16z] {
+xPO7bkCm34F10bBtl_0MFpcKF0vdixqXlNmOL1-_XVxhlv8ntv7v5JpXyvqWVW4ViFbElufFo2pROUChPE2P1FbL1KYUJffV5K1dAVfL1YcmnpkDhpF8Cm7y
+nGZxTHsG5ntswuO1i7ZLmW7XuY36B_F8yzKgUL81GDGOaTdwqCTKw98ywOef4JqKj_ni-pLvJe-WcufWYdTyo2nyIsuU5JjFxUHMU6LBcW2pVdUMRlWgN3so
+FC9D1HTnF5EuuF1WvEeIf9TYD0fNUQGc8ouLzwhstbBB9lv0Viz_6xyf9bqEqkUW3z_LjrxOfVyST-9uFdwOIqn2-4OEv2qka79EgWq3ktLw5-5B8GBeCCJX
+jLVC9potPZ3coIiqxlb-_IWUK6R7brYDM3nrUkvyltvwyJcYKZLy2kInVil2pxh0ZU_t3-xyaI0wFdNTltAiFFNz_0RTZ8ftgHueljk_nxN_Ok__Rbmc95VU
+O3VZfpk_-5Zvp6RyDkUdhvq_YZmjuRpAWEnvGNRhXyGxvzTWROHygno_YVxhlpu2
+}
+
+AWSEntityColoring(KinesisVideoStreams)
+!define KinesisVideoStreams(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, KinesisVideoStreams, KinesisVideoStreams)
+!define KinesisVideoStreams(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, KinesisVideoStreams, KinesisVideoStreams)
+!define KinesisVideoStreamsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, KinesisVideoStreams, KinesisVideoStreams)
+!define KinesisVideoStreamsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, KinesisVideoStreams, KinesisVideoStreams)
+
+sprite $LakeFormation [64x64/16z] {
+xTP7ckCm34JX1p01fVlVTqQKGqVAxLs7Vr6Ee81FKJ_Ddp_fParFsm9mFIaY1i_NTw0PD4cP4PbFr2j6Q3YJrvwFpzw1BeCwyFAV0zJGOx83PG2UeMr-5SsW
+faxTMcwpRUnMr0qREfE0rTP75lTMWQQh1ard7C3CtStO3TqCEryWeBZRvELDGJomGAFEGN8kPczMDuPE-FqlnjZqoi1IItd_IwDksKEAMwXIr-NKwry2InLS
+AfHBA8tKGgNfCgJJvO3PDJobHjE2aTl0P_T5wIMgMJsYM4g9wNDZDbbe2Zvfj31MUw_F8Ms--r1V3L28O_JcX3uKbCNunxwhyDcEdirDYz-orZfMs_X4ulEb
+KoYfgNXkSjUMNlQepadz00fGPoTGOqOvOjOl-m-3xj3c3Z47V8RjaOl-TQoTZd7ilz4pUpr2H-2d-qy56tfY_tMwfX6hltmgS9rmulpNfxVGgLggT2satHl8
+U1NtYyfAfzndwPlkCHMwrfocNJfGzgWEboyRhXDfzCj-xiOjPbt7KcS6zClC6VUOvGoT6z3qWNQKdnk6Xzu8nuOUa-Nj0qDKAAc7TGDl8rFA7Ct1khwaEpip
+TjxrPTbhSJCljQT-f3z__W4
+}
+
+AWSEntityColoring(LakeFormation)
+!define LakeFormation(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, LakeFormation, LakeFormation)
+!define LakeFormation(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, LakeFormation, LakeFormation)
+!define LakeFormationParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, LakeFormation, LakeFormation)
+!define LakeFormationParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, LakeFormation, LakeFormation)
+
+sprite $ManagedStreamingforKafka [64x64/16z] {
+xLO5kYCn68Bazxd_UTUIlgbBrdTBlOK94FbQVohUU2FTijRX163henEgG2mF3zasWwxg3RfjlgvFmeo8TJq0hEi5Ogfeg_KDPOUkklVv6elklxrkjfJ0mKhF
+SXy95jnlXWZ8IB3Ytk2DMVLw0iVGTVYSWvNk3U3u3CH2zuO-jkzh2RRXVkH7raXWsvFHrGYlgOyvS02c_fHr0Bs6IBDSyvid1O2MZ_TySxaMLj2zGnxfEsAh
+3bu0h2t9xzE3Z_tJRlct1dcgFqPT81k0dlKGOPvNfdehDtzo_QIhMfnULDNhoHMan5Vq-51tV0NrhYnpl7H0tAq1qwy3pTnbv9_CIrZph7GULfa26bKXW1qg
+d1IxlkS10liSEG4Ie1ySogHSBzAbiKaS9T9ETijpYZ-UG_Cy-oDWKK_2Hl-ITUmReDtlVr-1tKpuiGo3e9hrlPhh_N-Ry6W7dG1VewS2UhZEfDpgdur7Yzm0
+j0RWGCy-ALxN3H3ilg-Ga4OsoV7DJh7x7QGsWXAxp8LWqnoK1t0Eb_j2ala5uwvksB8nS-b4pvcQFcTnKlp6qQcc3R3zn10psHirJ8fTpTxEjcqfpxPjTDmx
+niFDutpPUbvI_X2yySPd
+}
+
+AWSEntityColoring(ManagedStreamingforKafka)
+!define ManagedStreamingforKafka(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, ManagedStreamingforKafka, ManagedStreamingforKafka)
+!define ManagedStreamingforKafka(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, ManagedStreamingforKafka, ManagedStreamingforKafka)
+!define ManagedStreamingforKafkaParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, ManagedStreamingforKafka, ManagedStreamingforKafka)
+!define ManagedStreamingforKafkaParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, ManagedStreamingforKafka, ManagedStreamingforKafka)
+
+sprite $QuickSight [64x64/16z] {
+xTOtZaGX44NH1vHd_-iTNnhHjlI9sjmKdGGVpz6xTyx5_B9d5EFBdY2cTpE-xct6tMQ8NVCQzpCMF-fpalImDpHXD3_g6JBdW1tr0fwnvJ4wUXIzZ24hHmEw
+5pq104La2cXOwhlUqCmQRE7X90MVapKP-i-_fOABNZ4YEcpXTMyDQ0rZuIMVd0WWNtZ99uzeBHPUzCdJM_AQJvvUazTyylIMlEIJfqzUyiav8hsrv1M_SaMJ
+v2M_SixhkkfNRcYg3LxsbdmzFqLl5jC0Ni_FA7kbmMqPxEWTFMfUpYVB1p2yvXrDhSDYoLFVzGQQyyfOpNSFWXprCT0QcX_sGIqdwu3FoThmt6tB4xJaD_yl
+klz_sls_RVyVdwDtxpu1
+}
+
+AWSEntityColoring(QuickSight)
+!define QuickSight(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, QuickSight, QuickSight)
+!define QuickSight(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, QuickSight, QuickSight)
+!define QuickSightParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, QuickSight, QuickSight)
+!define QuickSightParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, QuickSight, QuickSight)
+
+sprite $Redshift [64x64/16z] {
+xPO5jkH024KVKW9l__kTId_t8ZbpDBTTRf0MoF_3pGrVEQDcnXmFPZoUgDWnN0MlYFe8SbUVZeMQjxveReA5JsxPwO2q6U_hZza4yDmvWa77uNxknr3OHlW1
+-puCqz3vfzym-EEXsux_S_mz7_9z_OBD-83u-DZ_uGBedZ_3iH3prdflRv__tFJ97EtZzw-D9BVzfu9Zph6Opr-bhFW7_F05BCN_Z04QftqwrA3duuia5N7U
+nmn1dlNPiV3p-LCXBMi-doyB1YHPyzb5BFYS_o6MV0v07b7NEHHHzGs3Zfxa440po_vSFiIQm0IzdhyeP9bOqeJL_8K2EfdHO3dWrVW1ZJpkf68nQpxJqPa7
+31SRp9Bl0iJhty1nBla6aI_ltVS3cW792pwl-3JebVmP1dYUZy-Cv0K_d-swVtr-T-XFyrlHcN-YFyzltTwVlixlxVs9dFOwlm-UvxTDih8_uXs5_R6mlrxR
+dwzpS_CF
+}
+
+AWSEntityColoring(Redshift)
+!define Redshift(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, Redshift, Redshift)
+!define Redshift(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, Redshift, Redshift)
+!define RedshiftParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, Redshift, Redshift)
+!define RedshiftParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, Redshift, Redshift)
+

--- a/awslib/ApplicationIntegration/AppSync.puml
+++ b/awslib/ApplicationIntegration/AppSync.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $AppSync [64x64/16z] {
+xPRdrkCW34IlGAYmx_-yMr89PwtZBxzzquF6rWoupFznSN6HuVONZ_n6x5ru8DtpX-eX85tjBze5PEGyZmcevxiNXJY_SmNTTXT-NjveHVK9US_vFGsTXqJa
+h55w8GVfmuie7SbLCCPQRDp9G_F26jq066jpYBiU6pJMiK3CX5YpOSm2uRFTSNzxaBH4idBVvwuVs3ByIx4gVD_IqB6iN1URGQ_Qpsrxi2QIVuVbs43Izjcu
+vxVIYMFxEbVqvdzhU6m1R7ajn3rhmOkY5VlSTBl_z4zNVbPlJrt7JkhVGp5KY9SF7R4LrVaPG7iR0MpBhvg_5CmRbZUCvWQvp5-nVZBotaZmmfUbAMIvVXsz
+Br97sWt1vkntVRr-dNxtr-W3_9aVsf_7dMBryNlp5mtUXGQqk-lakFt8QNIHMvtxgsxzDHZ5kQifeFEOe3Zwj06K_bevEjErIPmukHTa9PUStwD8VA-EHZil
+zwqq1p-vh2RqxVv1R9udJO2czfTHtB-KKxdSFzbNkTVtRnSN5ty
+}
+
+AWSEntityColoring(AppSync)
+!define AppSync(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, AppSync, AppSync)
+!define AppSync(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, AppSync, AppSync)
+!define AppSyncParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, AppSync, AppSync)
+!define AppSyncParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, AppSync, AppSync)

--- a/awslib/ApplicationIntegration/ApplicationIntegration.puml
+++ b/awslib/ApplicationIntegration/ApplicationIntegration.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ApplicationIntegration [64x64/16z] {
+xTO5GiOm30NWbwIIXFlVbxL8AROrmzdxPVfDQ_YkNA67AK7AQZB0mvSRNupDtdikVtahxyHslH5eAkBJ4jcUBr0RSH6t4KNPzMG-qloJ6Erx36zLUVPOyPK0
+nBr2L2M5VQ8-5_ViST_dgdkjOMyC4KYRrPoAhNgtp4pDLu31jkP7-J7Qh295lQBsrt7Caxyu_wDtslUG5dLBRKea8kZNZpPtm3CBi7d6WvUqUMavUFsK-bEt
+kVuTl7vxzDfyfFoaVlsqpGddL9UzSTlOdBIjQTMxbPIrB-QsggxwEPI-pPTidazSlm24x77FEQj7VQJyKDp7-wzu_tc-_xx6FvVFjXgTV20Vvy4I2O_JKYZu
+2xa5
+}
+
+AWSEntityColoring(ApplicationIntegration)
+!define ApplicationIntegration(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, ApplicationIntegration, ApplicationIntegration)
+!define ApplicationIntegration(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, ApplicationIntegration, ApplicationIntegration)
+!define ApplicationIntegrationParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, ApplicationIntegration, ApplicationIntegration)
+!define ApplicationIntegrationParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, ApplicationIntegration, ApplicationIntegration)

--- a/awslib/ApplicationIntegration/MQ.puml
+++ b/awslib/ApplicationIntegration/MQ.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $MQ [64x64/16z] {
+xPO7acCh301R0P1q__l-mE1z3WorERUp6nKYKxybV_bBnkYjjJuYForklWqNReYDlDIPfgAjKW5hVOpHcmb8lwap1W9UVgjo9OENJsLrOg1HeOnd4Ncf0pRr
+m5-LBsNd-AYgm4xgGAFDgjfE-Ifm80NhXkH9dGW1DBPA0ObZj6UEFd9lfygeS_UVIT7ZwDUYZqVJhohwnrGljBheaEjhy6u2YUIL2jhNekaALwNMtiz_NDyT
+GCnC0Qm-WioyJmQVeQWBKHSPMJkQWCs24Mk-PaHavMnoZ9hEG5gzuc0wUo3cUwSjC-QtjvMNWXhuRkooogTn9EyMOQE_ZS5O1V9r5Qz22V8V87cjD4V-1uXI
+igxSFZQU3_5onU_oRtXbRlBFQYl_ji-_3753ujn_8PWBLY-a0_eqVXdvF7uAUDQ6d76BXAO2eErn_iJ8Zvw_QYe0jYrqNZ_IOxT-bFYuzPlRzJkmZze_-gDf
+jJWU82PP4L5xfefsNi46M6xbKYTIKLSqJ-f0nzSUkL6sr1UUVzyolcDPQVIJElUVcA2LJoAobdeokrNe6JpVN-ocwiZQdeSytv_QKX_7w_tjo-wFloT_-Sk_
+}
+
+AWSEntityColoring(MQ)
+!define MQ(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, MQ, MQ)
+!define MQ(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, MQ, MQ)
+!define MQParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, MQ, MQ)
+!define MQParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, MQ, MQ)

--- a/awslib/ApplicationIntegration/SNSEmailNotification.puml
+++ b/awslib/ApplicationIntegration/SNSEmailNotification.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SNSEmailNotification [64x64/16z] {
+xPG5iYD134DbkuttF_2MgZFvJBqfM7W11Vo6HtWK8e9ZDAgxomL7U5yi710zK-5HC-CdQvyoaDKp2pz4UqgmiPu-s7h3XVzy0weBTwGxyHDe19x8hX_x_jht
+-1xhxVgBVlNt67bd_mE8-WuzJTzx5YvYndvmrTANdhwSDLDCuV8JbXn0EW0hfUEml8RfRwbTQCLCSmewfghm3d2EHl8pCh7wbG-VcSwidcjBjAyjL4ZHb5uj
+7_XODKsc53T_cGayFU4P2NYYrhk-gW0hgoeCDtIgok39rMeaA7kzvyjxDxssCBZs3aH29oD7VkvZ2VqeCol_jZ_XlkYJI706tjldbVkv3oTG0p63CyNvKVZN
+Stzo7P7Jz6UcZvWP0P1zJ8B8CNW4Ay9lbGCiXknGwBDOa1rWqBZrptGNq0J8tIh1RuR5M316W9ETzz7YvBxz0yYgoblp29oXC8P16GvXF1ljQRdrvn5N_oWE
+KS7l8rc68wnI09dp_P_h_ZjYTJ_0t_rtWgZY0MGQZh3CVVsd0Oi0jaCP0daM2Z2UZMQFq9_J--VUFybltOKj2foXMpGemo6Ck8_ci_xXs_F0X_4qytVqp__-
+gJgzVwiUsZ__--T__-0RyT3--GK
+}
+
+AWSEntityColoring(SNSEmailNotification)
+!define SNSEmailNotification(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SNSEmailNotification, SNSEmailNotification)
+!define SNSEmailNotification(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SNSEmailNotification, SNSEmailNotification)
+!define SNSEmailNotificationParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SNSEmailNotification, SNSEmailNotification)
+!define SNSEmailNotificationParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SNSEmailNotification, SNSEmailNotification)

--- a/awslib/ApplicationIntegration/SNSHTTPNotification.puml
+++ b/awslib/ApplicationIntegration/SNSHTTPNotification.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SNSHTTPNotification [64x64/16z] {
+xPJNskCm24G7a0J3-p_mVbXn-NkYzSsMSw59uRXxS1SYWcLq1CdeWYKwTneM6CoCqKTaPb_PUuQXQCniU15bXc1YJ2uSlM6dltu0mS21a8vNA6FWn1al-_sz
+tyTpj8_x3qOjpv4oZVTdC-8Pc2o_ytB9HwQzyDIMBqpkJiiCRBZMH9VOC8-YQKJuCLp-bDW5W8nCAZQofjnXvc4cQfqLQTgfRttqpAHxCCyZsOQ6pwKmxWlx
+EnyjaaM6uW6xglhun1UsDxwg0ArES1WE6ExE3twwX-Fgo-SlFQtKZtvhXcL_Ba_uv_L_v-UpVfSQjxaKqchfd_ZfRGdFpSzCBf6P0i2vZAEGPN07ROp-g1oW
+LSWCXLwYGMQWeen7_oGP00l0PwkC-cPe5GrMCRP9-Z4QDJbV_m5uHFYZUGIzGc4L1gtea8hBA9FowCy5plvHBAA2tqSy34jOk02Iw-UVv_ktG2Dly6V_hI2g
+k07trUllFfz_Dw0LWCtG2e5SGkVCPTJdzSzSVN-E_l7wHWQcAEWLEaM3LdH8nJX6_T8_jLm3NyOvytVqp__-YLXzVoDkxP___VE_V_14tDe_lm
+}
+
+AWSEntityColoring(SNSHTTPNotification)
+!define SNSHTTPNotification(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SNSHTTPNotification, SNSHTTPNotification)
+!define SNSHTTPNotification(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SNSHTTPNotification, SNSHTTPNotification)
+!define SNSHTTPNotificationParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SNSHTTPNotification, SNSHTTPNotification)
+!define SNSHTTPNotificationParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SNSHTTPNotification, SNSHTTPNotification)

--- a/awslib/ApplicationIntegration/SNSTopic.puml
+++ b/awslib/ApplicationIntegration/SNSTopic.puml
@@ -1,0 +1,12 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SNSTopic [64x64/16z] {
+xPHLWiOm28GdYjp_m1lRtnvJR_agSGK61sDadYO3SAegKvI13d2YJ5EmIXil4LD4MJJUnjlunVwxD7uMn-_nvBOFOcOQXt58DV48DGdmDKbmp3zTX_u80r81
+gFpL8KiX8DOa8jGamsb9wDMLHTMryPo0J4GPI3LnY5Jmy1z9XAjzFhfo7y_p_iCEot5kmKYBtsNtjvI5_hFOVvV6pvBuVR3-cFwO_fZ-cFuOVm
+}
+
+AWSEntityColoring(SNSTopic)
+!define SNSTopic(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SNSTopic, SNSTopic)
+!define SNSTopic(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SNSTopic, SNSTopic)
+!define SNSTopicParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SNSTopic, SNSTopic)
+!define SNSTopicParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SNSTopic, SNSTopic)

--- a/awslib/ApplicationIntegration/SQSMessage.puml
+++ b/awslib/ApplicationIntegration/SQSMessage.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SQSMessage [64x64/16z] {
+xPU7RiOW38JFu9dtV-364XA1piZTxVtJ9xwiSmQeYtOD4y2eLcyrqMCN0nPXW6Qb61L7H4EB526ndhp4iT37OQ3Z29-ydoR1JdFmPyKd9eCNdfA8vCCwqDF8
+Nula8uH0d0AQJ9vmaITlYKzrCuAOugeSymn_Gn_2aplZ8dOdg1kcnfXd-3ms-peiVE5VEdwny_4CNrj_TV-_RNwwzv_k_JTwzDRnYsf-NyhhniVpF6YniiuF
+RTx7vIUovYT2O945LFcb-TNFNxI-UDGRq5h3r1ZpCVc1kIshOiwl9TCSynlpgsz__VZTKAb_2ltxY_EhNxzkg7Jzhjq_VcD-zUU7_-VN_-VN6ohDdwhpj-hy
+iJf_hSwVwte
+}
+
+AWSEntityColoring(SQSMessage)
+!define SQSMessage(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SQSMessage, SQSMessage)
+!define SQSMessage(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SQSMessage, SQSMessage)
+!define SQSMessageParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SQSMessage, SQSMessage)
+!define SQSMessageParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SQSMessage, SQSMessage)

--- a/awslib/ApplicationIntegration/SQSQueue.puml
+++ b/awslib/ApplicationIntegration/SQSQueue.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SQSQueue [64x64/16z] {
+xTK5kWCX30HW4XB8pFtlM_TsmxVFXQci_Yje-SMPcPdn_kRuZWk9DuQKdGUZlob173oil2c6p_CM8Rk5HkY-Z29idNTWxojGznxmTTwENaazUXlvwJMwZBtq
+qDVUmT2Hro3yjJUGgBcl867BdlJCEvbvECYsx1i9H-AbWkXBleEealh3BUIrbyF3fLxtt9RkRo2R9fvng84bVoZzoCi_92j_2JBrVTH-Ukfzt7vzqHUhPUnB
+jK_llzCxU3l-4xxEgnrsYfaSJZNznFclwPlIJfvlpg6CWJTp78gglZbQ_dLcPhO
+}
+
+AWSEntityColoring(SQSQueue)
+!define SQSQueue(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SQSQueue, SQSQueue)
+!define SQSQueue(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SQSQueue, SQSQueue)
+!define SQSQueueParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SQSQueue, SQSQueue)
+!define SQSQueueParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SQSQueue, SQSQueue)

--- a/awslib/ApplicationIntegration/SimpleNotificationServiceSNS.puml
+++ b/awslib/ApplicationIntegration/SimpleNotificationServiceSNS.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SimpleNotificationServiceSNS [64x64/16z] {
+xPPNajim40NVvE3xtzSYQmb39GBEUNk3OcFY1_hVv9rtAjmUUDGto6cC0Lj-dUryM6eU4QxdY_XoEnXWhnwKCy1VceC2ylBT551zYLqCkitL_VWdRBNN8RNy
+K020QwjhBp58bkw-8SiFZOc0x2wYJG1Udom27AdJif49ghLV7yxK3T8B6DuRlulmLiGjCRAlT5DLCy-Q_2ubabo7Y3unme1iyhkhUaM2-iG1zSogJ5V0Xx_7
+OSCNZtmGBb_kozMO8anGVPcVX6kt3Hgc3omO_bo_yNq74o10tfxpl16pBy3z11bMTKNJQn8AxzbtS1t_NlG2d-70pD896ID9EW68hkLXrD8d8XwzFC8ddm34
+pCFVvzy1dJTYpZ_BmFl-NI56zNF_3d8plx5Ce_cptyQasNVeV6mHjO_mNxw_0pxy_1g_m5i_j_OeOE_Nna_8x3kz-C54rai4ySa7oFlPzsl62seQc4Bh-Umg
+GdGnOZC27MTTzl2Ppz21JGMw_D2P2JB6l49sdnAyWhQ3B85MBmWSM6-HnKt1fJgL9Rht6A1tzmVipUVlohVSNmOX05WzfllJpxs_xU-F_oRllFCH
+}
+
+AWSEntityColoring(SimpleNotificationServiceSNS)
+!define SimpleNotificationServiceSNS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SimpleNotificationServiceSNS, SimpleNotificationServiceSNS)
+!define SimpleNotificationServiceSNS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SimpleNotificationServiceSNS, SimpleNotificationServiceSNS)
+!define SimpleNotificationServiceSNSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SimpleNotificationServiceSNS, SimpleNotificationServiceSNS)
+!define SimpleNotificationServiceSNSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SimpleNotificationServiceSNS, SimpleNotificationServiceSNS)

--- a/awslib/ApplicationIntegration/SimpleQueueServiceSQS.puml
+++ b/awslib/ApplicationIntegration/SimpleQueueServiceSQS.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SimpleQueueServiceSQS [64x64/16z] {
+x5FN0Xin21DWbl__WrkSSNlrDLKs3aWwSVq7y9FuZtJJlx38VsWEPNp16i-wdQkhcRkRDW8WyO1R0BQSYo6WtRLX0FkcI22_rTu0soddL3-5W0-iEg0tsFdG
+Pz2b0gtsGmJWvxc1ukByD0M6Nzbhfyb9FqSIuivXQ2vED6vGs2IkBL8Cdf8x4U3JsYK3pNDyzOPPAYP7_PdBg01Y4KOX3lutmGMWcMj14nf3cimlkZ9eHu8L
+sqTd2VTgoeYiKL4s1hS0J83jRbQ-cBp69FWRIorDW_PwBsvR6XfrUoUOFLDgG7qjZ4dPdQ0zGJabDGCZttD2Y0YGRwa7n4SD5cZVaKVzRQS_Nlq-wp_MttVq
+zz9ln_e3iEp1PzVF1e-CR10x-PNiHNwvpO_tyYk44BZAv_kJMYp-O7_fP7_Fxv_Okt-KuyyepRyKbX-KbbyKbf-KbjyqgJyGoOP0_KLX_KbX_KrX-u72zWjb
+xIVwjTymsu_34uo2KG
+}
+
+AWSEntityColoring(SimpleQueueServiceSQS)
+!define SimpleQueueServiceSQS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SimpleQueueServiceSQS, SimpleQueueServiceSQS)
+!define SimpleQueueServiceSQS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SimpleQueueServiceSQS, SimpleQueueServiceSQS)
+!define SimpleQueueServiceSQSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SimpleQueueServiceSQS, SimpleQueueServiceSQS)
+!define SimpleQueueServiceSQSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SimpleQueueServiceSQS, SimpleQueueServiceSQS)

--- a/awslib/ApplicationIntegration/StepFunctions.puml
+++ b/awslib/ApplicationIntegration/StepFunctions.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $StepFunctions [64x64/16z] {
+xTPLOWOn20JW8KW2U__prcLTGht_zpvn8NwicvjcrX9nmGD9n4cLkXjma4SumQDBVUvPKBydxq2BQ8177mL408rUIW1fz7CYlvnf8qHjn4yVkdKI9p1u0_XS
+tcELVsw-5Ne2q9EYr_86q1ZAF4-odxTfRoKkCTWG8wzvjmLVpnSPUyqh5cpzkixmQrxhXApdepqhg9FJghFxFrWk7tPr_Cl-hwsVw9WnxCh-6HRgbVFZTS6x
+pc-uv-xFzz__xFkLVJ-pxtVc_yZ_N_d_C_z_Vt_zaQ-VylLRldxCrw_Vx-Rc7W
+}
+
+AWSEntityColoring(StepFunctions)
+!define StepFunctions(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, StepFunctions, StepFunctions)
+!define StepFunctions(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, StepFunctions, StepFunctions)
+!define StepFunctionsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, StepFunctions, StepFunctions)
+!define StepFunctionsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, StepFunctions, StepFunctions)

--- a/awslib/ApplicationIntegration/all.puml
+++ b/awslib/ApplicationIntegration/all.puml
@@ -1,0 +1,149 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $AppSync [64x64/16z] {
+xPRdrkCW34IlGAYmx_-yMr89PwtZBxzzquF6rWoupFznSN6HuVONZ_n6x5ru8DtpX-eX85tjBze5PEGyZmcevxiNXJY_SmNTTXT-NjveHVK9US_vFGsTXqJa
+h55w8GVfmuie7SbLCCPQRDp9G_F26jq066jpYBiU6pJMiK3CX5YpOSm2uRFTSNzxaBH4idBVvwuVs3ByIx4gVD_IqB6iN1URGQ_Qpsrxi2QIVuVbs43Izjcu
+vxVIYMFxEbVqvdzhU6m1R7ajn3rhmOkY5VlSTBl_z4zNVbPlJrt7JkhVGp5KY9SF7R4LrVaPG7iR0MpBhvg_5CmRbZUCvWQvp5-nVZBotaZmmfUbAMIvVXsz
+Br97sWt1vkntVRr-dNxtr-W3_9aVsf_7dMBryNlp5mtUXGQqk-lakFt8QNIHMvtxgsxzDHZ5kQifeFEOe3Zwj06K_bevEjErIPmukHTa9PUStwD8VA-EHZil
+zwqq1p-vh2RqxVv1R9udJO2czfTHtB-KKxdSFzbNkTVtRnSN5ty
+}
+
+AWSEntityColoring(AppSync)
+!define AppSync(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, AppSync, AppSync)
+!define AppSync(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, AppSync, AppSync)
+!define AppSyncParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, AppSync, AppSync)
+!define AppSyncParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, AppSync, AppSync)
+
+sprite $ApplicationIntegration [64x64/16z] {
+xTO5GiOm30NWbwIIXFlVbxL8AROrmzdxPVfDQ_YkNA67AK7AQZB0mvSRNupDtdikVtahxyHslH5eAkBJ4jcUBr0RSH6t4KNPzMG-qloJ6Erx36zLUVPOyPK0
+nBr2L2M5VQ8-5_ViST_dgdkjOMyC4KYRrPoAhNgtp4pDLu31jkP7-J7Qh295lQBsrt7Caxyu_wDtslUG5dLBRKea8kZNZpPtm3CBi7d6WvUqUMavUFsK-bEt
+kVuTl7vxzDfyfFoaVlsqpGddL9UzSTlOdBIjQTMxbPIrB-QsggxwEPI-pPTidazSlm24x77FEQj7VQJyKDp7-wzu_tc-_xx6FvVFjXgTV20Vvy4I2O_JKYZu
+2xa5
+}
+
+AWSEntityColoring(ApplicationIntegration)
+!define ApplicationIntegration(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, ApplicationIntegration, ApplicationIntegration)
+!define ApplicationIntegration(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, ApplicationIntegration, ApplicationIntegration)
+!define ApplicationIntegrationParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, ApplicationIntegration, ApplicationIntegration)
+!define ApplicationIntegrationParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, ApplicationIntegration, ApplicationIntegration)
+
+sprite $MQ [64x64/16z] {
+xPO7acCh301R0P1q__l-mE1z3WorERUp6nKYKxybV_bBnkYjjJuYForklWqNReYDlDIPfgAjKW5hVOpHcmb8lwap1W9UVgjo9OENJsLrOg1HeOnd4Ncf0pRr
+m5-LBsNd-AYgm4xgGAFDgjfE-Ifm80NhXkH9dGW1DBPA0ObZj6UEFd9lfygeS_UVIT7ZwDUYZqVJhohwnrGljBheaEjhy6u2YUIL2jhNekaALwNMtiz_NDyT
+GCnC0Qm-WioyJmQVeQWBKHSPMJkQWCs24Mk-PaHavMnoZ9hEG5gzuc0wUo3cUwSjC-QtjvMNWXhuRkooogTn9EyMOQE_ZS5O1V9r5Qz22V8V87cjD4V-1uXI
+igxSFZQU3_5onU_oRtXbRlBFQYl_ji-_3753ujn_8PWBLY-a0_eqVXdvF7uAUDQ6d76BXAO2eErn_iJ8Zvw_QYe0jYrqNZ_IOxT-bFYuzPlRzJkmZze_-gDf
+jJWU82PP4L5xfefsNi46M6xbKYTIKLSqJ-f0nzSUkL6sr1UUVzyolcDPQVIJElUVcA2LJoAobdeokrNe6JpVN-ocwiZQdeSytv_QKX_7w_tjo-wFloT_-Sk_
+}
+
+AWSEntityColoring(MQ)
+!define MQ(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, MQ, MQ)
+!define MQ(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, MQ, MQ)
+!define MQParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, MQ, MQ)
+!define MQParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, MQ, MQ)
+
+sprite $SNSEmailNotification [64x64/16z] {
+xPG5iYD134DbkuttF_2MgZFvJBqfM7W11Vo6HtWK8e9ZDAgxomL7U5yi710zK-5HC-CdQvyoaDKp2pz4UqgmiPu-s7h3XVzy0weBTwGxyHDe19x8hX_x_jht
+-1xhxVgBVlNt67bd_mE8-WuzJTzx5YvYndvmrTANdhwSDLDCuV8JbXn0EW0hfUEml8RfRwbTQCLCSmewfghm3d2EHl8pCh7wbG-VcSwidcjBjAyjL4ZHb5uj
+7_XODKsc53T_cGayFU4P2NYYrhk-gW0hgoeCDtIgok39rMeaA7kzvyjxDxssCBZs3aH29oD7VkvZ2VqeCol_jZ_XlkYJI706tjldbVkv3oTG0p63CyNvKVZN
+Stzo7P7Jz6UcZvWP0P1zJ8B8CNW4Ay9lbGCiXknGwBDOa1rWqBZrptGNq0J8tIh1RuR5M316W9ETzz7YvBxz0yYgoblp29oXC8P16GvXF1ljQRdrvn5N_oWE
+KS7l8rc68wnI09dp_P_h_ZjYTJ_0t_rtWgZY0MGQZh3CVVsd0Oi0jaCP0daM2Z2UZMQFq9_J--VUFybltOKj2foXMpGemo6Ck8_ci_xXs_F0X_4qytVqp__-
+gJgzVwiUsZ__--T__-0RyT3--GK
+}
+
+AWSEntityColoring(SNSEmailNotification)
+!define SNSEmailNotification(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SNSEmailNotification, SNSEmailNotification)
+!define SNSEmailNotification(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SNSEmailNotification, SNSEmailNotification)
+!define SNSEmailNotificationParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SNSEmailNotification, SNSEmailNotification)
+!define SNSEmailNotificationParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SNSEmailNotification, SNSEmailNotification)
+
+sprite $SNSHTTPNotification [64x64/16z] {
+xPJNskCm24G7a0J3-p_mVbXn-NkYzSsMSw59uRXxS1SYWcLq1CdeWYKwTneM6CoCqKTaPb_PUuQXQCniU15bXc1YJ2uSlM6dltu0mS21a8vNA6FWn1al-_sz
+tyTpj8_x3qOjpv4oZVTdC-8Pc2o_ytB9HwQzyDIMBqpkJiiCRBZMH9VOC8-YQKJuCLp-bDW5W8nCAZQofjnXvc4cQfqLQTgfRttqpAHxCCyZsOQ6pwKmxWlx
+EnyjaaM6uW6xglhun1UsDxwg0ArES1WE6ExE3twwX-Fgo-SlFQtKZtvhXcL_Ba_uv_L_v-UpVfSQjxaKqchfd_ZfRGdFpSzCBf6P0i2vZAEGPN07ROp-g1oW
+LSWCXLwYGMQWeen7_oGP00l0PwkC-cPe5GrMCRP9-Z4QDJbV_m5uHFYZUGIzGc4L1gtea8hBA9FowCy5plvHBAA2tqSy34jOk02Iw-UVv_ktG2Dly6V_hI2g
+k07trUllFfz_Dw0LWCtG2e5SGkVCPTJdzSzSVN-E_l7wHWQcAEWLEaM3LdH8nJX6_T8_jLm3NyOvytVqp__-YLXzVoDkxP___VE_V_14tDe_lm
+}
+
+AWSEntityColoring(SNSHTTPNotification)
+!define SNSHTTPNotification(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SNSHTTPNotification, SNSHTTPNotification)
+!define SNSHTTPNotification(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SNSHTTPNotification, SNSHTTPNotification)
+!define SNSHTTPNotificationParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SNSHTTPNotification, SNSHTTPNotification)
+!define SNSHTTPNotificationParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SNSHTTPNotification, SNSHTTPNotification)
+
+sprite $SNSTopic [64x64/16z] {
+xPHLWiOm28GdYjp_m1lRtnvJR_agSGK61sDadYO3SAegKvI13d2YJ5EmIXil4LD4MJJUnjlunVwxD7uMn-_nvBOFOcOQXt58DV48DGdmDKbmp3zTX_u80r81
+gFpL8KiX8DOa8jGamsb9wDMLHTMryPo0J4GPI3LnY5Jmy1z9XAjzFhfo7y_p_iCEot5kmKYBtsNtjvI5_hFOVvV6pvBuVR3-cFwO_fZ-cFuOVm
+}
+
+AWSEntityColoring(SNSTopic)
+!define SNSTopic(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SNSTopic, SNSTopic)
+!define SNSTopic(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SNSTopic, SNSTopic)
+!define SNSTopicParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SNSTopic, SNSTopic)
+!define SNSTopicParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SNSTopic, SNSTopic)
+
+sprite $SQSMessage [64x64/16z] {
+xPU7RiOW38JFu9dtV-364XA1piZTxVtJ9xwiSmQeYtOD4y2eLcyrqMCN0nPXW6Qb61L7H4EB526ndhp4iT37OQ3Z29-ydoR1JdFmPyKd9eCNdfA8vCCwqDF8
+Nula8uH0d0AQJ9vmaITlYKzrCuAOugeSymn_Gn_2aplZ8dOdg1kcnfXd-3ms-peiVE5VEdwny_4CNrj_TV-_RNwwzv_k_JTwzDRnYsf-NyhhniVpF6YniiuF
+RTx7vIUovYT2O945LFcb-TNFNxI-UDGRq5h3r1ZpCVc1kIshOiwl9TCSynlpgsz__VZTKAb_2ltxY_EhNxzkg7Jzhjq_VcD-zUU7_-VN_-VN6ohDdwhpj-hy
+iJf_hSwVwte
+}
+
+AWSEntityColoring(SQSMessage)
+!define SQSMessage(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SQSMessage, SQSMessage)
+!define SQSMessage(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SQSMessage, SQSMessage)
+!define SQSMessageParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SQSMessage, SQSMessage)
+!define SQSMessageParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SQSMessage, SQSMessage)
+
+sprite $SQSQueue [64x64/16z] {
+xTK5kWCX30HW4XB8pFtlM_TsmxVFXQci_Yje-SMPcPdn_kRuZWk9DuQKdGUZlob173oil2c6p_CM8Rk5HkY-Z29idNTWxojGznxmTTwENaazUXlvwJMwZBtq
+qDVUmT2Hro3yjJUGgBcl867BdlJCEvbvECYsx1i9H-AbWkXBleEealh3BUIrbyF3fLxtt9RkRo2R9fvng84bVoZzoCi_92j_2JBrVTH-Ukfzt7vzqHUhPUnB
+jK_llzCxU3l-4xxEgnrsYfaSJZNznFclwPlIJfvlpg6CWJTp78gglZbQ_dLcPhO
+}
+
+AWSEntityColoring(SQSQueue)
+!define SQSQueue(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SQSQueue, SQSQueue)
+!define SQSQueue(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SQSQueue, SQSQueue)
+!define SQSQueueParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SQSQueue, SQSQueue)
+!define SQSQueueParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SQSQueue, SQSQueue)
+
+sprite $SimpleNotificationServiceSNS [64x64/16z] {
+xPPNajim40NVvE3xtzSYQmb39GBEUNk3OcFY1_hVv9rtAjmUUDGto6cC0Lj-dUryM6eU4QxdY_XoEnXWhnwKCy1VceC2ylBT551zYLqCkitL_VWdRBNN8RNy
+K020QwjhBp58bkw-8SiFZOc0x2wYJG1Udom27AdJif49ghLV7yxK3T8B6DuRlulmLiGjCRAlT5DLCy-Q_2ubabo7Y3unme1iyhkhUaM2-iG1zSogJ5V0Xx_7
+OSCNZtmGBb_kozMO8anGVPcVX6kt3Hgc3omO_bo_yNq74o10tfxpl16pBy3z11bMTKNJQn8AxzbtS1t_NlG2d-70pD896ID9EW68hkLXrD8d8XwzFC8ddm34
+pCFVvzy1dJTYpZ_BmFl-NI56zNF_3d8plx5Ce_cptyQasNVeV6mHjO_mNxw_0pxy_1g_m5i_j_OeOE_Nna_8x3kz-C54rai4ySa7oFlPzsl62seQc4Bh-Umg
+GdGnOZC27MTTzl2Ppz21JGMw_D2P2JB6l49sdnAyWhQ3B85MBmWSM6-HnKt1fJgL9Rht6A1tzmVipUVlohVSNmOX05WzfllJpxs_xU-F_oRllFCH
+}
+
+AWSEntityColoring(SimpleNotificationServiceSNS)
+!define SimpleNotificationServiceSNS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SimpleNotificationServiceSNS, SimpleNotificationServiceSNS)
+!define SimpleNotificationServiceSNS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SimpleNotificationServiceSNS, SimpleNotificationServiceSNS)
+!define SimpleNotificationServiceSNSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SimpleNotificationServiceSNS, SimpleNotificationServiceSNS)
+!define SimpleNotificationServiceSNSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SimpleNotificationServiceSNS, SimpleNotificationServiceSNS)
+
+sprite $SimpleQueueServiceSQS [64x64/16z] {
+x5FN0Xin21DWbl__WrkSSNlrDLKs3aWwSVq7y9FuZtJJlx38VsWEPNp16i-wdQkhcRkRDW8WyO1R0BQSYo6WtRLX0FkcI22_rTu0soddL3-5W0-iEg0tsFdG
+Pz2b0gtsGmJWvxc1ukByD0M6Nzbhfyb9FqSIuivXQ2vED6vGs2IkBL8Cdf8x4U3JsYK3pNDyzOPPAYP7_PdBg01Y4KOX3lutmGMWcMj14nf3cimlkZ9eHu8L
+sqTd2VTgoeYiKL4s1hS0J83jRbQ-cBp69FWRIorDW_PwBsvR6XfrUoUOFLDgG7qjZ4dPdQ0zGJabDGCZttD2Y0YGRwa7n4SD5cZVaKVzRQS_Nlq-wp_MttVq
+zz9ln_e3iEp1PzVF1e-CR10x-PNiHNwvpO_tyYk44BZAv_kJMYp-O7_fP7_Fxv_Okt-KuyyepRyKbX-KbbyKbf-KbjyqgJyGoOP0_KLX_KbX_KrX-u72zWjb
+xIVwjTymsu_34uo2KG
+}
+
+AWSEntityColoring(SimpleQueueServiceSQS)
+!define SimpleQueueServiceSQS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SimpleQueueServiceSQS, SimpleQueueServiceSQS)
+!define SimpleQueueServiceSQS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SimpleQueueServiceSQS, SimpleQueueServiceSQS)
+!define SimpleQueueServiceSQSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SimpleQueueServiceSQS, SimpleQueueServiceSQS)
+!define SimpleQueueServiceSQSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SimpleQueueServiceSQS, SimpleQueueServiceSQS)
+
+sprite $StepFunctions [64x64/16z] {
+xTPLOWOn20JW8KW2U__prcLTGht_zpvn8NwicvjcrX9nmGD9n4cLkXjma4SumQDBVUvPKBydxq2BQ8177mL408rUIW1fz7CYlvnf8qHjn4yVkdKI9p1u0_XS
+tcELVsw-5Ne2q9EYr_86q1ZAF4-odxTfRoKkCTWG8wzvjmLVpnSPUyqh5cpzkixmQrxhXApdepqhg9FJghFxFrWk7tPr_Cl-hwsVw9WnxCh-6HRgbVFZTS6x
+pc-uv-xFzz__xFkLVJ-pxtVc_yZ_N_d_C_z_Vt_zaQ-VylLRldxCrw_Vx-Rc7W
+}
+
+AWSEntityColoring(StepFunctions)
+!define StepFunctions(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, StepFunctions, StepFunctions)
+!define StepFunctions(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, StepFunctions, StepFunctions)
+!define StepFunctionsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, StepFunctions, StepFunctions)
+!define StepFunctionsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, StepFunctions, StepFunctions)
+

--- a/awslib/Blockchain/Blockchain.puml
+++ b/awslib/Blockchain/Blockchain.puml
@@ -1,0 +1,12 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Blockchain [64x64/16z] {
+xPE5WSGm30HNkEw_ubV-c9ar8GicRBoAHXP7WOPV2g0hFyQbSCFtb_ljjzz--ymvt3yyuLCnHrBs39KdV7Z-4t34pj1nqW-wcP4b9QrWrf3Jq1bd-0vLA06a
+JKFB6bAdeP_bonYc8o9OXw766jPX37cE3v75_TTmUVyrzBZm_TNGBtf_rt-_w_-Vw__Vry-_zjjlltrUIcxuLt0_7shNe885SXNu1lu
+}
+
+AWSEntityColoring(Blockchain)
+!define Blockchain(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, Blockchain, Blockchain)
+!define Blockchain(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, Blockchain, Blockchain)
+!define BlockchainParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, Blockchain, Blockchain)
+!define BlockchainParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, Blockchain, Blockchain)

--- a/awslib/Blockchain/ManagedBlockchain.puml
+++ b/awslib/Blockchain/ManagedBlockchain.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ManagedBlockchain [64x64/16z] {
+xTK5ejn038DX6MJv_XTU31H3vRxvbk6VSD9_cM4OXc969DLNA0qmCm3EFetFJEfMfSEgJv4Zr8iovCcS_Id5gG4SNyrlWhrX_xy17UwploOUwSL9IPofYvFQ
+oGspJCoSMAYbZHwfUfA5-_GsB56g1nMgmxJHatXm-RCt05Pf2GKUKl0mc3PwDp911pn1qY9XA0JfLcvcG6tryNh922RKxL4HMSyceMdhflPwLUdTlrV3r3yK
+LN0Tc7yYt_CFc-VVCF7lzMNlzUVh-aEiwo_ua00tjv--i_tuNdLoNjv_VkN-EodsrnJgWmBLNt4SxcMcdJ5t1wYD4ze-ELAze85zYXA8cixV1bUVfLYl7zLN
+w7tzAlLVQXY6uGu
+}
+
+AWSEntityColoring(ManagedBlockchain)
+!define ManagedBlockchain(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ManagedBlockchain, ManagedBlockchain)
+!define ManagedBlockchain(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ManagedBlockchain, ManagedBlockchain)
+!define ManagedBlockchainParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ManagedBlockchain, ManagedBlockchain)
+!define ManagedBlockchainParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ManagedBlockchain, ManagedBlockchain)

--- a/awslib/Blockchain/QuantumLedgerDatabaseQLDB.puml
+++ b/awslib/Blockchain/QuantumLedgerDatabaseQLDB.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $QuantumLedgerDatabaseQLDB [64x64/16z] {
+xPO5Zi0W50MVVE7-5rvZlILXNISsaVdrmdZWdt_-wSgm9JcY-gLncW18YiIrkLwG9q5dTSzXNI50knFQqE6CEudOwmEn65ixUTFZ76ghXrQ3ztekpt-p9vY7
+-nV4Peye0ehgxlduSZu_xVPZbEThG_9653N62_hx5zYEoFaslAW_ylFxp9UzVnsUHDsh7-lg_LFVM80Jw5Ivw0NSp3P7PMODq-ofyKZHY-jl0tIRXMioUARh
+VenEgyr4TLC17bIATJ-vxdiCAIKVz2KzwOFkzPJW04zqenyXoHqyqsNlknun8UzLZtJH4pMjU4USwrZqo9vwn_IZBivVuDCrhojg37lt-oi1e2CoCsm2o9Tz
+lvqXuWPIysnUqa-T_B3_rthzzCUlt_lxXvVlNpvZ__Jo_Ti___np2G
+}
+
+AWSEntityColoring(QuantumLedgerDatabaseQLDB)
+!define QuantumLedgerDatabaseQLDB(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, QuantumLedgerDatabaseQLDB, QuantumLedgerDatabaseQLDB)
+!define QuantumLedgerDatabaseQLDB(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, QuantumLedgerDatabaseQLDB, QuantumLedgerDatabaseQLDB)
+!define QuantumLedgerDatabaseQLDBParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, QuantumLedgerDatabaseQLDB, QuantumLedgerDatabaseQLDB)
+!define QuantumLedgerDatabaseQLDBParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, QuantumLedgerDatabaseQLDB, QuantumLedgerDatabaseQLDB)

--- a/awslib/Blockchain/all.puml
+++ b/awslib/Blockchain/all.puml
@@ -1,0 +1,40 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $Blockchain [64x64/16z] {
+xPE5WSGm30HNkEw_ubV-c9ar8GicRBoAHXP7WOPV2g0hFyQbSCFtb_ljjzz--ymvt3yyuLCnHrBs39KdV7Z-4t34pj1nqW-wcP4b9QrWrf3Jq1bd-0vLA06a
+JKFB6bAdeP_bonYc8o9OXw766jPX37cE3v75_TTmUVyrzBZm_TNGBtf_rt-_w_-Vw__Vry-_zjjlltrUIcxuLt0_7shNe885SXNu1lu
+}
+
+AWSEntityColoring(Blockchain)
+!define Blockchain(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, Blockchain, Blockchain)
+!define Blockchain(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, Blockchain, Blockchain)
+!define BlockchainParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, Blockchain, Blockchain)
+!define BlockchainParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, Blockchain, Blockchain)
+
+sprite $ManagedBlockchain [64x64/16z] {
+xTK5ejn038DX6MJv_XTU31H3vRxvbk6VSD9_cM4OXc969DLNA0qmCm3EFetFJEfMfSEgJv4Zr8iovCcS_Id5gG4SNyrlWhrX_xy17UwploOUwSL9IPofYvFQ
+oGspJCoSMAYbZHwfUfA5-_GsB56g1nMgmxJHatXm-RCt05Pf2GKUKl0mc3PwDp911pn1qY9XA0JfLcvcG6tryNh922RKxL4HMSyceMdhflPwLUdTlrV3r3yK
+LN0Tc7yYt_CFc-VVCF7lzMNlzUVh-aEiwo_ua00tjv--i_tuNdLoNjv_VkN-EodsrnJgWmBLNt4SxcMcdJ5t1wYD4ze-ELAze85zYXA8cixV1bUVfLYl7zLN
+w7tzAlLVQXY6uGu
+}
+
+AWSEntityColoring(ManagedBlockchain)
+!define ManagedBlockchain(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ManagedBlockchain, ManagedBlockchain)
+!define ManagedBlockchain(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ManagedBlockchain, ManagedBlockchain)
+!define ManagedBlockchainParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ManagedBlockchain, ManagedBlockchain)
+!define ManagedBlockchainParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ManagedBlockchain, ManagedBlockchain)
+
+sprite $QuantumLedgerDatabaseQLDB [64x64/16z] {
+xPO5Zi0W50MVVE7-5rvZlILXNISsaVdrmdZWdt_-wSgm9JcY-gLncW18YiIrkLwG9q5dTSzXNI50knFQqE6CEudOwmEn65ixUTFZ76ghXrQ3ztekpt-p9vY7
+-nV4Peye0ehgxlduSZu_xVPZbEThG_9653N62_hx5zYEoFaslAW_ylFxp9UzVnsUHDsh7-lg_LFVM80Jw5Ivw0NSp3P7PMODq-ofyKZHY-jl0tIRXMioUARh
+VenEgyr4TLC17bIATJ-vxdiCAIKVz2KzwOFkzPJW04zqenyXoHqyqsNlknun8UzLZtJH4pMjU4USwrZqo9vwn_IZBivVuDCrhojg37lt-oi1e2CoCsm2o9Tz
+lvqXuWPIysnUqa-T_B3_rthzzCUlt_lxXvVlNpvZ__Jo_Ti___np2G
+}
+
+AWSEntityColoring(QuantumLedgerDatabaseQLDB)
+!define QuantumLedgerDatabaseQLDB(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, QuantumLedgerDatabaseQLDB, QuantumLedgerDatabaseQLDB)
+!define QuantumLedgerDatabaseQLDB(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, QuantumLedgerDatabaseQLDB, QuantumLedgerDatabaseQLDB)
+!define QuantumLedgerDatabaseQLDBParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, QuantumLedgerDatabaseQLDB, QuantumLedgerDatabaseQLDB)
+!define QuantumLedgerDatabaseQLDBParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, QuantumLedgerDatabaseQLDB, QuantumLedgerDatabaseQLDB)
+

--- a/awslib/BusinessApplications/AlexaForBusiness.puml
+++ b/awslib/BusinessApplications/AlexaForBusiness.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $AlexaForBusiness [64x64/16z] {
+xPK5qXjB38HRE5Bx_kTzBr78KF_EUWk2dncwXLl3NvH__ADhPQvgNg52yHMDufii0w0Udt05O8jlq0veDh_IgO0tpr82NHpb9-RDKaYTpHtmUNKLGDJ7ou5r
+LfuaKm28whpC5-SCIf1a6s1hSkzbW3MPfqfGn9XOtNdQI0FA7GaRUV2160D3yfWM57laBmRDWlGkl9CEvmi-l-mIKDHTb9VCQjE1-Ns2TFWT-JMryJyW4Mn1
+auLxZ6H3cd5SW6EnO9FAFLEFeRZWFC3GayC7oIKRTjo-Pc3DrZtH4xkXXthvfYyyKImuM_Ha_7YYMVluXlgu_ZLwEzd__iRzS6y5tysVZ_EFU_DR8hRx5mYo
+xIl9huoleRRxFvl-Ii7O8hs__XBALnnvMx0JrpyD_XeUqZGi7ZEnMs7zCjgy5OGx3346MhndGSU3ErgGPFlZYLE2ket7biBCU0cq7anRi4uUNzQJWZI7LlXT
+LtUKGhB96C6aucH0coS9G1Pxsjq1nClfiw4SHegmKo2BJA3u1WqZ5Iw0zylfkwScFW0licsIVriVbit9tPeNzCFIwTyrVQS2LhoahpHSKezU1814yH8DY8tu
+8cirVt7-yO__0G
+}
+
+AWSEntityColoring(AlexaForBusiness)
+!define AlexaForBusiness(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, AlexaForBusiness, AlexaForBusiness)
+!define AlexaForBusiness(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, AlexaForBusiness, AlexaForBusiness)
+!define AlexaForBusinessParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, AlexaForBusiness, AlexaForBusiness)
+!define AlexaForBusinessParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, AlexaForBusiness, AlexaForBusiness)

--- a/awslib/BusinessApplications/BusinessApplications.puml
+++ b/awslib/BusinessApplications/BusinessApplications.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $BusinessApplications [64x64/16z] {
+xTO5Oi9054NHzrrc_-kjjpX4wkJYSkA6dsgBtby9udCpW7VUHy-i3dt_Ix_vgdLUP9KV8cE5JoEoNEuLHD0LdhjveGyYmhC74SLyRp3dPyzkiDb-EFNGPw-Z
+oSTChqAqctyYqLc-m6exRygeERuHetU-Hw2d-p257wu_XrfCz0wY8__-tIJFqdNgguMdURBptkWl-CrlVXIYUtVywGxKcEGhaxGIbfabdCbIcMd8Kigi6xu8
+LwEwxjl1UJ66tvn_X_Q553vX-Jb0PmDyql8Flr1irqzd_UQjvfO7Va6Vvy6o92QyHul2V-WH
+}
+
+AWSEntityColoring(BusinessApplications)
+!define BusinessApplications(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, BusinessApplications, BusinessApplications)
+!define BusinessApplications(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, BusinessApplications, BusinessApplications)
+!define BusinessApplicationsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, BusinessApplications, BusinessApplications)
+!define BusinessApplicationsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, BusinessApplications, BusinessApplications)

--- a/awslib/BusinessApplications/Chime.puml
+++ b/awslib/BusinessApplications/Chime.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Chime [64x64/16z] {
+xPK5iYGn34CLScpV_xuBIhd6W-bimTBNC3prQqZYVso-yfLPcV6hV4Cf1QXdr3HVCP83SeGBUhmZsM1dEA2XRvGumqj7J_gIzFKAhbwXh_HdXMnmfVj4VzGd
+3MmBAepF6kI41DrD2sH_y2cGz8DsTnPS50Zze9aEp6i2eTyIdPgs0WDB_u5MtsHY2O3w1VM4pW9eOpIWw06T1PWYWFfiUxfNiNi1KLNp2LG0mxRQ02kMW08Q
+FYjDx3Cl3QkYmZITPnLqaxgfgCNTMD4QAl68OhZxvmho7XM0-2D_gvXlUSPcAoYM-SPFKL5VybdD6jBfieBIfiN7yfAVBU_ToBmBG6zxprCjAXxu2HIq6XNa
+DnKTeWbNHNKTh12G_rZ1p3odTNva1VbFiGwiIy1KTMtF5iMA_XdNpdEiW9IRIOTuP4TNgclX6Eu8WUiqOnM5Ks08p2Ew0sWy-UEQW3tGjK7MTD0l7O49zDmK
+CtXplIR0nIzeah4ANXDWGT0abxvV4o22e4c6n19GmBO5GMTz2kmNFrAfAY__7OtuzMHzkX_XMP_f9pZ94H8hUW2JH2abzC_JApFzZyrNll8T
+}
+
+AWSEntityColoring(Chime)
+!define Chime(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, Chime, Chime)
+!define Chime(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, Chime, Chime)
+!define ChimeParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, Chime, Chime)
+!define ChimeParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, Chime, Chime)

--- a/awslib/BusinessApplications/WorkMail.puml
+++ b/awslib/BusinessApplications/WorkMail.puml
@@ -1,0 +1,12 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $WorkMail [64x64/16z] {
+xTOt4iGm34DHpz3Azx_l6hKPi3dnjyHJhVaHPTbebQmDpRUDhcc-7eTAX9dbPOQ9xQji4dEffiSrvDFnk4VSzLZuFF3OU3pqM3ayzjWvFFPOEZpss6gSzbWh
+dFVOAvpt4DPhb8VHEEsX5CvxE8Np7bBXl8S5v_tvWOFVuOV8kCFhfKz_BdtwnV1b-hrIxV3t_X_l_x--loox
+}
+
+AWSEntityColoring(WorkMail)
+!define WorkMail(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, WorkMail, WorkMail)
+!define WorkMail(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, WorkMail, WorkMail)
+!define WorkMailParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, WorkMail, WorkMail)
+!define WorkMailParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, WorkMail, WorkMail)

--- a/awslib/BusinessApplications/all.puml
+++ b/awslib/BusinessApplications/all.puml
@@ -1,0 +1,55 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $AlexaForBusiness [64x64/16z] {
+xPK5qXjB38HRE5Bx_kTzBr78KF_EUWk2dncwXLl3NvH__ADhPQvgNg52yHMDufii0w0Udt05O8jlq0veDh_IgO0tpr82NHpb9-RDKaYTpHtmUNKLGDJ7ou5r
+LfuaKm28whpC5-SCIf1a6s1hSkzbW3MPfqfGn9XOtNdQI0FA7GaRUV2160D3yfWM57laBmRDWlGkl9CEvmi-l-mIKDHTb9VCQjE1-Ns2TFWT-JMryJyW4Mn1
+auLxZ6H3cd5SW6EnO9FAFLEFeRZWFC3GayC7oIKRTjo-Pc3DrZtH4xkXXthvfYyyKImuM_Ha_7YYMVluXlgu_ZLwEzd__iRzS6y5tysVZ_EFU_DR8hRx5mYo
+xIl9huoleRRxFvl-Ii7O8hs__XBALnnvMx0JrpyD_XeUqZGi7ZEnMs7zCjgy5OGx3346MhndGSU3ErgGPFlZYLE2ket7biBCU0cq7anRi4uUNzQJWZI7LlXT
+LtUKGhB96C6aucH0coS9G1Pxsjq1nClfiw4SHegmKo2BJA3u1WqZ5Iw0zylfkwScFW0licsIVriVbit9tPeNzCFIwTyrVQS2LhoahpHSKezU1814yH8DY8tu
+8cirVt7-yO__0G
+}
+
+AWSEntityColoring(AlexaForBusiness)
+!define AlexaForBusiness(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, AlexaForBusiness, AlexaForBusiness)
+!define AlexaForBusiness(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, AlexaForBusiness, AlexaForBusiness)
+!define AlexaForBusinessParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, AlexaForBusiness, AlexaForBusiness)
+!define AlexaForBusinessParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, AlexaForBusiness, AlexaForBusiness)
+
+sprite $BusinessApplications [64x64/16z] {
+xTO5Oi9054NHzrrc_-kjjpX4wkJYSkA6dsgBtby9udCpW7VUHy-i3dt_Ix_vgdLUP9KV8cE5JoEoNEuLHD0LdhjveGyYmhC74SLyRp3dPyzkiDb-EFNGPw-Z
+oSTChqAqctyYqLc-m6exRygeERuHetU-Hw2d-p257wu_XrfCz0wY8__-tIJFqdNgguMdURBptkWl-CrlVXIYUtVywGxKcEGhaxGIbfabdCbIcMd8Kigi6xu8
+LwEwxjl1UJ66tvn_X_Q553vX-Jb0PmDyql8Flr1irqzd_UQjvfO7Va6Vvy6o92QyHul2V-WH
+}
+
+AWSEntityColoring(BusinessApplications)
+!define BusinessApplications(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, BusinessApplications, BusinessApplications)
+!define BusinessApplications(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, BusinessApplications, BusinessApplications)
+!define BusinessApplicationsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, BusinessApplications, BusinessApplications)
+!define BusinessApplicationsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, BusinessApplications, BusinessApplications)
+
+sprite $Chime [64x64/16z] {
+xPK5iYGn34CLScpV_xuBIhd6W-bimTBNC3prQqZYVso-yfLPcV6hV4Cf1QXdr3HVCP83SeGBUhmZsM1dEA2XRvGumqj7J_gIzFKAhbwXh_HdXMnmfVj4VzGd
+3MmBAepF6kI41DrD2sH_y2cGz8DsTnPS50Zze9aEp6i2eTyIdPgs0WDB_u5MtsHY2O3w1VM4pW9eOpIWw06T1PWYWFfiUxfNiNi1KLNp2LG0mxRQ02kMW08Q
+FYjDx3Cl3QkYmZITPnLqaxgfgCNTMD4QAl68OhZxvmho7XM0-2D_gvXlUSPcAoYM-SPFKL5VybdD6jBfieBIfiN7yfAVBU_ToBmBG6zxprCjAXxu2HIq6XNa
+DnKTeWbNHNKTh12G_rZ1p3odTNva1VbFiGwiIy1KTMtF5iMA_XdNpdEiW9IRIOTuP4TNgclX6Eu8WUiqOnM5Ks08p2Ew0sWy-UEQW3tGjK7MTD0l7O49zDmK
+CtXplIR0nIzeah4ANXDWGT0abxvV4o22e4c6n19GmBO5GMTz2kmNFrAfAY__7OtuzMHzkX_XMP_f9pZ94H8hUW2JH2abzC_JApFzZyrNll8T
+}
+
+AWSEntityColoring(Chime)
+!define Chime(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, Chime, Chime)
+!define Chime(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, Chime, Chime)
+!define ChimeParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, Chime, Chime)
+!define ChimeParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, Chime, Chime)
+
+sprite $WorkMail [64x64/16z] {
+xTOt4iGm34DHpz3Azx_l6hKPi3dnjyHJhVaHPTbebQmDpRUDhcc-7eTAX9dbPOQ9xQji4dEffiSrvDFnk4VSzLZuFF3OU3pqM3ayzjWvFFPOEZpss6gSzbWh
+dFVOAvpt4DPhb8VHEEsX5CvxE8Np7bBXl8S5v_tvWOFVuOV8kCFhfKz_BdtwnV1b-hrIxV3t_X_l_x--loox
+}
+
+AWSEntityColoring(WorkMail)
+!define WorkMail(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, WorkMail, WorkMail)
+!define WorkMail(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, WorkMail, WorkMail)
+!define WorkMailParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, WorkMail, WorkMail)
+!define WorkMailParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, WorkMail, WorkMail)
+

--- a/awslib/Compute/Batch.puml
+++ b/awslib/Compute/Batch.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Batch [64x64/16z] {
+xLQ7bjim30CdzFzVtEV1iErPkJpT7iYm5aWDKERujFZ5Bp8YkSvM011VfMzSDy2Mw1JidbCGAtmllmbPuIkoImjyGUsyBV4LV95_Xny50bpW4uTRAjOKu81b
+Xa0vbX3OKFG5C0IMNLyxXA_3PvW5hqHSOFBP_Ovk4036hYi0pJdTCgqD6A0g4FQ0hOwygxSikGOanw11AuvtomxXjNiRDECmn21xxTkJP0N4tdy1Gmu5T2GW
+6ygFL_sqbx3NvA_FVtt_ri_F1CZNra-10TpNhvVr2KGcyVCOdoBySlpv-jC1ZSVveO36_Fwb0UASqGqG0QpfJgP2Eo60u59-fLVozhhdNk2WTeDpq2O6AAL_
+uV7KGPNO2lya17gz1pMiD1VmFNH9IBLNe3xA3q07eNsMy_WdXESwU4jRmddEk-FUuPFjjthiqAEGVUz8rlqmsK1nhtYlklvp7vWRfka0jUNITUdTzgxFyzLx
+-Ikh_YdmYr_y0G
+}
+
+AWSEntityColoring(Batch)
+!define Batch(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, Batch, Batch)
+!define Batch(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, Batch, Batch)
+!define BatchParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, Batch, Batch)
+!define BatchParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, Batch, Batch)

--- a/awslib/Compute/Compute.puml
+++ b/awslib/Compute/Compute.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Compute [64x64/16z] {
+xTO5SWKn30DGIN5Mll-5IvyvMPTRpMJuXGbVbVyGcv1GZza0ElYUi_69Zz_b_xrzKQPyfpEKsLgc8iq-wU4CPagPZ3Gcl2D2s1Go0jgKy90tmQi1FU83lZNb
+CUIPDyAFz-vTjxrwzmDFuCqlJKTfovi7-C2dlUc_q8uujEc_FJf-jJnAq-Zu8xJnElRQU4Ky73znsuFqIFyl_LZ_wzvDlEsfvgB_yl5Nrw-wVwhxjtf-gkUt
+UdzywVrNlR-hxqVn_QgydzNtk_f_-Ct_ft_lsImdVaNUpqDjJKJimbN1RyWp
+}
+
+AWSEntityColoring(Compute)
+!define Compute(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, Compute, Compute)
+!define Compute(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, Compute, Compute)
+!define ComputeParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, Compute, Compute)
+!define ComputeParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, Compute, Compute)

--- a/awslib/Compute/EC2.puml
+++ b/awslib/Compute/EC2.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2 [64x64/16z] {
+xTP5bWGn30DGevpxNtWmk_ABtCFGMkU7QVtOt7CFiWkcFAKFXjx5ungJdFgsfVWrFctWvvbx65PPF8t0dyfRBHZ6VXU1F5dLrrb8YTjyL8eLL54cMN6JTsdY
+GuyCKRz49H8JRxkjfaysRB_tlFsTwdtDnb_8tYVgAyOVRhqtZwDFVqg-UVmGsLr4xt7sAGwWbglsNjMFVc_neoy0VlJd_jk-VtlFzy-UuuCdwxVJUxf_YEVx
+jyry_CJJy_i5uoVt5_7a_YIUtD_Kq_U3U_v-SSypzx1ydnV_DTxY6XzxI9zyxsVrn-QUUnu1
+}
+
+AWSEntityColoring(EC2)
+!define EC2(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2, EC2)
+!define EC2(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2, EC2)
+!define EC2Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2, EC2)
+!define EC2Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2, EC2)

--- a/awslib/Compute/EC2A1Instance.puml
+++ b/awslib/Compute/EC2A1Instance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2A1Instance [64x64/16z] {
+xPS5hiGm30LhdDx_mXyIHLGLt6KOGN0M_8hJLR68tNQBWCtMcQNY-x9zJz-Z0Mos2HaDNtnnZRYwFnLu8ryRMVMpUwFoLFrENExB9RzVdZM_R_uYiXWKyWzW
+E1f0CNy0Qpr906hrL-QPR5s3kXzaqF-0kahL5t057-DLVwL-1Zf1hlgZVYlv9RGLNVEtyvUsOk1h_dR-1aJap9Wivfzqvl47QlKNmFu8Y3E-Wu_FEUC3EZfs
+8dztxnrprz4fv7_7w_-brw_lzLykgDyt__VnQrpkN_h-y7t_klZzzVBtvylv1G
+}
+
+AWSEntityColoring(EC2A1Instance)
+!define EC2A1Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2A1Instance, EC2A1Instance)
+!define EC2A1Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2A1Instance, EC2A1Instance)
+!define EC2A1InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2A1Instance, EC2A1Instance)
+!define EC2A1InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2A1Instance, EC2A1Instance)

--- a/awslib/Compute/EC2AMI.puml
+++ b/awslib/Compute/EC2AMI.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2AMI [64x64/16z] {
+xPS5mi8m34ON_Nh_2_-21OSq6zg7ixswPPeBId4aio69yHGOEh2TxW1SLUv6TQL4xivJ4lPj2JXIIk40RxBd7fyt1OZiymNuUoT0-tm5QELBdoy7Faa2ElKT
+2VoctzhHhzk-KQ00noy6b0Axu1-tpOwZDYxvmnz-TVmkCtyI-CphHvhFyyKJo2BhhmM7lmnm2_3Ays_umn--7ljwsuS7G7CF6k318li7Mm8EltP-BfxVg_53
+DNufna_5-AqOFvRZrthyNESN
+}
+
+AWSEntityColoring(EC2AMI)
+!define EC2AMI(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2AMI, EC2AMI)
+!define EC2AMI(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2AMI, EC2AMI)
+!define EC2AMIParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2AMI, EC2AMI)
+!define EC2AMIParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2AMI, EC2AMI)

--- a/awslib/Compute/EC2AutoScaling.puml
+++ b/awslib/Compute/EC2AutoScaling.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2AutoScaling [64x64/16z] {
+xPO50kL024CJPCBzBxn2lxlxgrF2kDJhykF767KD2UHryci299gy8lFanKLe8Nbf7OZ84gbAK9SqNTQahnnr8QrltbDVPghd88zAbpmhN1VemNAC0Iz2PwiL
+006o7o7LIRZFdW2u080l_nz0d3c6WLf0M4noKAS5A59B8-ia-J90JgvBMnwLgwdH0Hph-id6CVVQGIuhAqfZFVz35SigpKDw0hvBxmivSty1kh3QbNzryIUd
+_SWErT_HqIGxt7vsOlC7r_iFJ-i_Sgicq10WcgZ6N7KGpHxArV6Jcjkl7B-derZE7w5w4cRLVCNwSVtwUVtwVVt-uVhzo_Nxf-ltRyiYNBj_VLr-_FWB
+}
+
+AWSEntityColoring(EC2AutoScaling)
+!define EC2AutoScaling(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2AutoScaling, EC2AutoScaling)
+!define EC2AutoScaling(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2AutoScaling, EC2AutoScaling)
+!define EC2AutoScalingParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2AutoScaling, EC2AutoScaling)
+!define EC2AutoScalingParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2AutoScaling, EC2AutoScaling)

--- a/awslib/Compute/EC2AutoScalingResource.puml
+++ b/awslib/Compute/EC2AutoScalingResource.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2AutoScalingResource [64x64/16z] {
+xPS7hkCm34I7HHhT_y9R1084ue28nTtV7qfYcq-zuaiZSqf79qdfw6kHSgvldtAgXqyvr8UIDaZAcGub5KS9R1tRtmdSzVsl7Zu67NSnf0_32UdZ-_g63Y9u
+5yHTe6w0kUwdWuex2P0E8_MsFtIIPkJKSSyNrSaLit_jFvogKaew5O5l8ub7luOcGbBJNtJLnBdIrwVhWMS2ObdXR0wJr1se4e1UVKMj8nDGdrT_kjOwO2Gr
+wl_eBz93jsjt1PEa5lxMfseWsCpifTXkOi1Tvg54I32x_cFv1qchocyanqFv4zrwuKSJ5yrlLVzbKA4NuoV32hqOlrK2Gj9Ucp_sTFvOwENypT0hylhw8Otr
+gx5-zjRlTq44xx1__fm_6kUtnlcnVNxjdv_xv_V-_Q5_V-dVdx8Aqhq_Vcb-0m
+}
+
+AWSEntityColoring(EC2AutoScalingResource)
+!define EC2AutoScalingResource(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2AutoScalingResource, EC2AutoScalingResource)
+!define EC2AutoScalingResource(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2AutoScalingResource, EC2AutoScalingResource)
+!define EC2AutoScalingResourceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2AutoScalingResource, EC2AutoScalingResource)
+!define EC2AutoScalingResourceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2AutoScalingResource, EC2AutoScalingResource)

--- a/awslib/Compute/EC2C4Instance.puml
+++ b/awslib/Compute/EC2C4Instance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2C4Instance [64x64/16z] {
+xPS55iCm34DdLEv_uZsdpFKRWmOD_O0qlDnLOdRYkYq3Tg-AGXbUbzVlvDMg0EnU7N2hqiN2ETdT-Kj2NyHpbMTvvwh1-HpVocxdwPRzqzlczy-VHOPyY9Bv
+AwgahsagVqTLIt6KClvR04mat0ulAPxQdOzcI_42-AGcM_p2lwLT58Et_5lFpyR37Hw09l8VymhmDh-vVnjsxo8IptGw_yYRUlD2fG1oFdy0JesxNXKDV9Pl
+Lmsi6vRAVzZsYBT4_j4ivcvARLML4_a_x_F_ri-l_-S_tU3VF__FvT_hztV-_yF__zVD_rzl__zykwu
+}
+
+AWSEntityColoring(EC2C4Instance)
+!define EC2C4Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2C4Instance, EC2C4Instance)
+!define EC2C4Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2C4Instance, EC2C4Instance)
+!define EC2C4InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2C4Instance, EC2C4Instance)
+!define EC2C4InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2C4Instance, EC2C4Instance)

--- a/awslib/Compute/EC2C5Instance.puml
+++ b/awslib/Compute/EC2C5Instance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2C5Instance [64x64/16z] {
+xPS5jiCm30GjIwlj_I_ymM6ENZd9F2XEGHDoUYWARDwk0NBrrdYJY6_JssFwXWB9rLid7GMRV74CFDnF0Gxavu97VQ-yRl91lmBt-tBFxvUFxNVrpwfL7wc8
+zJSMjFi2YVHtLbXtLmBpnx-QHJJ_-ox_1Fe9IPsyTx-lfATT_lpyZBJ-hDsXi_rblXzwljnOGA1_tq-gEHj9tT_V9lzPIUpldxlStJC8z2VfrRQRf9rem5UM
+gJkHu313SFjBoWgqyzMz_Ij4uGwJwewR1Fg_yFX_x_7hElxVS_wy-X_7Zt6_V-_wuLf_tRr-lN_zV3-_
+}
+
+AWSEntityColoring(EC2C5Instance)
+!define EC2C5Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2C5Instance, EC2C5Instance)
+!define EC2C5Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2C5Instance, EC2C5Instance)
+!define EC2C5InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2C5Instance, EC2C5Instance)
+!define EC2C5InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2C5Instance, EC2C5Instance)

--- a/awslib/Compute/EC2C5nInstance.puml
+++ b/awslib/Compute/EC2C5nInstance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2C5nInstance [64x64/16z] {
+xPS7ZaCX44FnDEV-5zx2h884Aw9HUdaglxuFsAdjegZxoUqE9xTRum4LtzRjQ_hc7PBRRP3X7Li6hk4Nzrk15_Ab4rK_qXl95_t4p_TnplpnWFrz-XVLtWp-
+gFLlxEXuD2hz1nCRkoZaxoHD09LVFzRvxtsGb7_kCjEc4IudV2MZ3T_cm8Z9d_8p3WSa8rmp5OOfIPloc_fpKeUVUFheixDz_vvt9AeYHb8s_Zp_9HabVV8t
+_SloGfR5t_PFqf6xE2PQy9KzzQ0t3pVp0uc2tvI97vFLBYp-sdy2zGWtv4uO-bFjLuIPBFtVzVF_tC-lp-S_piZlq__h-3NEzy_z__3v_tNs_zVp_p-VppS
+}
+
+AWSEntityColoring(EC2C5nInstance)
+!define EC2C5nInstance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2C5nInstance, EC2C5nInstance)
+!define EC2C5nInstance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2C5nInstance, EC2C5nInstance)
+!define EC2C5nInstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2C5nInstance, EC2C5nInstance)
+!define EC2C5nInstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2C5nInstance, EC2C5nInstance)

--- a/awslib/Compute/EC2ContainerRegistry.puml
+++ b/awslib/Compute/EC2ContainerRegistry.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2ContainerRegistry [64x64/16z] {
+xPPdMWOn28GXeNZ_2rlY_C0I1TPk-7fvzna8xMPlnuwPs0NQ9n69TsaXudd_q1QkJ2I-D0ohEpuUCRoTNdQSzPcKilGOYbmOzdhtOKZyCHq62CsuLVy7mcev
+n_T_sShBH4Y9vkOd8MaSJUGjTJJkFLxuuMWSCgkyyPAkJ1qUvRHUoZoo2lvRcKTM8JKhV3mpHsfM-5XEJho-gV0EpLr-GdEN7_Ygp_ltyuT76eykZpJs3X_J
+kCcZVj_dvHN-USyr9adrV_26RsCSKjqTlD9CZl7eQUJbsQ-5-Gi-g2iiFf6lh56O5967hAJvcbI1h-vFK0j-9XpVdENYuNXd_wG7dlN2_ki6ntjNU5FuiMDt
+}
+
+AWSEntityColoring(EC2ContainerRegistry)
+!define EC2ContainerRegistry(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2ContainerRegistry, EC2ContainerRegistry)
+!define EC2ContainerRegistry(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2ContainerRegistry, EC2ContainerRegistry)
+!define EC2ContainerRegistryParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2ContainerRegistry, EC2ContainerRegistry)
+!define EC2ContainerRegistryParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2ContainerRegistry, EC2ContainerRegistry)

--- a/awslib/Compute/EC2ContainerRegistryImage.puml
+++ b/awslib/Compute/EC2ContainerRegistryImage.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2ContainerRegistryImage [64x64/16z] {
+xTS5ZWGn30NHsC7xdtW7eanbhIP7BUo_3A-6AQplcURhI_2bEXOdNwwjjjddS6rIx_IFVxoeYjzBgRMseawlk94vlBnaLaslB-BnBvZ2Q_6LyVXIoxXZyFXQ
+ypWYidBusNVuBwRzlyhl0jL3puilIj3o-Z9uRsvwBjM-38x0XZU1zECv8R3XCOav9m4F0O4DRqREmBQNf1iSWMqllCsG8x3bEvy3u0XOFtX1W7mEMDzv3X41
+SWQi7pmWG3u7h1-y1yXj81dVEGBW9j3QFzyv0-GsCFlIEGE6Cz1gWiS_8r2CGs3s3HmduVJZ1_XsODlZg2BWVlnWmEKPS7a6N9u1bsV0vHdmU0R4uH5m73ud
+Tp__Md_zu5XSVlsqlcT_
+}
+
+AWSEntityColoring(EC2ContainerRegistryImage)
+!define EC2ContainerRegistryImage(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2ContainerRegistryImage, EC2ContainerRegistryImage)
+!define EC2ContainerRegistryImage(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2ContainerRegistryImage, EC2ContainerRegistryImage)
+!define EC2ContainerRegistryImageParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2ContainerRegistryImage, EC2ContainerRegistryImage)
+!define EC2ContainerRegistryImageParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2ContainerRegistryImage, EC2ContainerRegistryImage)

--- a/awslib/Compute/EC2ContainerRegistryResource.puml
+++ b/awslib/Compute/EC2ContainerRegistryResource.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2ContainerRegistryResource [64x64/16z] {
+p9I74eD020KV70V__yLM9ZT3ZapiRegwkdR5MT0cGipLDb8P3Q-tKJ-vcfcAbByHMPAsTMLiXDNt0EnhsegQiM-UimlmoxFlW9ccvx1ctdS009c9JtsZkGV4
+Z9Q-hBsMmAHo3vJGLmIgQUApdWZjh_N1f_qopcQyp6jzy6_kPLrEGXzyqaE4GI845a7hex_e-b70-uuF_VRxz_oUIWTAVUot4tlkaFhORtz_d7_-bGEJIlnL
+xuzI2EH_hU_wiVkwA000Xc4ewj_rFEoLUnv3aW__xuP--Fdv_VdxyVVh_yV_xqUPVlNgB_e7lZ_qpnFwuVqzl_dzUNxL_8pvNVb1-GNv2VaD-P7vrVdPwm4
+}
+
+AWSEntityColoring(EC2ContainerRegistryResource)
+!define EC2ContainerRegistryResource(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2ContainerRegistryResource, EC2ContainerRegistryResource)
+!define EC2ContainerRegistryResource(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2ContainerRegistryResource, EC2ContainerRegistryResource)
+!define EC2ContainerRegistryResourceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2ContainerRegistryResource, EC2ContainerRegistryResource)
+!define EC2ContainerRegistryResourceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2ContainerRegistryResource, EC2ContainerRegistryResource)

--- a/awslib/Compute/EC2D2Instance.puml
+++ b/awslib/Compute/EC2D2Instance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2D2Instance [64x64/16z] {
+xPS5aiDG34DhLEz_uGMbNcZGKuOty6bUm0hkpef5hBPB1B3OElRIyNtSFgVlGG0ijWba41_jk4UStTyrU29VINRzLFAdyZr_84xtvPJZbtlCxvs_aD-nccaZ
+VwbLuT0vIDcSlw3GxvrZ83VMdtwAQ89FIuCBDw8T_xjDmB-BCVJxlh8j0pBfJzSl3stDUXcZ-WN8sF-xKsLlFV_n_gKwriZ_ZyysgNVopxydNNgp_iRCI-_v
+oAotL62F_2OwFl7Xw8lD-JinuSZyW2taVwld_wdFh_VpNqwetpl_v_5xdEwV-l_m_lyw-V_rzF_dq_a4
+}
+
+AWSEntityColoring(EC2D2Instance)
+!define EC2D2Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2D2Instance, EC2D2Instance)
+!define EC2D2Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2D2Instance, EC2D2Instance)
+!define EC2D2InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2D2Instance, EC2D2Instance)
+!define EC2D2InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2D2Instance, EC2D2Instance)

--- a/awslib/Compute/EC2DBonInstance.puml
+++ b/awslib/Compute/EC2DBonInstance.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2DBonInstance [64x64/16z] {
+xPPLOe0m44HPczdxdxXia7hPrEtz3FQ0U9PtH02h34I50nKAQjqaxCedlH8SOf0LnirFlixNtUStzZK69BRWdG0JbKd4G1_xnWdiAJ_P99_nTMcXp_dIy-NT
+VLdn6T_BE2y4Yvpm1t5SmAoVB70MtLV0la-KOUzJVp_VTwnmncSP_khsJnRn3j__RxztwFzutVZ5QzkV6p4__sp8HgF-6dosB-OH029STq5DLQFZrrEy0rnc
+wZ-uiOyt5jRtou6hd2M9xGMYAzVjfoJqYLMxMtz6qku_8y7Chg-Zn5M0WPeZcPD-CMAZNj3jlqgQnLqRNWtQhVzZ5wNcXOs6A1zJ_bs6VymVh_O7zlDzj-UH
+XiyNq6j_a9bFnOLVIA5aL8Ae25BNS5xuZVtxJ_QjvnTckeLLw1PoqVuTFiZtATyVNKJV5p93vUuL1uc99R90k1KU6AUoj97WGtoPGYoOEqICrhq1
+}
+
+AWSEntityColoring(EC2DBonInstance)
+!define EC2DBonInstance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2DBonInstance, EC2DBonInstance)
+!define EC2DBonInstance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2DBonInstance, EC2DBonInstance)
+!define EC2DBonInstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2DBonInstance, EC2DBonInstance)
+!define EC2DBonInstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2DBonInstance, EC2DBonInstance)

--- a/awslib/Compute/EC2ElasticIPAddress.puml
+++ b/awslib/Compute/EC2ElasticIPAddress.puml
@@ -1,0 +1,12 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2ElasticIPAddress [64x64/16z] {
+xTJ50SH020LG_4__5QyhOILSUSS8Da9jOumnnEB8bNRHm8tH1qoR74TnXAFWkaXezRin7R7Yg0h0m5O0Vyx93WGLJj4b5uNWrt3sJu1uBxZiuCZIIm4y9L7w
+EO3bYauHIvRRfToHrE8rGEHnEnPgQoruz_zk_StvDTUlkN_Q-xT_VlhdDzyVxZlkZyRzrRW_EyOOOnm
+}
+
+AWSEntityColoring(EC2ElasticIPAddress)
+!define EC2ElasticIPAddress(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2ElasticIPAddress, EC2ElasticIPAddress)
+!define EC2ElasticIPAddress(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2ElasticIPAddress, EC2ElasticIPAddress)
+!define EC2ElasticIPAddressParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2ElasticIPAddress, EC2ElasticIPAddress)
+!define EC2ElasticIPAddressParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2ElasticIPAddress, EC2ElasticIPAddress)

--- a/awslib/Compute/EC2F1Instance.puml
+++ b/awslib/Compute/EC2F1Instance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2F1Instance [64x64/16z] {
+xPS55eGm34HfEybm_mlZxdbXVJyk7qazkvKaShezGiZ3BPW7Yu_rzZjzI0F9mwsIAWrOlTY6tEvd1hx8ZmrgzRNrniZR_0xn-y7p_U4zq--V_g5ZEBAbFzXH
+Uqb9DQN_r8zQRzKMVv3IVRymhoQxZtuNCTBXLuG3VpT-aYhs_Iv-E-a7vgpPzJlamDUAqJUdF-hjwVTxu_UMlZ_z8n0dFf0Eql-LzR-t_lhN_vxsyv_-t-FR
+yFlUySD__EKUl_h7ptvA
+}
+
+AWSEntityColoring(EC2F1Instance)
+!define EC2F1Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2F1Instance, EC2F1Instance)
+!define EC2F1Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2F1Instance, EC2F1Instance)
+!define EC2F1InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2F1Instance, EC2F1Instance)
+!define EC2F1InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2F1Instance, EC2F1Instance)

--- a/awslib/Compute/EC2G3Instance.puml
+++ b/awslib/Compute/EC2G3Instance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2G3Instance [64x64/16z] {
+xPS5jiCm40EpgDp_mXzibMdzoctcGN5YMmfEDyKY2g-d2U3igsEM4TyFNp_JzsW0EFkQG4R33mOU8sxkJmDyaA-D7FLJ6-la1tqIr_jopVpbLVjR-fTrFK96
+-lV4FwdJPEZaGFy1OlHd0FNy7O2hYBfo_WbusHS0khiSwZLVkTWrHltGFveVHrk7RZt8u_a5oAxVhBdF8rb5gVzT7xou902fzczSdYHoAo2hzg_W9_hh2Alz
+9n2oycKzVjbNz0jccuTdk6Tn_oCAaYtDXjRw9nQPqNVVzjQaqF_Zp__Ndh-My_yrry-b_y_nnxZUl_RvONd-klhvzVhdv-lv1G
+}
+
+AWSEntityColoring(EC2G3Instance)
+!define EC2G3Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2G3Instance, EC2G3Instance)
+!define EC2G3Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2G3Instance, EC2G3Instance)
+!define EC2G3InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2G3Instance, EC2G3Instance)
+!define EC2G3InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2G3Instance, EC2G3Instance)

--- a/awslib/Compute/EC2H1Instance.puml
+++ b/awslib/Compute/EC2H1Instance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2H1Instance [64x64/16z] {
+xPU55iCm24MR17Zv_n-UKEOB6uVEzuv4RuK8C2sgndopzCI0Mn9wYV1qMNudJwm2u9O22Ale_CL1yUBy5D0NyLKbKLvcRc_v86_YF5yotr_USVt-wr-AbLgn
+slthtm1I292vGm3srt_0Osu24D_-pli57Jt14vMQuBKsuaVs4zg87TxiTtNz6ZfKVSJxwz_CNOZ31zRV-_wi_TwLP-DXF2BhNucgLeYQJTAQi_wlkl-pzzV_
+_i_up__wVmyVKvxFvW___2kTl-RpvxpM
+}
+
+AWSEntityColoring(EC2H1Instance)
+!define EC2H1Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2H1Instance, EC2H1Instance)
+!define EC2H1Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2H1Instance, EC2H1Instance)
+!define EC2H1InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2H1Instance, EC2H1Instance)
+!define EC2H1InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2H1Instance, EC2H1Instance)

--- a/awslib/Compute/EC2HighMemoryInstance.puml
+++ b/awslib/Compute/EC2HighMemoryInstance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2HighMemoryInstance [64x64/16z] {
+xPS55iCm34DZYdB_4ozlBeCBOz30eJ-GYkck4hFD6ic0i2eA7U5rNh-JLxiAG5Wpa7sbJh_ueEpkV3gWB-BvgdoKpyvrpX_bNNOxJxVyVdgl_Fxv4wMcKli-
+6GZpPy3Q1NLbRhj90BXD7EKlCnxi_Mw08_zvoXVl2yfP7kJTSxnx904_zGzQPUtoh03LQke3K_yc-J4AN2rFW0h0FH_bp-s9ekEJ0l0ovUFyMvvGnIqVvB_2
+LzBVJ_cVVPk-WNS5VB3zekTjL_waAlvrglLTQgyHDmDAq_nVUlo_zVZrF_xJ3Vxzy_yU_fXkvs-zV_ZVVzry_thx_VFjkW
+}
+
+AWSEntityColoring(EC2HighMemoryInstance)
+!define EC2HighMemoryInstance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2HighMemoryInstance, EC2HighMemoryInstance)
+!define EC2HighMemoryInstance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2HighMemoryInstance, EC2HighMemoryInstance)
+!define EC2HighMemoryInstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2HighMemoryInstance, EC2HighMemoryInstance)
+!define EC2HighMemoryInstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2HighMemoryInstance, EC2HighMemoryInstance)

--- a/awslib/Compute/EC2I3Instance.puml
+++ b/awslib/Compute/EC2I3Instance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2I3Instance [64x64/16z] {
+xPS5beH034H9HuhxNtWbpVfEpolSFYuVIQ7ThAZxqs4B1vf3Go-CRt-7v_JD4m3DOG3XYVtPCOVFxdS49_9B4gmVrVkiFEjNVBelKuvVzfhVdR-8PBz2vry0
+ptw5p3_D6FmU05t_zElnE-3Z_4J_wenV06latwXV34Dew_vn98_ykbZ9_BzyTOyUA7p-wIS6sAZylyQTh__V_VE-miq2W8prAqhdBsQQvOy84oB_TP__KvzV
+z_DV9jJlplyyFiTqV-h_m_t_DVd_TVh_ytHU0G
+}
+
+AWSEntityColoring(EC2I3Instance)
+!define EC2I3Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2I3Instance, EC2I3Instance)
+!define EC2I3Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2I3Instance, EC2I3Instance)
+!define EC2I3InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2I3Instance, EC2I3Instance)
+!define EC2I3InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2I3Instance, EC2I3Instance)

--- a/awslib/Compute/EC2Instance.puml
+++ b/awslib/Compute/EC2Instance.puml
@@ -1,0 +1,12 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2Instance [64x64/16z] {
+xPS54aCX34InP7l_2zUz_PB18Mzanz2uIOedsjGr25ZLW8ELh0-_EkRwG5S0h2e3J5V2py4oAFbw8s2WzUuAIzVpRTtpvwNhRr3yUXjpVpkp_TN-Ql_O_rFx
+rrolze_DNtFQN-slzg_TVyVE3pf_HS-lyVDpF2S
+}
+
+AWSEntityColoring(EC2Instance)
+!define EC2Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2Instance, EC2Instance)
+!define EC2Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2Instance, EC2Instance)
+!define EC2InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2Instance, EC2Instance)
+!define EC2InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2Instance, EC2Instance)

--- a/awslib/Compute/EC2Instances.puml
+++ b/awslib/Compute/EC2Instances.puml
@@ -1,0 +1,12 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2Instances [64x64/16z] {
+xTT54WCm34DHGsBr_XSkSwkuZFxxDwDLG1wGyYxH0LvOwWF3KW-4ipfW2LV0XMLt-FBbIK_qrdbDK-yOble0WeK9FFTTM8e_z-NRFLxSzGxFLtLRfMUy6a-F
+xhyuzOvH9lDiu1N3OZsHxZUW6Qi3AaUTUXEMVvmlNnwnpQxtZhqkzkJ-riiyxzjz-VBTMP7w_FxBiXXnlVTpVNyp
+}
+
+AWSEntityColoring(EC2Instances)
+!define EC2Instances(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2Instances, EC2Instances)
+!define EC2Instances(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2Instances, EC2Instances)
+!define EC2InstancesParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2Instances, EC2Instances)
+!define EC2InstancesParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2Instances, EC2Instances)

--- a/awslib/Compute/EC2InstancewithCloudWatch.puml
+++ b/awslib/Compute/EC2InstancewithCloudWatch.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2InstancewithCloudWatch [64x64/16z] {
+xPS73kiW44IzPVRb_XV-3JaMjh8nlxTHGUq1EqFTlgj2Ujjs4hHjyh0LFg_jtycdlWXesuBI5-Lvu4Nfk_FRWluYth-eLlaQtE7y8Z-aR-VjnVmz9ONryxTN
+_aKn9FyQ_mKyA01odIyWxNDj0dALJoZRRG1YBNy3lk171ohvxVm5lXqAXdGtVwXfiWKKaFVoztF10JuLrUVlSChSRVGIT_ptclZ9LVbRFc7YPnl8bX-u9joo
+eD8s2m4vyoV_x39u0i007R3Plpc_F7ilU9HKW8Q9sUKlE8zU4HaU3BAeBl-YJfvN5C2Ulw39_ymd102nJrtG-I-O8wk4jDspCK33n-mVQEzne0xPyGROn2Vu
+atV0klot0DA7x3Dop0WaoAtBVxw8jmINdhimZNox_uE3j-CWCm2pxS9Vpo_VDTQF7xrYr_Ehlpy5b0IW16pr_asUiWHiZH_xjofrTD3mZPBHWThy-mvmeC-_
+x-01rUNVAm6ypR-NAstE___xx_TuVw__7_x_lxxx_tNz__pj-WW
+}
+
+AWSEntityColoring(EC2InstancewithCloudWatch)
+!define EC2InstancewithCloudWatch(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2InstancewithCloudWatch, EC2InstancewithCloudWatch)
+!define EC2InstancewithCloudWatch(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2InstancewithCloudWatch, EC2InstancewithCloudWatch)
+!define EC2InstancewithCloudWatchParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2InstancewithCloudWatch, EC2InstancewithCloudWatch)
+!define EC2InstancewithCloudWatchParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2InstancewithCloudWatch, EC2InstancewithCloudWatch)

--- a/awslib/Compute/EC2M4Instance.puml
+++ b/awslib/Compute/EC2M4Instance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2M4Instance [64x64/16z] {
+xPS5iWGX30M1I7F_2tz9rXLgNReaOxsIDuMKgo9c0_Ku1YUhqkkCh_lrFNsr03XP7Tm2tVlYEUpgVfdWZVmM-AplwQqxF-adThbVB_dzzVdo--PVQproE9Q_
+WUTH0-f2ZyEX_0sGE79Muxs7FzH_e-FvzRqlV6NEf-LtBlp6b0zuVBqlVCVqY7-eVwxGYkDA-0PLZ_JF2BRz2jP097m1AU4Fv1z-aRmKVetd58Rpztn2qZTG
+4GDfG_c7Bq19dwHtVB3_dk_hmZV_1xhRX1-4d-Xm_hu-bhKqdh-eB0-RQbqV7XW_7pt-Npf-VSV_Ua7_llc_Zp_7vVwb-uVl_klY_Ulb--VB-GK
+}
+
+AWSEntityColoring(EC2M4Instance)
+!define EC2M4Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2M4Instance, EC2M4Instance)
+!define EC2M4Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2M4Instance, EC2M4Instance)
+!define EC2M4InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2M4Instance, EC2M4Instance)
+!define EC2M4InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2M4Instance, EC2M4Instance)

--- a/awslib/Compute/EC2M5Instance.puml
+++ b/awslib/Compute/EC2M5Instance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2M5Instance [64x64/16z] {
+xPS55iCm34Dhadh_2m-YCQPl31hOXL-myWB3NHLLL-Cb5Nan9aURmkTn_4u-gudanGWIrPH7DvwckZi_JD0NyTw4gJp4RIe_bPVgTjvkUNvxF__-_flPGMfI
+f_z5GfcJj6MGiiD_vOoMWQs_ZmtVLV_YIEZsuoX-35kgdwVhzetVzBgzF4cqs-CQVxf-ID87BADu0aWxzj-E_1DlP3aPqVYYv1t-Ynz2kyHxX0T8zFeFdH7Y
+junr-WzvFkpnKDvJVwZDhlc66ScXcvV46v6P_UqFoiLpoKlLwNzah5FFjEK_WF9J_UUh-_zR-wz__sytrE_l_nVmBvf_txf--A-_Rbw_thv-lbrp
+}
+
+AWSEntityColoring(EC2M5Instance)
+!define EC2M5Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2M5Instance, EC2M5Instance)
+!define EC2M5Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2M5Instance, EC2M5Instance)
+!define EC2M5InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2M5Instance, EC2M5Instance)
+!define EC2M5InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2M5Instance, EC2M5Instance)

--- a/awslib/Compute/EC2M5aInstance.puml
+++ b/awslib/Compute/EC2M5aInstance.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2M5aInstance [64x64/16z] {
+xPS5heH040LfBUv_uI_ToIJhErcNYg25l4U0MQwAHPmnFKp0qQcpoeplkzFtz3qAuEWq8QFmJJ-O9AxkBnEyaQz5plhPtaX-rc_YSbykkNvvglw-_Ol8KenP
+QSxhNm0VWMHD6ZchVndt8Hps3-Sli6Azl9QVP5__kJxGCyCVWLXafX_tIR2-R79pnw383NydFq-ofxHFPbY_uaqjGJRp2uhXAvY337_ZRMkWX_flVqceIVbc
+gWvONQcPWnxiltq5aFORgnsjZ1Kzsh__Puvl9azdagO1UZH_xoTtmtU8nUecx0o_QDy9z-1VKWZHdFKRgnMD7kv_STSHclzB_Sn9xHYP9kuR_J_w_N_f--lx
+_fSBylls_px-79VxbuuVlkElYyUlbu-VB-SN
+}
+
+AWSEntityColoring(EC2M5aInstance)
+!define EC2M5aInstance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2M5aInstance, EC2M5aInstance)
+!define EC2M5aInstance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2M5aInstance, EC2M5aInstance)
+!define EC2M5aInstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2M5aInstance, EC2M5aInstance)
+!define EC2M5aInstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2M5aInstance, EC2M5aInstance)

--- a/awslib/Compute/EC2OptimizedInstance.puml
+++ b/awslib/Compute/EC2OptimizedInstance.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2OptimizedInstance [64x64/16z] {
+xTPLWk9054RXw-VkVyCZk2GfAensztb1FvmVv9UaaNEvtkfalhXm0w1cEe0JLw1CfbAlomqaX4od1Nuu0ZMBRrs0JUCRc22xCl23htrU-qtFal_oNrxLp7Id
+roWQQD94nBdDXZwuLlE-k8pPqLkTetleauPGEMGcDncGiksTfbIMqWCVU83rkKiPUAFnPN_W8v-0BlA4ag4lg7K-za2kB2qwzWh40dUwWVIHxrxqmQdIRS-o
+z_nHGOEE7d_AMfeqEVlwtPR0wFrZmnkDRVcWiJUyqUGRNeh6Ltq0kkaD85Qu0JNOZm0WtSmygbGaAmvJQl7IVZctwMNGQ00Vxw_b_Nx6pKbxQV_L8wiotOud
+BQge2lkNVh--_9Tl_1Vy_tRmNJv1Jwkj--w-Jfj1wHwENMSxJ6Uol1sw16XUhnzsqek9biR8V2wLVwJl
+}
+
+AWSEntityColoring(EC2OptimizedInstance)
+!define EC2OptimizedInstance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2OptimizedInstance, EC2OptimizedInstance)
+!define EC2OptimizedInstance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2OptimizedInstance, EC2OptimizedInstance)
+!define EC2OptimizedInstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2OptimizedInstance, EC2OptimizedInstance)
+!define EC2OptimizedInstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2OptimizedInstance, EC2OptimizedInstance)

--- a/awslib/Compute/EC2P2Instance.puml
+++ b/awslib/Compute/EC2P2Instance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2P2Instance [64x64/16z] {
+xPS5jiCm40EzgDp_mX_MPLOvC0-A4v1U3EsfMCGDh-S9uEAhOn36z-FNQVeU1O2Bhmba57vqOevukjy89kHhaQoVMcoIP_rEFExB8zSlNzdVqhyKcqiqKwf_
+HSThp4UXHFyA32N5pdiYVmL2HEki2fTMRpc_ZxRUH5Q_6-rR9L3acVEVpI_sJcf0didlkB_oKOCzf9y3W1BzQqM-aIG18_jFTxVjpJln_6_k_qWdy-_4aKxv
+ZW7vJzpd1zRSth-uR-fINtEc_u-E_u-ENyluBm_aj_G_Nl-xrj_y_c7PVpsyVtry__mulm
+}
+
+AWSEntityColoring(EC2P2Instance)
+!define EC2P2Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2P2Instance, EC2P2Instance)
+!define EC2P2Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2P2Instance, EC2P2Instance)
+!define EC2P2InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2P2Instance, EC2P2Instance)
+!define EC2P2InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2P2Instance, EC2P2Instance)

--- a/awslib/Compute/EC2P3Instance.puml
+++ b/awslib/Compute/EC2P3Instance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2P3Instance [64x64/16z] {
+xPS5iWGm24CN2cJlV-4lf5zNisuPgRuAcQaiJggHkJFTfWIsfe6bANoife_9HxO0R4qBg6p5oiIQykJyGj03yTugbIzoFv4NUIgFv-sOzTjD-lVotrepFoNu
+xw22UKhmtu4bnoVV9I7-3gJP9-bSVm8XyZnjIGsMLNwGPxg1tnI_vA2ZIvrkYD-gVoJwi8Tzdyr3yDzd-E6z_3cKv7z5nC-K7Kh1V-v_fKQ8_sfx7COFPCJA
+_XMUSi5_Y_1VRwgg2XFyl-3vV-pvzJh_Zxa_N_xVBtzRxs_z__3wVntzVpt-_toytW4
+}
+
+AWSEntityColoring(EC2P3Instance)
+!define EC2P3Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2P3Instance, EC2P3Instance)
+!define EC2P3Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2P3Instance, EC2P3Instance)
+!define EC2P3InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2P3Instance, EC2P3Instance)
+!define EC2P3InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2P3Instance, EC2P3Instance)

--- a/awslib/Compute/EC2R4Instance.puml
+++ b/awslib/Compute/EC2R4Instance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2R4Instance [64x64/16z] {
+xPU5iSHG3CIUKUc_uG-UO_OnQI2em6vmN1MBE3eyHC31eJD9n_VjuNlw7WLmS9YGKVZMZdl4rVtHu8ryBRBhfnRBv7l-ZBZSbqkENvwols__KgpFQFHl5EdB
+6MIZVrjkln0W6_aRk8Z2x6cPVTzgPWs6Svxlr430Ou-_Dpyhhuu_oH5xyjlTdp6H2VZidR7bpuZzFb17hpKelzE_womzmCmIJ3hzMvaoPAAOm9lvEyIGB82q
+RdzP-HVHwdzMlB6mUlshkzHs_eU5kJNwlz_p_zBdr_VvBnVaz-t_VVmUb_kN_Zzy_xyk_d-z_F_vSdu1
+}
+
+AWSEntityColoring(EC2R4Instance)
+!define EC2R4Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2R4Instance, EC2R4Instance)
+!define EC2R4Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2R4Instance, EC2R4Instance)
+!define EC2R4InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2R4Instance, EC2R4Instance)
+!define EC2R4InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2R4Instance, EC2R4Instance)

--- a/awslib/Compute/EC2R5Instance.puml
+++ b/awslib/Compute/EC2R5Instance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2R5Instance [64x64/16z] {
+xPS5bW9H30I9TNF_4-zBiYv_oSDX2XcjiK9t9yKY_Xsk278vTEvbullFuMFw7WN9vH0ael0VEvuH9_Tt0nx8rm9J7-szN_cftyJnlXnp_7AJ_RR-KdoPa45_
+Om7lpwn63-zlV2L-zTVNltqNKP9IYxIFV-9RpxHyHiyT-ru3hFpVhr_xqiSF4e3_sbz-xsVS4o2P5bXWq3_zn6h2L3E8Z_gxHlkDaXZqBxLFln6Iq-llP7oQ
+Wt4_v04OuHuaxN2_m_TEZOqF-gkxvD1pg9xvTT3_Wf__ntv-RP__SiJrs_e_ZZ_ZUF_O_m_R_w-Z_xyU___vU5u
+}
+
+AWSEntityColoring(EC2R5Instance)
+!define EC2R5Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2R5Instance, EC2R5Instance)
+!define EC2R5Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2R5Instance, EC2R5Instance)
+!define EC2R5InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2R5Instance, EC2R5Instance)
+!define EC2R5InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2R5Instance, EC2R5Instance)

--- a/awslib/Compute/EC2R5aInstance.puml
+++ b/awslib/Compute/EC2R5aInstance.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2R5aInstance [64x64/16z] {
+xPS5jWCn54Bp36R_6_x2r2tDgGkLYTq8LDjL5LNTwoaLUVAQd6o4p_thU_9P4icJLv0eAVSM7bDTdMy3UYFU9OpoS6dj_20_goxdxPBzsvFbzytVPcrLR21_
+K89lLWRo1oTAlh7CWFyWtIn9pCFiNsFyue3MZCosa6K15GDy--TZnx7Su_VzizQ2X7W0vLeWmuFaZdzx-K7C9FziUr6DjKx-2__nFyuYt5DPp1NntVpTvTvI
+IQQU9UlcJnr_xM_yyqwMLh6U_ng2-VpBhbYSlCxbNVu3bGcIyo4iU1w_NbJQZ8BMoJyorPePpQA0IY5UgB3ClVmV-_b_wUVNz_FVBl3lc__hyi_r-tly_yFt
+_zV5_ryl__zykNu1
+}
+
+AWSEntityColoring(EC2R5aInstance)
+!define EC2R5aInstance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2R5aInstance, EC2R5aInstance)
+!define EC2R5aInstance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2R5aInstance, EC2R5aInstance)
+!define EC2R5aInstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2R5aInstance, EC2R5aInstance)
+!define EC2R5aInstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2R5aInstance, EC2R5aInstance)

--- a/awslib/Compute/EC2Rescue.puml
+++ b/awslib/Compute/EC2Rescue.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2Rescue [64x64/16z] {
+h987ieCm30KZIthh-r_u5uen7MQowU6jok3Fjx1NREIIl2HBfoUy9vikG17-c8X1MRghV5vID4zGMgLt2ChKljpSaUC9fW7Esel6QU2_2yHXTpeE9mYm8USd
+Vlf0dlX-vtlBlVRDLHU_oksDRm7qFX3ss7T6_EZdlP-0VBs_2yWdlcbgrVlZEx9RtpJ5rltRbJjVa6VtBq4tVWxwYT-kdleEkZe_0h_mZHOjwdsLBd3kH-zK
+b0EYzl_7gMzjUcU7jmtipFVvQm4yr0W7IiiS-cOci04jeIKh6nY_x7m1jJ9HYRKVj6j3IXlVsA2rBpROpazVqDwNB-IHts-SUpzt9_Ut_Jeb00200H3OlpKX
+pZ8_inSW_tpkdyuFpY_k3-sltW-yNte_yNxZ_y3_nV_J_xVpW_EByvFpc_EZywloC_Ax-eFw2_eJ-Xlw8_kh-xD7
+}
+
+AWSEntityColoring(EC2Rescue)
+!define EC2Rescue(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2Rescue, EC2Rescue)
+!define EC2Rescue(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2Rescue, EC2Rescue)
+!define EC2RescueParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2Rescue, EC2Rescue)
+!define EC2RescueParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2Rescue, EC2Rescue)

--- a/awslib/Compute/EC2SpotInstance.puml
+++ b/awslib/Compute/EC2SpotInstance.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2SpotInstance [64x64/16z] {
+tPU7aYGn24DFO93__uSlKBLKgsZNJRYuscnuQeTP1d_vr48ctk6Dj5TPcAyWOxdXQTXMyeVshX-vx6SBzSiV1L_vihZCmXFA9za6gy0CDpZfC8yiczKucSex
+FmoSbGhTFvGfNPEdGVsyh0MupBbJ55U3x6aEBUR0Xm5iH5g6CpuZZoPfx27yPGC_9zYj0KJVCxnIfvo9QH0KhR9C-kH9Oip0gAeKa1puAdCrA3vMAqbqhWfa
+oYOsR_8Cr2zb95hDYC61zp41MP8tXGWeB-ajKqEtSN3ABvbNHsH4j3GBr0KaKt5ivJU4Lq3j-k2y5QGfhnCsUT7D4HU-HpJ-EAzn2Jp6wufXGPer-bsOFCoY
+UJCo35sxz-vGa6JQLdvRaln80el86nxxp3UXl5cIRXqACvlpB_KQdSp-ysPZ1j-vaYRnXtc9oryFy3AYaFBpzNl-Xqkcyg2eimLGEvrAwFj_pEqRzKCZi8lm
+FSNrUReWCfMN-ZKsDCbPFuLlohIeQltK-dtcrK3hjqu0Sd2zJZ6OZo-Ec0Utcs-3JbKvimQ3-oBcJOUIz_tBiV2F6GYkSNkt_VYjxSy3xHTmXe5XC8nJeYAN
+_l7z_lNSFwUF_ZbF_RFsxzrgvtB0I0EyO791-_Vp_O6bJUvTFuIUzuSf2xs_XBrqVyfQX-4Ftz_q_lYfzGq
+}
+
+AWSEntityColoring(EC2SpotInstance)
+!define EC2SpotInstance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2SpotInstance, EC2SpotInstance)
+!define EC2SpotInstance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2SpotInstance, EC2SpotInstance)
+!define EC2SpotInstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2SpotInstance, EC2SpotInstance)
+!define EC2SpotInstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2SpotInstance, EC2SpotInstance)

--- a/awslib/Compute/EC2T2Instance.puml
+++ b/awslib/Compute/EC2T2Instance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2T2Instance [64x64/16z] {
+xPTbmeGm34IRHeRxN_YJXlL5WjlxWpwaKqsJmgezjiqeqBeLL1JnvNDxJ5-q0A1rQu1fGJvU74CdzrE00_cvO57Vt7kKVD1tTBnFOxwVjfZVbJyz-3_Ap3cI
+F-EEfII-G_tpTx_oh-9wN_kMlt-IrAz8Oapb8HJABmDMTbmpLCDyXm0qVF-Z_5fy0QIX_1HEcyy00lc_-BwF7CZ_pIS076t_xd_gyVpieOTzJnxsZmppSSD2
+-PC8UtPImu7y5-l_n_PVL_y_PloyyZ-E7sEyFtRzSAs_HgzVnw-Vn_CB
+}
+
+AWSEntityColoring(EC2T2Instance)
+!define EC2T2Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2T2Instance, EC2T2Instance)
+!define EC2T2Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2T2Instance, EC2T2Instance)
+!define EC2T2InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2T2Instance, EC2T2Instance)
+!define EC2T2InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2T2Instance, EC2T2Instance)

--- a/awslib/Compute/EC2T3Instance.puml
+++ b/awslib/Compute/EC2T3Instance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2T3Instance [64x64/16z] {
+xPS53iCm34K3Xjx_meEucaUkR9NX2OOlz1jAar8H7Qyso3pu2jpbY0-_hyVq0HlCFFXAp8GD-Aau1axkfm07yak3eZw9foCVz0KSx-SnxSzRpE_AFolwmPz_
+vHUKW0NovQz-9ws2_Zrvnr-Q17qLhVc5c6iil_9U8wWUyKrTVHq_sszTCUQFvcVxCln6VWuVshx1xlpLLuYvkFDNtqWWClxvf_wOZuG0fAq9-wpZ7yW_0rHv
+Kv48gv7_skl_sFNhMl_7x9zN_iVnOuptnzuVhllNwFlh-FlpUEu
+}
+
+AWSEntityColoring(EC2T3Instance)
+!define EC2T3Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2T3Instance, EC2T3Instance)
+!define EC2T3Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2T3Instance, EC2T3Instance)
+!define EC2T3InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2T3Instance, EC2T3Instance)
+!define EC2T3InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2T3Instance, EC2T3Instance)

--- a/awslib/Compute/EC2T3aInstance.puml
+++ b/awslib/Compute/EC2T3aInstance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2T3aInstance [64x64/16z] {
+xPT7siCm24I3O1ZV_y9_GKvOA2vywULjN9yAutguAWfiBjS0kReqJbBnRLo-fsy8IAukdNG4DdHS0rVt3mNUo6-1LttlNbQ-w7TmkI-NZ5-UAxzl_fBaHY5_
+vmaxRUYk_DEVfkuVrtL__QMFnQ9j-KD9IYq_C7iKdtM5kwEL_D0zzCQE37xMxuplf7KVfWsa3VK3Wy7FNZ5CE_DRzmK0vqwRgex-slXp3BsEv4Iivvz-4dva
+6lqNwd-il4U7eLLyePlDyoVP15K_NtMMwvlvDpEPL_AQKtU8cexvF_JvV-dpw_lyl-Jz-St_VVmQb_kN_Zzy_xyk_d-z_F_vSdu1
+}
+
+AWSEntityColoring(EC2T3aInstance)
+!define EC2T3aInstance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2T3aInstance, EC2T3aInstance)
+!define EC2T3aInstance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2T3aInstance, EC2T3aInstance)
+!define EC2T3aInstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2T3aInstance, EC2T3aInstance)
+!define EC2T3aInstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2T3aInstance, EC2T3aInstance)

--- a/awslib/Compute/EC2X1Instance.puml
+++ b/awslib/Compute/EC2X1Instance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2X1Instance [64x64/16z] {
+xPS5jiKW34GRI7Ax_mr_8T-5T-QvT8vKu28PT3cgUiJEvqm1qwUpciBxx-TzyXv3mFIPa37alohM54Vd5q5tnBUXLFaixZFo8b-AmtaxfFrsZVvj_flPvxDU
+5FyRjKm5rSsU48h_NYLNCHrO2Id-G5iI-ijxiifyW-oGep5k3OMlxvNFjTec_E_u5G7uHtCcyVl7_m3i5p_rVrw_DlyJWFR9A_uFpwD1Vl9I_6la1FXUV95L
+oZvyexuSyeCN_E_k5Jbt7mqmzoxuVyRr_z3rQrl_xO3uRVxV0NyLvs_z_h3Tlmw-lnv-VpvSpm
+}
+
+AWSEntityColoring(EC2X1Instance)
+!define EC2X1Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2X1Instance, EC2X1Instance)
+!define EC2X1Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2X1Instance, EC2X1Instance)
+!define EC2X1InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2X1Instance, EC2X1Instance)
+!define EC2X1InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2X1Instance, EC2X1Instance)

--- a/awslib/Compute/EC2X1eInstance.puml
+++ b/awslib/Compute/EC2X1eInstance.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2X1eInstance [64x64/16z] {
+xPS5ZWGX44KfVNt_2w-GMgCJPicu_4WBFAG-saugYpZud2bW-dGsMU5z_tnCtgCBc3uJChfyh7XHSNA-BUY1UEtALJwrwoVoQtmfZkVbcFRBRVdtybz4slYo
+uhz3VZuJx1DsG1VyBz0XQbNPi9NuAz24lauAYtozkLVhmyGfNZmpx30llSvifIzUwOgHtyyVOmCP-GJJ01dZj_SVo3RmscqGiAd_HO0ElB65Uu3F_Q-Wx_hl
+R7JPpFzwKmSVwySAcCVV8Cl_eV_-B_y1hLB6-8UPXypvg9Iawek__gDp_zszrw3ktkf5liTVXWtpvzhh_x7hrslzboFYz_B_VldREd-ltnzUzw-Zxw_7tv-F
+rpi
+}
+
+AWSEntityColoring(EC2X1eInstance)
+!define EC2X1eInstance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2X1eInstance, EC2X1eInstance)
+!define EC2X1eInstance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2X1eInstance, EC2X1eInstance)
+!define EC2X1eInstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2X1eInstance, EC2X1eInstance)
+!define EC2X1eInstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2X1eInstance, EC2X1eInstance)

--- a/awslib/Compute/EC2z1dInstance.puml
+++ b/awslib/Compute/EC2z1dInstance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EC2z1dInstance [64x64/16z] {
+xPS5aWCn30HNEFl_3nzO3kf0gZ1qGR1DiwRbh8XPuVLt3FZpLR5InzVy-fo-sW30dwyEk0qqLTp3pkul3Px8vu5tVGzlD_9DFx3JVJgb_VJE_vhv4tNp9phi
+97Vo9qKOoI_a7orR8SalZZzX-DppHGDQo8Is1fkxUi5t179G8sEm9Z-DdyxbcWzy02QAF7uvlx1qr-EetdxBB_iwMxSp591o_X9wyelvC-3B_tuU_wGVzD-B
+FkOEcSTV3IK_qCtNifS_2lbFUFCqKdHBpPXKAUT_q_N_rFNhlVwVid--yty2_oxEt_txm_l-TVBzzVJxy-by0W
+}
+
+AWSEntityColoring(EC2z1dInstance)
+!define EC2z1dInstance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2z1dInstance, EC2z1dInstance)
+!define EC2z1dInstance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2z1dInstance, EC2z1dInstance)
+!define EC2z1dInstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2z1dInstance, EC2z1dInstance)
+!define EC2z1dInstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2z1dInstance, EC2z1dInstance)

--- a/awslib/Compute/ECSContainer1.puml
+++ b/awslib/Compute/ECSContainer1.puml
@@ -1,0 +1,12 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ECSContainer1 [64x64/16z] {
+xPLL0eKm30GRs-N-5qRot5t9_60xrDisQueYS3SnwjBnRZePVH9n5o0NlhMxiA_o0pvT797VWEaYW4nNO2zpw8EH4J8Z-QqfgIqpANALmHb_zMtRNsM-r2-_
+_FBBB__-_Tzy-wAUWhXB_ivrD_DLvwVVv_lA9-w2wJS-G3OZxiRQ0nH5CG
+}
+
+AWSEntityColoring(ECSContainer1)
+!define ECSContainer1(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ECSContainer1, ECSContainer1)
+!define ECSContainer1(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ECSContainer1, ECSContainer1)
+!define ECSContainer1Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ECSContainer1, ECSContainer1)
+!define ECSContainer1Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ECSContainer1, ECSContainer1)

--- a/awslib/Compute/ECSContainer2.puml
+++ b/awslib/Compute/ECSContainer2.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ECSContainer2 [64x64/16z] {
+xPK5OiKW44HPc-7-9ovTKk4hK9SN3pnSof_cdty2sqJJfNARAiqd4Lk0xBwLBUmx-K2c4l1RYYFI10O_xoc2aH7LswU5DoMitLppTn2PJ3FFV7ljPumWya-c
+_jgt6TyKf2e9jJLVn5WhoShZrhvCPDP_T2e7yiUytz01alE-6OWo0C9illtYt8_vzbEzbB_gGltF_SP2-v_vA-qlbyildzL-vfVoT_kiziDb7s-j_sVv4Jpt
+6R4q_tnWQVu5U3x_YPYllu3Z-aF8Illri6YMWD53L_przRVs63nyCIr5zVbcSlZigTVHVzuXpAtSu0XMz--qV_gUxqy-iGNJBtm3MOtOnieR-EUVVnu
+}
+
+AWSEntityColoring(ECSContainer2)
+!define ECSContainer2(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ECSContainer2, ECSContainer2)
+!define ECSContainer2(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ECSContainer2, ECSContainer2)
+!define ECSContainer2Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ECSContainer2, ECSContainer2)
+!define ECSContainer2Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ECSContainer2, ECSContainer2)

--- a/awslib/Compute/ECSContainer3.puml
+++ b/awslib/Compute/ECSContainer3.puml
@@ -1,0 +1,12 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ECSContainer3 [64x64/16z] {
+xTR5WSKm54DHwHcK_XiU3gDXFlgiSyC6lBMceMKZ0AW00Ae0V_fWMKBVEsHnDNiItqW2t7tRP7_Oek_l8Ye0sW44HVJbRa_juEK-s4f8wHrMtDM-zQttNF49
+_OvBVVduWxbUa8BhsTL-H8aONUxjZvUy_KdeetfTfrvCxtlfVRI5cDO7ZEWz44hxszx_MlL-V_q2R0EmltwbgzQNxnyA480A5E_VtbhJV08
+}
+
+AWSEntityColoring(ECSContainer3)
+!define ECSContainer3(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ECSContainer3, ECSContainer3)
+!define ECSContainer3(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ECSContainer3, ECSContainer3)
+!define ECSContainer3Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ECSContainer3, ECSContainer3)
+!define ECSContainer3Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ECSContainer3, ECSContainer3)

--- a/awslib/Compute/ECSService.puml
+++ b/awslib/Compute/ECSService.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ECSService [64x64/16z] {
+xTS5TiCm381X2opf_YVU70q3aklGeFzupVV0-5gE2j8YZTeHRNlkyJNqJ66S-PAKUJZ08ssdAjGAF6gGMJ2AxabDaqmbyaeO9uc74fTvtE-1wtQgsdvmu5ax
+ucrVEsOXzEaeWYQ-tEv9F1ZqeXwFUn7Pu-NjET5Pz9ZNdNw-cXdxny-KTuu_3NfWR-_w-wyUQ0f7VTqvVwAsS_q80BRdY6TXz_elE_TFsRD_bRbEpy6iIyul
+TYvuo_fxUX9jNNT_cRvcNtsjye2Vij7xosyP6Tn_Nk_-XyZ3XxVMwdE1DqQK-FwAlQkFyzTvhqVN_Ujl7hPas7lrT5yopnJ6YKyBFVLutFbU-gXU
+}
+
+AWSEntityColoring(ECSService)
+!define ECSService(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ECSService, ECSService)
+!define ECSService(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ECSService, ECSService)
+!define ECSServiceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ECSService, ECSService)
+!define ECSServiceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ECSService, ECSService)

--- a/awslib/Compute/ECSforKubernetes.puml
+++ b/awslib/Compute/ECSforKubernetes.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ECSforKubernetes [64x64/16z] {
+xPNhhiCm28DDGg3l_yJdHAuKCOcDiRzbjxRXox1pkx9uuWdt_qyVjm5t6TQZVG8m0p2zGIiWidaHY7wBBm7qcfkVkn2nxuIpQFAy7rONpkp3t_LuMVZYDVdm
+-5EOiFJ8nxBoi9X3_iMMGka9_y46UsrSs7peqJKVIsLniTgecZPenjlh84P76LRWenDB8EeLFh69CxZCpxjWTz9-cr7a7RmmAb0Ppi7mAYzK0IN7nzBXYRVv
+ZQ-hpnlnBZ-8jtdmgiqFuQ3_ed_-mby6w2yyExZvrU1F1rpGrVb_4er_xFUghAy_zosOlpv5TmPaTTQ_0XlbHj3PVw16_JRmvVx7VVHShB6Q-oyBUNTqdPgP
+JjdHY54uU4zwy35JdvzmPdd_9medNFa4PrgXuueDvQCxoIuApwhD5HLjo8JNRKY4bssWy6uieOPs-BlIdtZY3m
+}
+
+AWSEntityColoring(ECSforKubernetes)
+!define ECSforKubernetes(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ECSforKubernetes, ECSforKubernetes)
+!define ECSforKubernetes(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ECSforKubernetes, ECSforKubernetes)
+!define ECSforKubernetesParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ECSforKubernetes, ECSforKubernetes)
+!define ECSforKubernetesParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ECSforKubernetes, ECSforKubernetes)

--- a/awslib/Compute/ElasticBeanstalk.puml
+++ b/awslib/Compute/ElasticBeanstalk.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ElasticBeanstalk [64x64/16z] {
+xPM74gDQ34FbAlx_YzzSF1aklKrvkulI4v_W9XXM-lJf4vcPV4gd2Ph4-O2c0L0p4m3EsxX0eYWweBoDsuHG8Rp5AspePT0xUAp25Jum8gzclmnCm010ylRX
+qprR1O2v0ddE6wBl7G0bQmP-fPCAThYu2tH8rc-8Krx0HIaJ5R0Jce69jwetOLqZyx1vqg-R_dYTxNNku_F_T_ZqKc8SJ261M7ucOm4umBtM-oeV4IoRxZjT
+P3TUkghbaBfHBsKpWNuwAG360ujihLXkyzuvEAjm4RPipA8l88xvWFuIQdn8hV49dx0-e1eYKbiJ2kqiSjo_YM_r6tpQfgQT_bLWjt5U-GlObLVLROhuXIWq
+qW1ky2dRwVV-eABEDnppZyc6T1oOC0KGDJOdrOc_-XTCWmof0i0F_Qke_LQmQPmVKDdabGiICuiljPca0OtZZGkYowYQAQ738r7UyDM_TyU7DhtWI_Qu_kIe
+n_mpSEBv9_D3vh2dJvy-_GS
+}
+
+AWSEntityColoring(ElasticBeanstalk)
+!define ElasticBeanstalk(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ElasticBeanstalk, ElasticBeanstalk)
+!define ElasticBeanstalk(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ElasticBeanstalk, ElasticBeanstalk)
+!define ElasticBeanstalkParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ElasticBeanstalk, ElasticBeanstalk)
+!define ElasticBeanstalkParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ElasticBeanstalk, ElasticBeanstalk)

--- a/awslib/Compute/ElasticBeanstalkApplication.puml
+++ b/awslib/Compute/ElasticBeanstalkApplication.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ElasticBeanstalkApplication [64x64/16z] {
+xTDNbjim341HeZxkVyDfCxOAb0CwlGY_zXKgnoy9KJFt27VJLwb5iWzx0QldVBWv9yn9B6lBDqY6cOg8ECLtEaosNbZs-aN7SLe9a4l9lsWPXt28NF8EfDPl
+fYpv0Bmi4j01iPIzdac2ZHLlbpo-I05lk5voXnnBFi4lQvAtZrjRVNwz9eFc0G5IH_z8wo1TUYzyQocXxLuAtvRMdQzIzxlZseq_wdnYbzExyG7NVArzXQXS
+Tdk8xlBrp97wSp_zchrsLmEoP2-tKQFqLxANqonHrvidxatwu-kGCzUjkNxybGkWZG-GPpAYlg7UFnkfF1gzdQTpIgP0ZbKVW9tcGen5BtcQbB6LqtlbC7Zn
+15B7eZ-KAXOSahT-llrRHCqZUTCorlsS9Bi86-kH729TI-hEHsH6X5kXIpx7wt7xsz_-zhSNbV6NnKS
+}
+
+AWSEntityColoring(ElasticBeanstalkApplication)
+!define ElasticBeanstalkApplication(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ElasticBeanstalkApplication, ElasticBeanstalkApplication)
+!define ElasticBeanstalkApplication(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ElasticBeanstalkApplication, ElasticBeanstalkApplication)
+!define ElasticBeanstalkApplicationParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ElasticBeanstalkApplication, ElasticBeanstalkApplication)
+!define ElasticBeanstalkApplicationParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ElasticBeanstalkApplication, ElasticBeanstalkApplication)

--- a/awslib/Compute/ElasticBeanstalkDeployment.puml
+++ b/awslib/Compute/ElasticBeanstalkDeployment.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ElasticBeanstalkDeployment [64x64/16z] {
+xPO7ReL034HnVTp_n1627SLAxtLI_-9dZxU9xHrbaLMLOOz7cNiSSX_ZsJkNEXuiq83KcnHhwFhZTs2VBFiEUbW0wNOKyGA8MJaMt5qPXzXXTTeJi0BoTcyd
+M-6ceSE0gNgV_qQvsidPM_de1bXyGYiIrtE_tPlDVe06M__RmdSbk99Q0oLQ3HDnOGKkV5U2X3YIoyYSZzhov0rAvjdbmA1FdwFuYhJ59_ZgEA0IM4LiAsgR
+qjmKNAsiUVBjz1KhBBSjxk06n2OGLR3hm_Ah9rCDUVxj0z923qG1TrJGA_RauzcyDeiAlvGFRHQ_mEVw5-uw03QY1g-DCUG8rxeLsEHLYxYBnyW-mWQln1FF
+kzc1oIjwsZVXCtjgUF0D_Z1kq88W1gyZDl0na68qguDFdJl521zDpzlAp7G1-WEuUfu9MduikOFFU5Dv1LptgqSsoFpq9vMw7pMbyNJWympD3Cr-sJXc85tH
+tCqdUqFcxZfTAQztSP_Sb4xdN8bXvndyGLapfz9avpby87oix3Fv16hIKBOzZyzXrQBrQl4iVjThX7bK8_gv_BxJrTqibHf_PdrffrFmS_bkwExvHlPydb7m
+h_3__3__p__pyKRU8cpx0Re1
+}
+
+AWSEntityColoring(ElasticBeanstalkDeployment)
+!define ElasticBeanstalkDeployment(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ElasticBeanstalkDeployment, ElasticBeanstalkDeployment)
+!define ElasticBeanstalkDeployment(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ElasticBeanstalkDeployment, ElasticBeanstalkDeployment)
+!define ElasticBeanstalkDeploymentParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ElasticBeanstalkDeployment, ElasticBeanstalkDeployment)
+!define ElasticBeanstalkDeploymentParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ElasticBeanstalkDeployment, ElasticBeanstalkDeployment)

--- a/awslib/Compute/ElasticContainerService.puml
+++ b/awslib/Compute/ElasticContainerService.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ElasticContainerService [64x64/16z] {
+xPRRhWCX24KtAkpp_rzyedCXaTemqrVflSvoM2IYVylOiOFz-Jgi22d5tj6i0Cm0LBwW6o3IUG6aFSLLWChQ-Vu1iMVYGDS-UF-T5nVjtqx-pASn9tvUUlDU
+3qsaBbvlvrqg9nvvB-eIzXmZ7zrYs3oeqddHkROBYOPYaqib2yBVRSLRl56qjWG_Aj4OofBYuorPNIB1trTFnKZo13IEAi0iBv-6vIT-yvlNjxolYYHlwpqb
+j_ugmrQgPoFGRxolrZQj_vxz-2AP_gNY4cm3LXdP5wJxNxdxd-YOPw1QTCKNdbzTmWhSXTMpYc68_H-Ocgz04nklctid_9h0Qe-aJTDLPWuUYw7C8OBjB4DC
+JVJ1-IFy5oVDbq4bIkNBO47yYGHh5CzBi0NnHnAkyIBOHEpN0_mwTkpu1m
+}
+
+AWSEntityColoring(ElasticContainerService)
+!define ElasticContainerService(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ElasticContainerService, ElasticContainerService)
+!define ElasticContainerService(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ElasticContainerService, ElasticContainerService)
+!define ElasticContainerServiceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ElasticContainerService, ElasticContainerService)
+!define ElasticContainerServiceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ElasticContainerService, ElasticContainerService)

--- a/awslib/Compute/Fargate.puml
+++ b/awslib/Compute/Fargate.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Fargate [64x64/16z] {
+xPQ7Qkqm40Ld-_x_5p-i22nUZ2CxX7g7UiiSbTt5xh_ZmuVCNzaA-ZeX54H0uuLSCSogaHBrqFR3plCKulNGjkNSQOyI5BJ-YxJvtGR5zzNIW6rVZFK0NtVu
+n5-kODvbj3xmpnAKCoiXp_pP0lCWJ_r9W4_hbTyYtK_yobpz4gdLpwoV6i_kVBjjGmSqxlnGmA_jKh3gll5l6zcGxBxt3rAmwrkltl6xBYkHPwgGt_qyKusy
+Mxy3B6kjVwL1zDtwxKWkXH3po1J933TPhZs5wmeOM2uJkw9HqpQmlYO4nBFcbjrqOCjN0XBNzhciMcHLBrHbc2uRkOiG1Y8w4PdVdF8TbU6cmeAeUMJrDjLT
+LJce6cBjow7dEPV9pFsdXx1EQXgm-oGqaEmKreP6imFO2510J3dz4a1DTlqmG7tn9KQUxVdLZdSTVfhNrnGfsR7h1t7ugG2MXs_Khk_ZZmwWuGAGXr-supk8
+CllFCfK35NJa_4pQb-epH20K7hn2bAjNvpY8H2dLQVhq9IX64RJF9_TBNzxv2HPeAE_ySc6WqU-eKB3iNv3LVyQ73_y
+}
+
+AWSEntityColoring(Fargate)
+!define Fargate(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, Fargate, Fargate)
+!define Fargate(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, Fargate, Fargate)
+!define FargateParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, Fargate, Fargate)
+!define FargateParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, Fargate, Fargate)

--- a/awslib/Compute/Lambda.puml
+++ b/awslib/Compute/Lambda.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Lambda [64x64/16z] {
+xPQ7QWGn44CrFV__m-bcPHy63-b5ARTDw1qZXhtxLlhNloecjVsAIT7t-vNkaBw_fhDuap-XVVzycc_o1xJlPmcoxNyBW2BhMQDF1D3fZzO0W7Nyhl8e1U82
+g8R_Tl3U0hXjNW7LzmS3UDVDWtyxW7K1t1S0QG4aa6y1KC2cvcKB8262cWPldJrY28TDpKj89xuA1D1SP0P_jHRQ0CFK1k3uKLe626WZVdmQlBL92Tcw01pF
+0ArDkdOc8Gs0qLawD4HZamPiEIG0Xnt6yzTL1X0HZOETGOVKF0S0-C7Eed5pywegu2VnkHuEvTRFcHpAntl_cYaBre6VSkYGkBP-pgIX4y21dp8DiPdBtf-0
+NwzjjGucNcKxluFaQo_vti6BQwrmoxtle7_zwm4
+}
+
+AWSEntityColoring(Lambda)
+!define Lambda(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, Lambda, Lambda)
+!define Lambda(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, Lambda, Lambda)
+!define LambdaParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, Lambda, Lambda)
+!define LambdaParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, Lambda, Lambda)

--- a/awslib/Compute/LambdaLambdaFunction.puml
+++ b/awslib/Compute/LambdaLambdaFunction.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $LambdaLambdaFunction [64x64/16z] {
+jPU7ZiGm24GNOaZ-_uUtU6szmvghretA5XY64Yluzg-m9_x8F2BpxCYCutTHlELr5bpP_AVi8w-fsvwOULnv_8mzv8p_R2JqVGJlMirLJJqdB0gjiqqRxMtz
+WXvFUzZdTkiEdrfVkVipIdv43UUl6apJXydFWX0YzWazXaJ6X73clpLkp1ITV4N3GfKGdGv_8X5RVDV1vKtn3pMnv4_QQf9_Urfahxm6dB_Xay31Btoo-iH7
+Mnmlp0Hm1L6YbeduClc6QwrWwH6c2Hk_HG945JEo5mWQIxE8AfuHaDycuENRYcyIG3LBU35v5uSMcgdqpMWHfQm5sCZJHNUSoUiE-GWV-eIaJA1g17Mifkjq
+6YzE4SGyGvJMWzFu5ASetlmJFlAPvvh08OgKxUzr6mamJ3M0oiUtjypbAVgSZ-kWYeTOy8MyIi0Ll_QFMNsVG4oTKFA3AayHy-CngF9yItsA8FByeaeVcJmM
+db_EJvMd47sCEJyCe8eWN4vHFb7QJnre5Fdo47SuvJDP9TzMUul8Q_pmOUSRyaGY0JnyLSKrX3oJXqzGVBKyau9FL-lx2o5g8YtulB_g-zEqF7d13-HvVyTy
+ynxj6WJixMtfAVB-Bll32QOyTk3i3tL_oK_NjcAodexQYGpS5c0PlgkTc09YVzFxeuRU7_N-Ag7tLxq_2uZzUMD_jxtxm_xzPV_-j7z_sxy_xjzVz-_F-tW
+}
+
+AWSEntityColoring(LambdaLambdaFunction)
+!define LambdaLambdaFunction(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, LambdaLambdaFunction, LambdaLambdaFunction)
+!define LambdaLambdaFunction(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, LambdaLambdaFunction, LambdaLambdaFunction)
+!define LambdaLambdaFunctionParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, LambdaLambdaFunction, LambdaLambdaFunction)
+!define LambdaLambdaFunctionParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, LambdaLambdaFunction, LambdaLambdaFunction)

--- a/awslib/Compute/Lightsail.puml
+++ b/awslib/Compute/Lightsail.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Lightsail [64x64/16z] {
+xLO74iCW39DjRF7_3tU0kvV9xLxKcGGDDlq_iMF73iO9t4WE4mo8RT1m0Q1sWW8GN_HMG3rT6GP8h9W3-b2U1jGZjFl28PwIhUv-DYTJ335rYWaY2RHnQO3m
+TlytqYSKTkOf59QvX9NqcjsFSmSGGabZApJ1A3p0DkKi9QTMnJunokfPxXRWHnE-50de395NzZi-7o_zBZX5-8kl3sdIK17vos_a73NalA12-50h-p84GaIf
+8c4YpKKi04sx1h_zLlbUu9Vpn-rtG_i9EDGLtDX_lHkp_zR7JuFHe17G-lZD7aVCEH7YALwRFzJKizwWGuy0V_6pC4DXqTVdRpOPNQ3UNzQF-lf5uSlwvRs0
+N34P_MdzB2_0zdxzjfKDGEDXL1lAxXaMzhX_ULy1syF-YSQ-2BeA9jIvzVZW7i7-bzYnOySH
+}
+
+AWSEntityColoring(Lightsail)
+!define Lightsail(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, Lightsail, Lightsail)
+!define Lightsail(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, Lightsail, Lightsail)
+!define LightsailParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, Lightsail, Lightsail)
+!define LightsailParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, Lightsail, Lightsail)

--- a/awslib/Compute/Outposts.puml
+++ b/awslib/Compute/Outposts.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Outposts [64x64/16z] {
+xPO7RWCn30INHKlz_yMHQSCWZ7PKUg9nByFgSlDlSZZ4C5LrRkeKtB7OqGUW8u8kqEZh1CPCGc5zNrDFGk2c7htqMbkv8Pq0VajV2XWqMAjyrcgOGQ8p_FGh
+BhneX-A-Cuu2BwSt21zXAdOr_MFK3d5xue9njNb_bC6Nfnkx-qQVqASVRWkdntL_2lpf8p6muHCmaba_auYil_VJeSLdovynRB7ya8twape_eyUUNzZBhtB3
+9Rx7dv5irr_uL_xnZ-_mA7ZN9rvW_n1A192y0iRiebXO1bf4stTThBJKXSNyOnmERm
+}
+
+AWSEntityColoring(Outposts)
+!define Outposts(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, Outposts, Outposts)
+!define Outposts(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, Outposts, Outposts)
+!define OutpostsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, Outposts, Outposts)
+!define OutpostsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, Outposts, Outposts)

--- a/awslib/Compute/ServerlessApplicationRepository.puml
+++ b/awslib/Compute/ServerlessApplicationRepository.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ServerlessApplicationRepository [64x64/16z] {
+xPHNOkGm34F1pljVU3VXDCOnFUKdJM-g2o0Hb9pVYyLYiGWJPbQBrzI2CwGlE1X0OXu21iZoIHJGEFsn4C2U7jqlHbQ7Jnb4oQ_wCdWc0u5cqzSFXpABFpOy
+nKQVX1FoK7ZQ_tkSAX0FetPfXE5D_yQR9gI4yKWGX6XwQkrhSvk9hW-BT71US73a8KP0RFDi_m7s70a6s6hWoitPGdlghdJK1GRx9JUEStxacncE1dekpq32
+uCgFn3ydP5DqVcrXVUdkdTuIwJYujL0cVLbFkxu09BqEwWH72dK06_GNf1_0az4PzH8NCkECGQgqkA6mm_gthfjB5SqUkuq9GArTQKjyVd1rRBlpzM01xSv0
+rJ_Uv3aRaFg6UCClQ7Lln1dtOCyZN8LdH3s_1ul5Ol4V
+}
+
+AWSEntityColoring(ServerlessApplicationRepository)
+!define ServerlessApplicationRepository(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ServerlessApplicationRepository, ServerlessApplicationRepository)
+!define ServerlessApplicationRepository(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ServerlessApplicationRepository, ServerlessApplicationRepository)
+!define ServerlessApplicationRepositoryParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ServerlessApplicationRepository, ServerlessApplicationRepository)
+!define ServerlessApplicationRepositoryParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ServerlessApplicationRepository, ServerlessApplicationRepository)

--- a/awslib/Compute/VMwareCloudOnAWS.puml
+++ b/awslib/Compute/VMwareCloudOnAWS.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $VMwareCloudOnAWS [64x64/16z] {
+xTG5ZkH058DX-v5z_nDlDftIK6f8FEfFqFY72lm7FJqzIUjDPSuFsyaW6JNsuB_o3pHn80unZfm6nj-b0A9rcE9rvaBz8ETuQI1j2-5l2eGqYuSeMwJyBOsG
+0qjxYB69x_Mw_fsdGDaDoeGaVwsGjacV6cKxK2PSbByKcBEVEEIZ7vH05y9V4QYpRnpuw5qp23lGN_VXizVfwgyR6OI_C5Xz7sRrJlHwjjvJ4U6Frx-6Bm2s
+juP0pgEVElIZbmJwC1L0Q9S3APz8lTos-78TdW3bMu6oRte7Y9bL9MBxwExx1a2KBvkdcEXDBmA8yQMHlX7GfdSpnrOnj5_BtFUMhS2Xpvu_EVz5883Szudn
+I--N_g862MsdSIDVUlJyLtZf7PZ2RFT24VtIB-Mb49Pi4VAT1dgzpKM-21WV54ZVAo17lg5hTcgA27cZ2V3EE15k4a39M-eWFYeNA16CLM_fXXiOw-2VKVVr
+OCQ_4iXfWkFV4N48-RTKMUE_wEdfwHy
+}
+
+AWSEntityColoring(VMwareCloudOnAWS)
+!define VMwareCloudOnAWS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, VMwareCloudOnAWS, VMwareCloudOnAWS)
+!define VMwareCloudOnAWS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, VMwareCloudOnAWS, VMwareCloudOnAWS)
+!define VMwareCloudOnAWSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, VMwareCloudOnAWS, VMwareCloudOnAWS)
+!define VMwareCloudOnAWSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, VMwareCloudOnAWS, VMwareCloudOnAWS)

--- a/awslib/Compute/all.puml
+++ b/awslib/Compute/all.puml
@@ -1,0 +1,715 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $Batch [64x64/16z] {
+xLQ7bjim30CdzFzVtEV1iErPkJpT7iYm5aWDKERujFZ5Bp8YkSvM011VfMzSDy2Mw1JidbCGAtmllmbPuIkoImjyGUsyBV4LV95_Xny50bpW4uTRAjOKu81b
+Xa0vbX3OKFG5C0IMNLyxXA_3PvW5hqHSOFBP_Ovk4036hYi0pJdTCgqD6A0g4FQ0hOwygxSikGOanw11AuvtomxXjNiRDECmn21xxTkJP0N4tdy1Gmu5T2GW
+6ygFL_sqbx3NvA_FVtt_ri_F1CZNra-10TpNhvVr2KGcyVCOdoBySlpv-jC1ZSVveO36_Fwb0UASqGqG0QpfJgP2Eo60u59-fLVozhhdNk2WTeDpq2O6AAL_
+uV7KGPNO2lya17gz1pMiD1VmFNH9IBLNe3xA3q07eNsMy_WdXESwU4jRmddEk-FUuPFjjthiqAEGVUz8rlqmsK1nhtYlklvp7vWRfka0jUNITUdTzgxFyzLx
+-Ikh_YdmYr_y0G
+}
+
+AWSEntityColoring(Batch)
+!define Batch(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, Batch, Batch)
+!define Batch(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, Batch, Batch)
+!define BatchParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, Batch, Batch)
+!define BatchParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, Batch, Batch)
+
+sprite $Compute [64x64/16z] {
+xTO5SWKn30DGIN5Mll-5IvyvMPTRpMJuXGbVbVyGcv1GZza0ElYUi_69Zz_b_xrzKQPyfpEKsLgc8iq-wU4CPagPZ3Gcl2D2s1Go0jgKy90tmQi1FU83lZNb
+CUIPDyAFz-vTjxrwzmDFuCqlJKTfovi7-C2dlUc_q8uujEc_FJf-jJnAq-Zu8xJnElRQU4Ky73znsuFqIFyl_LZ_wzvDlEsfvgB_yl5Nrw-wVwhxjtf-gkUt
+UdzywVrNlR-hxqVn_QgydzNtk_f_-Ct_ft_lsImdVaNUpqDjJKJimbN1RyWp
+}
+
+AWSEntityColoring(Compute)
+!define Compute(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, Compute, Compute)
+!define Compute(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, Compute, Compute)
+!define ComputeParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, Compute, Compute)
+!define ComputeParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, Compute, Compute)
+
+sprite $EC2 [64x64/16z] {
+xTP5bWGn30DGevpxNtWmk_ABtCFGMkU7QVtOt7CFiWkcFAKFXjx5ungJdFgsfVWrFctWvvbx65PPF8t0dyfRBHZ6VXU1F5dLrrb8YTjyL8eLL54cMN6JTsdY
+GuyCKRz49H8JRxkjfaysRB_tlFsTwdtDnb_8tYVgAyOVRhqtZwDFVqg-UVmGsLr4xt7sAGwWbglsNjMFVc_neoy0VlJd_jk-VtlFzy-UuuCdwxVJUxf_YEVx
+jyry_CJJy_i5uoVt5_7a_YIUtD_Kq_U3U_v-SSypzx1ydnV_DTxY6XzxI9zyxsVrn-QUUnu1
+}
+
+AWSEntityColoring(EC2)
+!define EC2(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2, EC2)
+!define EC2(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2, EC2)
+!define EC2Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2, EC2)
+!define EC2Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2, EC2)
+
+sprite $EC2A1Instance [64x64/16z] {
+xPS5hiGm30LhdDx_mXyIHLGLt6KOGN0M_8hJLR68tNQBWCtMcQNY-x9zJz-Z0Mos2HaDNtnnZRYwFnLu8ryRMVMpUwFoLFrENExB9RzVdZM_R_uYiXWKyWzW
+E1f0CNy0Qpr906hrL-QPR5s3kXzaqF-0kahL5t057-DLVwL-1Zf1hlgZVYlv9RGLNVEtyvUsOk1h_dR-1aJap9Wivfzqvl47QlKNmFu8Y3E-Wu_FEUC3EZfs
+8dztxnrprz4fv7_7w_-brw_lzLykgDyt__VnQrpkN_h-y7t_klZzzVBtvylv1G
+}
+
+AWSEntityColoring(EC2A1Instance)
+!define EC2A1Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2A1Instance, EC2A1Instance)
+!define EC2A1Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2A1Instance, EC2A1Instance)
+!define EC2A1InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2A1Instance, EC2A1Instance)
+!define EC2A1InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2A1Instance, EC2A1Instance)
+
+sprite $EC2AMI [64x64/16z] {
+xPS5mi8m34ON_Nh_2_-21OSq6zg7ixswPPeBId4aio69yHGOEh2TxW1SLUv6TQL4xivJ4lPj2JXIIk40RxBd7fyt1OZiymNuUoT0-tm5QELBdoy7Faa2ElKT
+2VoctzhHhzk-KQ00noy6b0Axu1-tpOwZDYxvmnz-TVmkCtyI-CphHvhFyyKJo2BhhmM7lmnm2_3Ays_umn--7ljwsuS7G7CF6k318li7Mm8EltP-BfxVg_53
+DNufna_5-AqOFvRZrthyNESN
+}
+
+AWSEntityColoring(EC2AMI)
+!define EC2AMI(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2AMI, EC2AMI)
+!define EC2AMI(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2AMI, EC2AMI)
+!define EC2AMIParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2AMI, EC2AMI)
+!define EC2AMIParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2AMI, EC2AMI)
+
+sprite $EC2AutoScaling [64x64/16z] {
+xPO50kL024CJPCBzBxn2lxlxgrF2kDJhykF767KD2UHryci299gy8lFanKLe8Nbf7OZ84gbAK9SqNTQahnnr8QrltbDVPghd88zAbpmhN1VemNAC0Iz2PwiL
+006o7o7LIRZFdW2u080l_nz0d3c6WLf0M4noKAS5A59B8-ia-J90JgvBMnwLgwdH0Hph-id6CVVQGIuhAqfZFVz35SigpKDw0hvBxmivSty1kh3QbNzryIUd
+_SWErT_HqIGxt7vsOlC7r_iFJ-i_Sgicq10WcgZ6N7KGpHxArV6Jcjkl7B-derZE7w5w4cRLVCNwSVtwUVtwVVt-uVhzo_Nxf-ltRyiYNBj_VLr-_FWB
+}
+
+AWSEntityColoring(EC2AutoScaling)
+!define EC2AutoScaling(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2AutoScaling, EC2AutoScaling)
+!define EC2AutoScaling(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2AutoScaling, EC2AutoScaling)
+!define EC2AutoScalingParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2AutoScaling, EC2AutoScaling)
+!define EC2AutoScalingParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2AutoScaling, EC2AutoScaling)
+
+sprite $EC2AutoScalingResource [64x64/16z] {
+xPS7hkCm34I7HHhT_y9R1084ue28nTtV7qfYcq-zuaiZSqf79qdfw6kHSgvldtAgXqyvr8UIDaZAcGub5KS9R1tRtmdSzVsl7Zu67NSnf0_32UdZ-_g63Y9u
+5yHTe6w0kUwdWuex2P0E8_MsFtIIPkJKSSyNrSaLit_jFvogKaew5O5l8ub7luOcGbBJNtJLnBdIrwVhWMS2ObdXR0wJr1se4e1UVKMj8nDGdrT_kjOwO2Gr
+wl_eBz93jsjt1PEa5lxMfseWsCpifTXkOi1Tvg54I32x_cFv1qchocyanqFv4zrwuKSJ5yrlLVzbKA4NuoV32hqOlrK2Gj9Ucp_sTFvOwENypT0hylhw8Otr
+gx5-zjRlTq44xx1__fm_6kUtnlcnVNxjdv_xv_V-_Q5_V-dVdx8Aqhq_Vcb-0m
+}
+
+AWSEntityColoring(EC2AutoScalingResource)
+!define EC2AutoScalingResource(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2AutoScalingResource, EC2AutoScalingResource)
+!define EC2AutoScalingResource(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2AutoScalingResource, EC2AutoScalingResource)
+!define EC2AutoScalingResourceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2AutoScalingResource, EC2AutoScalingResource)
+!define EC2AutoScalingResourceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2AutoScalingResource, EC2AutoScalingResource)
+
+sprite $EC2C4Instance [64x64/16z] {
+xPS55iCm34DdLEv_uZsdpFKRWmOD_O0qlDnLOdRYkYq3Tg-AGXbUbzVlvDMg0EnU7N2hqiN2ETdT-Kj2NyHpbMTvvwh1-HpVocxdwPRzqzlczy-VHOPyY9Bv
+AwgahsagVqTLIt6KClvR04mat0ulAPxQdOzcI_42-AGcM_p2lwLT58Et_5lFpyR37Hw09l8VymhmDh-vVnjsxo8IptGw_yYRUlD2fG1oFdy0JesxNXKDV9Pl
+Lmsi6vRAVzZsYBT4_j4ivcvARLML4_a_x_F_ri-l_-S_tU3VF__FvT_hztV-_yF__zVD_rzl__zykwu
+}
+
+AWSEntityColoring(EC2C4Instance)
+!define EC2C4Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2C4Instance, EC2C4Instance)
+!define EC2C4Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2C4Instance, EC2C4Instance)
+!define EC2C4InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2C4Instance, EC2C4Instance)
+!define EC2C4InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2C4Instance, EC2C4Instance)
+
+sprite $EC2C5Instance [64x64/16z] {
+xPS5jiCm30GjIwlj_I_ymM6ENZd9F2XEGHDoUYWARDwk0NBrrdYJY6_JssFwXWB9rLid7GMRV74CFDnF0Gxavu97VQ-yRl91lmBt-tBFxvUFxNVrpwfL7wc8
+zJSMjFi2YVHtLbXtLmBpnx-QHJJ_-ox_1Fe9IPsyTx-lfATT_lpyZBJ-hDsXi_rblXzwljnOGA1_tq-gEHj9tT_V9lzPIUpldxlStJC8z2VfrRQRf9rem5UM
+gJkHu313SFjBoWgqyzMz_Ij4uGwJwewR1Fg_yFX_x_7hElxVS_wy-X_7Zt6_V-_wuLf_tRr-lN_zV3-_
+}
+
+AWSEntityColoring(EC2C5Instance)
+!define EC2C5Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2C5Instance, EC2C5Instance)
+!define EC2C5Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2C5Instance, EC2C5Instance)
+!define EC2C5InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2C5Instance, EC2C5Instance)
+!define EC2C5InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2C5Instance, EC2C5Instance)
+
+sprite $EC2C5nInstance [64x64/16z] {
+xPS7ZaCX44FnDEV-5zx2h884Aw9HUdaglxuFsAdjegZxoUqE9xTRum4LtzRjQ_hc7PBRRP3X7Li6hk4Nzrk15_Ab4rK_qXl95_t4p_TnplpnWFrz-XVLtWp-
+gFLlxEXuD2hz1nCRkoZaxoHD09LVFzRvxtsGb7_kCjEc4IudV2MZ3T_cm8Z9d_8p3WSa8rmp5OOfIPloc_fpKeUVUFheixDz_vvt9AeYHb8s_Zp_9HabVV8t
+_SloGfR5t_PFqf6xE2PQy9KzzQ0t3pVp0uc2tvI97vFLBYp-sdy2zGWtv4uO-bFjLuIPBFtVzVF_tC-lp-S_piZlq__h-3NEzy_z__3v_tNs_zVp_p-VppS
+}
+
+AWSEntityColoring(EC2C5nInstance)
+!define EC2C5nInstance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2C5nInstance, EC2C5nInstance)
+!define EC2C5nInstance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2C5nInstance, EC2C5nInstance)
+!define EC2C5nInstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2C5nInstance, EC2C5nInstance)
+!define EC2C5nInstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2C5nInstance, EC2C5nInstance)
+
+sprite $EC2ContainerRegistry [64x64/16z] {
+xPPdMWOn28GXeNZ_2rlY_C0I1TPk-7fvzna8xMPlnuwPs0NQ9n69TsaXudd_q1QkJ2I-D0ohEpuUCRoTNdQSzPcKilGOYbmOzdhtOKZyCHq62CsuLVy7mcev
+n_T_sShBH4Y9vkOd8MaSJUGjTJJkFLxuuMWSCgkyyPAkJ1qUvRHUoZoo2lvRcKTM8JKhV3mpHsfM-5XEJho-gV0EpLr-GdEN7_Ygp_ltyuT76eykZpJs3X_J
+kCcZVj_dvHN-USyr9adrV_26RsCSKjqTlD9CZl7eQUJbsQ-5-Gi-g2iiFf6lh56O5967hAJvcbI1h-vFK0j-9XpVdENYuNXd_wG7dlN2_ki6ntjNU5FuiMDt
+}
+
+AWSEntityColoring(EC2ContainerRegistry)
+!define EC2ContainerRegistry(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2ContainerRegistry, EC2ContainerRegistry)
+!define EC2ContainerRegistry(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2ContainerRegistry, EC2ContainerRegistry)
+!define EC2ContainerRegistryParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2ContainerRegistry, EC2ContainerRegistry)
+!define EC2ContainerRegistryParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2ContainerRegistry, EC2ContainerRegistry)
+
+sprite $EC2ContainerRegistryImage [64x64/16z] {
+xTS5ZWGn30NHsC7xdtW7eanbhIP7BUo_3A-6AQplcURhI_2bEXOdNwwjjjddS6rIx_IFVxoeYjzBgRMseawlk94vlBnaLaslB-BnBvZ2Q_6LyVXIoxXZyFXQ
+ypWYidBusNVuBwRzlyhl0jL3puilIj3o-Z9uRsvwBjM-38x0XZU1zECv8R3XCOav9m4F0O4DRqREmBQNf1iSWMqllCsG8x3bEvy3u0XOFtX1W7mEMDzv3X41
+SWQi7pmWG3u7h1-y1yXj81dVEGBW9j3QFzyv0-GsCFlIEGE6Cz1gWiS_8r2CGs3s3HmduVJZ1_XsODlZg2BWVlnWmEKPS7a6N9u1bsV0vHdmU0R4uH5m73ud
+Tp__Md_zu5XSVlsqlcT_
+}
+
+AWSEntityColoring(EC2ContainerRegistryImage)
+!define EC2ContainerRegistryImage(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2ContainerRegistryImage, EC2ContainerRegistryImage)
+!define EC2ContainerRegistryImage(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2ContainerRegistryImage, EC2ContainerRegistryImage)
+!define EC2ContainerRegistryImageParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2ContainerRegistryImage, EC2ContainerRegistryImage)
+!define EC2ContainerRegistryImageParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2ContainerRegistryImage, EC2ContainerRegistryImage)
+
+sprite $EC2ContainerRegistryResource [64x64/16z] {
+p9I74eD020KV70V__yLM9ZT3ZapiRegwkdR5MT0cGipLDb8P3Q-tKJ-vcfcAbByHMPAsTMLiXDNt0EnhsegQiM-UimlmoxFlW9ccvx1ctdS009c9JtsZkGV4
+Z9Q-hBsMmAHo3vJGLmIgQUApdWZjh_N1f_qopcQyp6jzy6_kPLrEGXzyqaE4GI845a7hex_e-b70-uuF_VRxz_oUIWTAVUot4tlkaFhORtz_d7_-bGEJIlnL
+xuzI2EH_hU_wiVkwA000Xc4ewj_rFEoLUnv3aW__xuP--Fdv_VdxyVVh_yV_xqUPVlNgB_e7lZ_qpnFwuVqzl_dzUNxL_8pvNVb1-GNv2VaD-P7vrVdPwm4
+}
+
+AWSEntityColoring(EC2ContainerRegistryResource)
+!define EC2ContainerRegistryResource(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2ContainerRegistryResource, EC2ContainerRegistryResource)
+!define EC2ContainerRegistryResource(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2ContainerRegistryResource, EC2ContainerRegistryResource)
+!define EC2ContainerRegistryResourceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2ContainerRegistryResource, EC2ContainerRegistryResource)
+!define EC2ContainerRegistryResourceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2ContainerRegistryResource, EC2ContainerRegistryResource)
+
+sprite $EC2D2Instance [64x64/16z] {
+xPS5aiDG34DhLEz_uGMbNcZGKuOty6bUm0hkpef5hBPB1B3OElRIyNtSFgVlGG0ijWba41_jk4UStTyrU29VINRzLFAdyZr_84xtvPJZbtlCxvs_aD-nccaZ
+VwbLuT0vIDcSlw3GxvrZ83VMdtwAQ89FIuCBDw8T_xjDmB-BCVJxlh8j0pBfJzSl3stDUXcZ-WN8sF-xKsLlFV_n_gKwriZ_ZyysgNVopxydNNgp_iRCI-_v
+oAotL62F_2OwFl7Xw8lD-JinuSZyW2taVwld_wdFh_VpNqwetpl_v_5xdEwV-l_m_lyw-V_rzF_dq_a4
+}
+
+AWSEntityColoring(EC2D2Instance)
+!define EC2D2Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2D2Instance, EC2D2Instance)
+!define EC2D2Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2D2Instance, EC2D2Instance)
+!define EC2D2InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2D2Instance, EC2D2Instance)
+!define EC2D2InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2D2Instance, EC2D2Instance)
+
+sprite $EC2DBonInstance [64x64/16z] {
+xPPLOe0m44HPczdxdxXia7hPrEtz3FQ0U9PtH02h34I50nKAQjqaxCedlH8SOf0LnirFlixNtUStzZK69BRWdG0JbKd4G1_xnWdiAJ_P99_nTMcXp_dIy-NT
+VLdn6T_BE2y4Yvpm1t5SmAoVB70MtLV0la-KOUzJVp_VTwnmncSP_khsJnRn3j__RxztwFzutVZ5QzkV6p4__sp8HgF-6dosB-OH029STq5DLQFZrrEy0rnc
+wZ-uiOyt5jRtou6hd2M9xGMYAzVjfoJqYLMxMtz6qku_8y7Chg-Zn5M0WPeZcPD-CMAZNj3jlqgQnLqRNWtQhVzZ5wNcXOs6A1zJ_bs6VymVh_O7zlDzj-UH
+XiyNq6j_a9bFnOLVIA5aL8Ae25BNS5xuZVtxJ_QjvnTckeLLw1PoqVuTFiZtATyVNKJV5p93vUuL1uc99R90k1KU6AUoj97WGtoPGYoOEqICrhq1
+}
+
+AWSEntityColoring(EC2DBonInstance)
+!define EC2DBonInstance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2DBonInstance, EC2DBonInstance)
+!define EC2DBonInstance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2DBonInstance, EC2DBonInstance)
+!define EC2DBonInstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2DBonInstance, EC2DBonInstance)
+!define EC2DBonInstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2DBonInstance, EC2DBonInstance)
+
+sprite $EC2ElasticIPAddress [64x64/16z] {
+xTJ50SH020LG_4__5QyhOILSUSS8Da9jOumnnEB8bNRHm8tH1qoR74TnXAFWkaXezRin7R7Yg0h0m5O0Vyx93WGLJj4b5uNWrt3sJu1uBxZiuCZIIm4y9L7w
+EO3bYauHIvRRfToHrE8rGEHnEnPgQoruz_zk_StvDTUlkN_Q-xT_VlhdDzyVxZlkZyRzrRW_EyOOOnm
+}
+
+AWSEntityColoring(EC2ElasticIPAddress)
+!define EC2ElasticIPAddress(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2ElasticIPAddress, EC2ElasticIPAddress)
+!define EC2ElasticIPAddress(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2ElasticIPAddress, EC2ElasticIPAddress)
+!define EC2ElasticIPAddressParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2ElasticIPAddress, EC2ElasticIPAddress)
+!define EC2ElasticIPAddressParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2ElasticIPAddress, EC2ElasticIPAddress)
+
+sprite $EC2F1Instance [64x64/16z] {
+xPS55eGm34HfEybm_mlZxdbXVJyk7qazkvKaShezGiZ3BPW7Yu_rzZjzI0F9mwsIAWrOlTY6tEvd1hx8ZmrgzRNrniZR_0xn-y7p_U4zq--V_g5ZEBAbFzXH
+Uqb9DQN_r8zQRzKMVv3IVRymhoQxZtuNCTBXLuG3VpT-aYhs_Iv-E-a7vgpPzJlamDUAqJUdF-hjwVTxu_UMlZ_z8n0dFf0Eql-LzR-t_lhN_vxsyv_-t-FR
+yFlUySD__EKUl_h7ptvA
+}
+
+AWSEntityColoring(EC2F1Instance)
+!define EC2F1Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2F1Instance, EC2F1Instance)
+!define EC2F1Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2F1Instance, EC2F1Instance)
+!define EC2F1InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2F1Instance, EC2F1Instance)
+!define EC2F1InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2F1Instance, EC2F1Instance)
+
+sprite $EC2G3Instance [64x64/16z] {
+xPS5jiCm40EpgDp_mXzibMdzoctcGN5YMmfEDyKY2g-d2U3igsEM4TyFNp_JzsW0EFkQG4R33mOU8sxkJmDyaA-D7FLJ6-la1tqIr_jopVpbLVjR-fTrFK96
+-lV4FwdJPEZaGFy1OlHd0FNy7O2hYBfo_WbusHS0khiSwZLVkTWrHltGFveVHrk7RZt8u_a5oAxVhBdF8rb5gVzT7xou902fzczSdYHoAo2hzg_W9_hh2Alz
+9n2oycKzVjbNz0jccuTdk6Tn_oCAaYtDXjRw9nQPqNVVzjQaqF_Zp__Ndh-My_yrry-b_y_nnxZUl_RvONd-klhvzVhdv-lv1G
+}
+
+AWSEntityColoring(EC2G3Instance)
+!define EC2G3Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2G3Instance, EC2G3Instance)
+!define EC2G3Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2G3Instance, EC2G3Instance)
+!define EC2G3InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2G3Instance, EC2G3Instance)
+!define EC2G3InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2G3Instance, EC2G3Instance)
+
+sprite $EC2H1Instance [64x64/16z] {
+xPU55iCm24MR17Zv_n-UKEOB6uVEzuv4RuK8C2sgndopzCI0Mn9wYV1qMNudJwm2u9O22Ale_CL1yUBy5D0NyLKbKLvcRc_v86_YF5yotr_USVt-wr-AbLgn
+slthtm1I292vGm3srt_0Osu24D_-pli57Jt14vMQuBKsuaVs4zg87TxiTtNz6ZfKVSJxwz_CNOZ31zRV-_wi_TwLP-DXF2BhNucgLeYQJTAQi_wlkl-pzzV_
+_i_up__wVmyVKvxFvW___2kTl-RpvxpM
+}
+
+AWSEntityColoring(EC2H1Instance)
+!define EC2H1Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2H1Instance, EC2H1Instance)
+!define EC2H1Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2H1Instance, EC2H1Instance)
+!define EC2H1InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2H1Instance, EC2H1Instance)
+!define EC2H1InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2H1Instance, EC2H1Instance)
+
+sprite $EC2HighMemoryInstance [64x64/16z] {
+xPS55iCm34DZYdB_4ozlBeCBOz30eJ-GYkck4hFD6ic0i2eA7U5rNh-JLxiAG5Wpa7sbJh_ueEpkV3gWB-BvgdoKpyvrpX_bNNOxJxVyVdgl_Fxv4wMcKli-
+6GZpPy3Q1NLbRhj90BXD7EKlCnxi_Mw08_zvoXVl2yfP7kJTSxnx904_zGzQPUtoh03LQke3K_yc-J4AN2rFW0h0FH_bp-s9ekEJ0l0ovUFyMvvGnIqVvB_2
+LzBVJ_cVVPk-WNS5VB3zekTjL_waAlvrglLTQgyHDmDAq_nVUlo_zVZrF_xJ3Vxzy_yU_fXkvs-zV_ZVVzry_thx_VFjkW
+}
+
+AWSEntityColoring(EC2HighMemoryInstance)
+!define EC2HighMemoryInstance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2HighMemoryInstance, EC2HighMemoryInstance)
+!define EC2HighMemoryInstance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2HighMemoryInstance, EC2HighMemoryInstance)
+!define EC2HighMemoryInstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2HighMemoryInstance, EC2HighMemoryInstance)
+!define EC2HighMemoryInstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2HighMemoryInstance, EC2HighMemoryInstance)
+
+sprite $EC2I3Instance [64x64/16z] {
+xPS5beH034H9HuhxNtWbpVfEpolSFYuVIQ7ThAZxqs4B1vf3Go-CRt-7v_JD4m3DOG3XYVtPCOVFxdS49_9B4gmVrVkiFEjNVBelKuvVzfhVdR-8PBz2vry0
+ptw5p3_D6FmU05t_zElnE-3Z_4J_wenV06latwXV34Dew_vn98_ykbZ9_BzyTOyUA7p-wIS6sAZylyQTh__V_VE-miq2W8prAqhdBsQQvOy84oB_TP__KvzV
+z_DV9jJlplyyFiTqV-h_m_t_DVd_TVh_ytHU0G
+}
+
+AWSEntityColoring(EC2I3Instance)
+!define EC2I3Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2I3Instance, EC2I3Instance)
+!define EC2I3Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2I3Instance, EC2I3Instance)
+!define EC2I3InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2I3Instance, EC2I3Instance)
+!define EC2I3InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2I3Instance, EC2I3Instance)
+
+sprite $EC2Instance [64x64/16z] {
+xPS54aCX34InP7l_2zUz_PB18Mzanz2uIOedsjGr25ZLW8ELh0-_EkRwG5S0h2e3J5V2py4oAFbw8s2WzUuAIzVpRTtpvwNhRr3yUXjpVpkp_TN-Ql_O_rFx
+rrolze_DNtFQN-slzg_TVyVE3pf_HS-lyVDpF2S
+}
+
+AWSEntityColoring(EC2Instance)
+!define EC2Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2Instance, EC2Instance)
+!define EC2Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2Instance, EC2Instance)
+!define EC2InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2Instance, EC2Instance)
+!define EC2InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2Instance, EC2Instance)
+
+sprite $EC2Instances [64x64/16z] {
+xTT54WCm34DHGsBr_XSkSwkuZFxxDwDLG1wGyYxH0LvOwWF3KW-4ipfW2LV0XMLt-FBbIK_qrdbDK-yOble0WeK9FFTTM8e_z-NRFLxSzGxFLtLRfMUy6a-F
+xhyuzOvH9lDiu1N3OZsHxZUW6Qi3AaUTUXEMVvmlNnwnpQxtZhqkzkJ-riiyxzjz-VBTMP7w_FxBiXXnlVTpVNyp
+}
+
+AWSEntityColoring(EC2Instances)
+!define EC2Instances(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2Instances, EC2Instances)
+!define EC2Instances(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2Instances, EC2Instances)
+!define EC2InstancesParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2Instances, EC2Instances)
+!define EC2InstancesParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2Instances, EC2Instances)
+
+sprite $EC2InstancewithCloudWatch [64x64/16z] {
+xPS73kiW44IzPVRb_XV-3JaMjh8nlxTHGUq1EqFTlgj2Ujjs4hHjyh0LFg_jtycdlWXesuBI5-Lvu4Nfk_FRWluYth-eLlaQtE7y8Z-aR-VjnVmz9ONryxTN
+_aKn9FyQ_mKyA01odIyWxNDj0dALJoZRRG1YBNy3lk171ohvxVm5lXqAXdGtVwXfiWKKaFVoztF10JuLrUVlSChSRVGIT_ptclZ9LVbRFc7YPnl8bX-u9joo
+eD8s2m4vyoV_x39u0i007R3Plpc_F7ilU9HKW8Q9sUKlE8zU4HaU3BAeBl-YJfvN5C2Ulw39_ymd102nJrtG-I-O8wk4jDspCK33n-mVQEzne0xPyGROn2Vu
+atV0klot0DA7x3Dop0WaoAtBVxw8jmINdhimZNox_uE3j-CWCm2pxS9Vpo_VDTQF7xrYr_Ehlpy5b0IW16pr_asUiWHiZH_xjofrTD3mZPBHWThy-mvmeC-_
+x-01rUNVAm6ypR-NAstE___xx_TuVw__7_x_lxxx_tNz__pj-WW
+}
+
+AWSEntityColoring(EC2InstancewithCloudWatch)
+!define EC2InstancewithCloudWatch(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2InstancewithCloudWatch, EC2InstancewithCloudWatch)
+!define EC2InstancewithCloudWatch(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2InstancewithCloudWatch, EC2InstancewithCloudWatch)
+!define EC2InstancewithCloudWatchParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2InstancewithCloudWatch, EC2InstancewithCloudWatch)
+!define EC2InstancewithCloudWatchParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2InstancewithCloudWatch, EC2InstancewithCloudWatch)
+
+sprite $EC2M4Instance [64x64/16z] {
+xPS5iWGX30M1I7F_2tz9rXLgNReaOxsIDuMKgo9c0_Ku1YUhqkkCh_lrFNsr03XP7Tm2tVlYEUpgVfdWZVmM-AplwQqxF-adThbVB_dzzVdo--PVQproE9Q_
+WUTH0-f2ZyEX_0sGE79Muxs7FzH_e-FvzRqlV6NEf-LtBlp6b0zuVBqlVCVqY7-eVwxGYkDA-0PLZ_JF2BRz2jP097m1AU4Fv1z-aRmKVetd58Rpztn2qZTG
+4GDfG_c7Bq19dwHtVB3_dk_hmZV_1xhRX1-4d-Xm_hu-bhKqdh-eB0-RQbqV7XW_7pt-Npf-VSV_Ua7_llc_Zp_7vVwb-uVl_klY_Ulb--VB-GK
+}
+
+AWSEntityColoring(EC2M4Instance)
+!define EC2M4Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2M4Instance, EC2M4Instance)
+!define EC2M4Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2M4Instance, EC2M4Instance)
+!define EC2M4InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2M4Instance, EC2M4Instance)
+!define EC2M4InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2M4Instance, EC2M4Instance)
+
+sprite $EC2M5Instance [64x64/16z] {
+xPS55iCm34Dhadh_2m-YCQPl31hOXL-myWB3NHLLL-Cb5Nan9aURmkTn_4u-gudanGWIrPH7DvwckZi_JD0NyTw4gJp4RIe_bPVgTjvkUNvxF__-_flPGMfI
+f_z5GfcJj6MGiiD_vOoMWQs_ZmtVLV_YIEZsuoX-35kgdwVhzetVzBgzF4cqs-CQVxf-ID87BADu0aWxzj-E_1DlP3aPqVYYv1t-Ynz2kyHxX0T8zFeFdH7Y
+junr-WzvFkpnKDvJVwZDhlc66ScXcvV46v6P_UqFoiLpoKlLwNzah5FFjEK_WF9J_UUh-_zR-wz__sytrE_l_nVmBvf_txf--A-_Rbw_thv-lbrp
+}
+
+AWSEntityColoring(EC2M5Instance)
+!define EC2M5Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2M5Instance, EC2M5Instance)
+!define EC2M5Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2M5Instance, EC2M5Instance)
+!define EC2M5InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2M5Instance, EC2M5Instance)
+!define EC2M5InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2M5Instance, EC2M5Instance)
+
+sprite $EC2M5aInstance [64x64/16z] {
+xPS5heH040LfBUv_uI_ToIJhErcNYg25l4U0MQwAHPmnFKp0qQcpoeplkzFtz3qAuEWq8QFmJJ-O9AxkBnEyaQz5plhPtaX-rc_YSbykkNvvglw-_Ol8KenP
+QSxhNm0VWMHD6ZchVndt8Hps3-Sli6Azl9QVP5__kJxGCyCVWLXafX_tIR2-R79pnw383NydFq-ofxHFPbY_uaqjGJRp2uhXAvY337_ZRMkWX_flVqceIVbc
+gWvONQcPWnxiltq5aFORgnsjZ1Kzsh__Puvl9azdagO1UZH_xoTtmtU8nUecx0o_QDy9z-1VKWZHdFKRgnMD7kv_STSHclzB_Sn9xHYP9kuR_J_w_N_f--lx
+_fSBylls_px-79VxbuuVlkElYyUlbu-VB-SN
+}
+
+AWSEntityColoring(EC2M5aInstance)
+!define EC2M5aInstance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2M5aInstance, EC2M5aInstance)
+!define EC2M5aInstance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2M5aInstance, EC2M5aInstance)
+!define EC2M5aInstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2M5aInstance, EC2M5aInstance)
+!define EC2M5aInstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2M5aInstance, EC2M5aInstance)
+
+sprite $EC2OptimizedInstance [64x64/16z] {
+xTPLWk9054RXw-VkVyCZk2GfAensztb1FvmVv9UaaNEvtkfalhXm0w1cEe0JLw1CfbAlomqaX4od1Nuu0ZMBRrs0JUCRc22xCl23htrU-qtFal_oNrxLp7Id
+roWQQD94nBdDXZwuLlE-k8pPqLkTetleauPGEMGcDncGiksTfbIMqWCVU83rkKiPUAFnPN_W8v-0BlA4ag4lg7K-za2kB2qwzWh40dUwWVIHxrxqmQdIRS-o
+z_nHGOEE7d_AMfeqEVlwtPR0wFrZmnkDRVcWiJUyqUGRNeh6Ltq0kkaD85Qu0JNOZm0WtSmygbGaAmvJQl7IVZctwMNGQ00Vxw_b_Nx6pKbxQV_L8wiotOud
+BQge2lkNVh--_9Tl_1Vy_tRmNJv1Jwkj--w-Jfj1wHwENMSxJ6Uol1sw16XUhnzsqek9biR8V2wLVwJl
+}
+
+AWSEntityColoring(EC2OptimizedInstance)
+!define EC2OptimizedInstance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2OptimizedInstance, EC2OptimizedInstance)
+!define EC2OptimizedInstance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2OptimizedInstance, EC2OptimizedInstance)
+!define EC2OptimizedInstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2OptimizedInstance, EC2OptimizedInstance)
+!define EC2OptimizedInstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2OptimizedInstance, EC2OptimizedInstance)
+
+sprite $EC2P2Instance [64x64/16z] {
+xPS5jiCm40EzgDp_mX_MPLOvC0-A4v1U3EsfMCGDh-S9uEAhOn36z-FNQVeU1O2Bhmba57vqOevukjy89kHhaQoVMcoIP_rEFExB8zSlNzdVqhyKcqiqKwf_
+HSThp4UXHFyA32N5pdiYVmL2HEki2fTMRpc_ZxRUH5Q_6-rR9L3acVEVpI_sJcf0didlkB_oKOCzf9y3W1BzQqM-aIG18_jFTxVjpJln_6_k_qWdy-_4aKxv
+ZW7vJzpd1zRSth-uR-fINtEc_u-E_u-ENyluBm_aj_G_Nl-xrj_y_c7PVpsyVtry__mulm
+}
+
+AWSEntityColoring(EC2P2Instance)
+!define EC2P2Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2P2Instance, EC2P2Instance)
+!define EC2P2Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2P2Instance, EC2P2Instance)
+!define EC2P2InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2P2Instance, EC2P2Instance)
+!define EC2P2InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2P2Instance, EC2P2Instance)
+
+sprite $EC2P3Instance [64x64/16z] {
+xPS5iWGm24CN2cJlV-4lf5zNisuPgRuAcQaiJggHkJFTfWIsfe6bANoife_9HxO0R4qBg6p5oiIQykJyGj03yTugbIzoFv4NUIgFv-sOzTjD-lVotrepFoNu
+xw22UKhmtu4bnoVV9I7-3gJP9-bSVm8XyZnjIGsMLNwGPxg1tnI_vA2ZIvrkYD-gVoJwi8Tzdyr3yDzd-E6z_3cKv7z5nC-K7Kh1V-v_fKQ8_sfx7COFPCJA
+_XMUSi5_Y_1VRwgg2XFyl-3vV-pvzJh_Zxa_N_xVBtzRxs_z__3wVntzVpt-_toytW4
+}
+
+AWSEntityColoring(EC2P3Instance)
+!define EC2P3Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2P3Instance, EC2P3Instance)
+!define EC2P3Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2P3Instance, EC2P3Instance)
+!define EC2P3InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2P3Instance, EC2P3Instance)
+!define EC2P3InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2P3Instance, EC2P3Instance)
+
+sprite $EC2R4Instance [64x64/16z] {
+xPU5iSHG3CIUKUc_uG-UO_OnQI2em6vmN1MBE3eyHC31eJD9n_VjuNlw7WLmS9YGKVZMZdl4rVtHu8ryBRBhfnRBv7l-ZBZSbqkENvwols__KgpFQFHl5EdB
+6MIZVrjkln0W6_aRk8Z2x6cPVTzgPWs6Svxlr430Ou-_Dpyhhuu_oH5xyjlTdp6H2VZidR7bpuZzFb17hpKelzE_womzmCmIJ3hzMvaoPAAOm9lvEyIGB82q
+RdzP-HVHwdzMlB6mUlshkzHs_eU5kJNwlz_p_zBdr_VvBnVaz-t_VVmUb_kN_Zzy_xyk_d-z_F_vSdu1
+}
+
+AWSEntityColoring(EC2R4Instance)
+!define EC2R4Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2R4Instance, EC2R4Instance)
+!define EC2R4Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2R4Instance, EC2R4Instance)
+!define EC2R4InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2R4Instance, EC2R4Instance)
+!define EC2R4InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2R4Instance, EC2R4Instance)
+
+sprite $EC2R5Instance [64x64/16z] {
+xPS5bW9H30I9TNF_4-zBiYv_oSDX2XcjiK9t9yKY_Xsk278vTEvbullFuMFw7WN9vH0ael0VEvuH9_Tt0nx8rm9J7-szN_cftyJnlXnp_7AJ_RR-KdoPa45_
+Om7lpwn63-zlV2L-zTVNltqNKP9IYxIFV-9RpxHyHiyT-ru3hFpVhr_xqiSF4e3_sbz-xsVS4o2P5bXWq3_zn6h2L3E8Z_gxHlkDaXZqBxLFln6Iq-llP7oQ
+Wt4_v04OuHuaxN2_m_TEZOqF-gkxvD1pg9xvTT3_Wf__ntv-RP__SiJrs_e_ZZ_ZUF_O_m_R_w-Z_xyU___vU5u
+}
+
+AWSEntityColoring(EC2R5Instance)
+!define EC2R5Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2R5Instance, EC2R5Instance)
+!define EC2R5Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2R5Instance, EC2R5Instance)
+!define EC2R5InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2R5Instance, EC2R5Instance)
+!define EC2R5InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2R5Instance, EC2R5Instance)
+
+sprite $EC2R5aInstance [64x64/16z] {
+xPS5jWCn54Bp36R_6_x2r2tDgGkLYTq8LDjL5LNTwoaLUVAQd6o4p_thU_9P4icJLv0eAVSM7bDTdMy3UYFU9OpoS6dj_20_goxdxPBzsvFbzytVPcrLR21_
+K89lLWRo1oTAlh7CWFyWtIn9pCFiNsFyue3MZCosa6K15GDy--TZnx7Su_VzizQ2X7W0vLeWmuFaZdzx-K7C9FziUr6DjKx-2__nFyuYt5DPp1NntVpTvTvI
+IQQU9UlcJnr_xM_yyqwMLh6U_ng2-VpBhbYSlCxbNVu3bGcIyo4iU1w_NbJQZ8BMoJyorPePpQA0IY5UgB3ClVmV-_b_wUVNz_FVBl3lc__hyi_r-tly_yFt
+_zV5_ryl__zykNu1
+}
+
+AWSEntityColoring(EC2R5aInstance)
+!define EC2R5aInstance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2R5aInstance, EC2R5aInstance)
+!define EC2R5aInstance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2R5aInstance, EC2R5aInstance)
+!define EC2R5aInstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2R5aInstance, EC2R5aInstance)
+!define EC2R5aInstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2R5aInstance, EC2R5aInstance)
+
+sprite $EC2Rescue [64x64/16z] {
+h987ieCm30KZIthh-r_u5uen7MQowU6jok3Fjx1NREIIl2HBfoUy9vikG17-c8X1MRghV5vID4zGMgLt2ChKljpSaUC9fW7Esel6QU2_2yHXTpeE9mYm8USd
+Vlf0dlX-vtlBlVRDLHU_oksDRm7qFX3ss7T6_EZdlP-0VBs_2yWdlcbgrVlZEx9RtpJ5rltRbJjVa6VtBq4tVWxwYT-kdleEkZe_0h_mZHOjwdsLBd3kH-zK
+b0EYzl_7gMzjUcU7jmtipFVvQm4yr0W7IiiS-cOci04jeIKh6nY_x7m1jJ9HYRKVj6j3IXlVsA2rBpROpazVqDwNB-IHts-SUpzt9_Ut_Jeb00200H3OlpKX
+pZ8_inSW_tpkdyuFpY_k3-sltW-yNte_yNxZ_y3_nV_J_xVpW_EByvFpc_EZywloC_Ax-eFw2_eJ-Xlw8_kh-xD7
+}
+
+AWSEntityColoring(EC2Rescue)
+!define EC2Rescue(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2Rescue, EC2Rescue)
+!define EC2Rescue(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2Rescue, EC2Rescue)
+!define EC2RescueParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2Rescue, EC2Rescue)
+!define EC2RescueParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2Rescue, EC2Rescue)
+
+sprite $EC2SpotInstance [64x64/16z] {
+tPU7aYGn24DFO93__uSlKBLKgsZNJRYuscnuQeTP1d_vr48ctk6Dj5TPcAyWOxdXQTXMyeVshX-vx6SBzSiV1L_vihZCmXFA9za6gy0CDpZfC8yiczKucSex
+FmoSbGhTFvGfNPEdGVsyh0MupBbJ55U3x6aEBUR0Xm5iH5g6CpuZZoPfx27yPGC_9zYj0KJVCxnIfvo9QH0KhR9C-kH9Oip0gAeKa1puAdCrA3vMAqbqhWfa
+oYOsR_8Cr2zb95hDYC61zp41MP8tXGWeB-ajKqEtSN3ABvbNHsH4j3GBr0KaKt5ivJU4Lq3j-k2y5QGfhnCsUT7D4HU-HpJ-EAzn2Jp6wufXGPer-bsOFCoY
+UJCo35sxz-vGa6JQLdvRaln80el86nxxp3UXl5cIRXqACvlpB_KQdSp-ysPZ1j-vaYRnXtc9oryFy3AYaFBpzNl-Xqkcyg2eimLGEvrAwFj_pEqRzKCZi8lm
+FSNrUReWCfMN-ZKsDCbPFuLlohIeQltK-dtcrK3hjqu0Sd2zJZ6OZo-Ec0Utcs-3JbKvimQ3-oBcJOUIz_tBiV2F6GYkSNkt_VYjxSy3xHTmXe5XC8nJeYAN
+_l7z_lNSFwUF_ZbF_RFsxzrgvtB0I0EyO791-_Vp_O6bJUvTFuIUzuSf2xs_XBrqVyfQX-4Ftz_q_lYfzGq
+}
+
+AWSEntityColoring(EC2SpotInstance)
+!define EC2SpotInstance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2SpotInstance, EC2SpotInstance)
+!define EC2SpotInstance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2SpotInstance, EC2SpotInstance)
+!define EC2SpotInstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2SpotInstance, EC2SpotInstance)
+!define EC2SpotInstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2SpotInstance, EC2SpotInstance)
+
+sprite $EC2T2Instance [64x64/16z] {
+xPTbmeGm34IRHeRxN_YJXlL5WjlxWpwaKqsJmgezjiqeqBeLL1JnvNDxJ5-q0A1rQu1fGJvU74CdzrE00_cvO57Vt7kKVD1tTBnFOxwVjfZVbJyz-3_Ap3cI
+F-EEfII-G_tpTx_oh-9wN_kMlt-IrAz8Oapb8HJABmDMTbmpLCDyXm0qVF-Z_5fy0QIX_1HEcyy00lc_-BwF7CZ_pIS076t_xd_gyVpieOTzJnxsZmppSSD2
+-PC8UtPImu7y5-l_n_PVL_y_PloyyZ-E7sEyFtRzSAs_HgzVnw-Vn_CB
+}
+
+AWSEntityColoring(EC2T2Instance)
+!define EC2T2Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2T2Instance, EC2T2Instance)
+!define EC2T2Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2T2Instance, EC2T2Instance)
+!define EC2T2InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2T2Instance, EC2T2Instance)
+!define EC2T2InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2T2Instance, EC2T2Instance)
+
+sprite $EC2T3Instance [64x64/16z] {
+xPS53iCm34K3Xjx_meEucaUkR9NX2OOlz1jAar8H7Qyso3pu2jpbY0-_hyVq0HlCFFXAp8GD-Aau1axkfm07yak3eZw9foCVz0KSx-SnxSzRpE_AFolwmPz_
+vHUKW0NovQz-9ws2_Zrvnr-Q17qLhVc5c6iil_9U8wWUyKrTVHq_sszTCUQFvcVxCln6VWuVshx1xlpLLuYvkFDNtqWWClxvf_wOZuG0fAq9-wpZ7yW_0rHv
+Kv48gv7_skl_sFNhMl_7x9zN_iVnOuptnzuVhllNwFlh-FlpUEu
+}
+
+AWSEntityColoring(EC2T3Instance)
+!define EC2T3Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2T3Instance, EC2T3Instance)
+!define EC2T3Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2T3Instance, EC2T3Instance)
+!define EC2T3InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2T3Instance, EC2T3Instance)
+!define EC2T3InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2T3Instance, EC2T3Instance)
+
+sprite $EC2T3aInstance [64x64/16z] {
+xPT7siCm24I3O1ZV_y9_GKvOA2vywULjN9yAutguAWfiBjS0kReqJbBnRLo-fsy8IAukdNG4DdHS0rVt3mNUo6-1LttlNbQ-w7TmkI-NZ5-UAxzl_fBaHY5_
+vmaxRUYk_DEVfkuVrtL__QMFnQ9j-KD9IYq_C7iKdtM5kwEL_D0zzCQE37xMxuplf7KVfWsa3VK3Wy7FNZ5CE_DRzmK0vqwRgex-slXp3BsEv4Iivvz-4dva
+6lqNwd-il4U7eLLyePlDyoVP15K_NtMMwvlvDpEPL_AQKtU8cexvF_JvV-dpw_lyl-Jz-St_VVmQb_kN_Zzy_xyk_d-z_F_vSdu1
+}
+
+AWSEntityColoring(EC2T3aInstance)
+!define EC2T3aInstance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2T3aInstance, EC2T3aInstance)
+!define EC2T3aInstance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2T3aInstance, EC2T3aInstance)
+!define EC2T3aInstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2T3aInstance, EC2T3aInstance)
+!define EC2T3aInstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2T3aInstance, EC2T3aInstance)
+
+sprite $EC2X1Instance [64x64/16z] {
+xPS5jiKW34GRI7Ax_mr_8T-5T-QvT8vKu28PT3cgUiJEvqm1qwUpciBxx-TzyXv3mFIPa37alohM54Vd5q5tnBUXLFaixZFo8b-AmtaxfFrsZVvj_flPvxDU
+5FyRjKm5rSsU48h_NYLNCHrO2Id-G5iI-ijxiifyW-oGep5k3OMlxvNFjTec_E_u5G7uHtCcyVl7_m3i5p_rVrw_DlyJWFR9A_uFpwD1Vl9I_6la1FXUV95L
+oZvyexuSyeCN_E_k5Jbt7mqmzoxuVyRr_z3rQrl_xO3uRVxV0NyLvs_z_h3Tlmw-lnv-VpvSpm
+}
+
+AWSEntityColoring(EC2X1Instance)
+!define EC2X1Instance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2X1Instance, EC2X1Instance)
+!define EC2X1Instance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2X1Instance, EC2X1Instance)
+!define EC2X1InstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2X1Instance, EC2X1Instance)
+!define EC2X1InstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2X1Instance, EC2X1Instance)
+
+sprite $EC2X1eInstance [64x64/16z] {
+xPS5ZWGX44KfVNt_2w-GMgCJPicu_4WBFAG-saugYpZud2bW-dGsMU5z_tnCtgCBc3uJChfyh7XHSNA-BUY1UEtALJwrwoVoQtmfZkVbcFRBRVdtybz4slYo
+uhz3VZuJx1DsG1VyBz0XQbNPi9NuAz24lauAYtozkLVhmyGfNZmpx30llSvifIzUwOgHtyyVOmCP-GJJ01dZj_SVo3RmscqGiAd_HO0ElB65Uu3F_Q-Wx_hl
+R7JPpFzwKmSVwySAcCVV8Cl_eV_-B_y1hLB6-8UPXypvg9Iawek__gDp_zszrw3ktkf5liTVXWtpvzhh_x7hrslzboFYz_B_VldREd-ltnzUzw-Zxw_7tv-F
+rpi
+}
+
+AWSEntityColoring(EC2X1eInstance)
+!define EC2X1eInstance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2X1eInstance, EC2X1eInstance)
+!define EC2X1eInstance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2X1eInstance, EC2X1eInstance)
+!define EC2X1eInstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2X1eInstance, EC2X1eInstance)
+!define EC2X1eInstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2X1eInstance, EC2X1eInstance)
+
+sprite $EC2z1dInstance [64x64/16z] {
+xPS5aWCn30HNEFl_3nzO3kf0gZ1qGR1DiwRbh8XPuVLt3FZpLR5InzVy-fo-sW30dwyEk0qqLTp3pkul3Px8vu5tVGzlD_9DFx3JVJgb_VJE_vhv4tNp9phi
+97Vo9qKOoI_a7orR8SalZZzX-DppHGDQo8Is1fkxUi5t179G8sEm9Z-DdyxbcWzy02QAF7uvlx1qr-EetdxBB_iwMxSp591o_X9wyelvC-3B_tuU_wGVzD-B
+FkOEcSTV3IK_qCtNifS_2lbFUFCqKdHBpPXKAUT_q_N_rFNhlVwVid--yty2_oxEt_txm_l-TVBzzVJxy-by0W
+}
+
+AWSEntityColoring(EC2z1dInstance)
+!define EC2z1dInstance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, EC2z1dInstance, EC2z1dInstance)
+!define EC2z1dInstance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, EC2z1dInstance, EC2z1dInstance)
+!define EC2z1dInstanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, EC2z1dInstance, EC2z1dInstance)
+!define EC2z1dInstanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, EC2z1dInstance, EC2z1dInstance)
+
+sprite $ECSContainer1 [64x64/16z] {
+xPLL0eKm30GRs-N-5qRot5t9_60xrDisQueYS3SnwjBnRZePVH9n5o0NlhMxiA_o0pvT797VWEaYW4nNO2zpw8EH4J8Z-QqfgIqpANALmHb_zMtRNsM-r2-_
+_FBBB__-_Tzy-wAUWhXB_ivrD_DLvwVVv_lA9-w2wJS-G3OZxiRQ0nH5CG
+}
+
+AWSEntityColoring(ECSContainer1)
+!define ECSContainer1(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ECSContainer1, ECSContainer1)
+!define ECSContainer1(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ECSContainer1, ECSContainer1)
+!define ECSContainer1Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ECSContainer1, ECSContainer1)
+!define ECSContainer1Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ECSContainer1, ECSContainer1)
+
+sprite $ECSContainer2 [64x64/16z] {
+xPK5OiKW44HPc-7-9ovTKk4hK9SN3pnSof_cdty2sqJJfNARAiqd4Lk0xBwLBUmx-K2c4l1RYYFI10O_xoc2aH7LswU5DoMitLppTn2PJ3FFV7ljPumWya-c
+_jgt6TyKf2e9jJLVn5WhoShZrhvCPDP_T2e7yiUytz01alE-6OWo0C9illtYt8_vzbEzbB_gGltF_SP2-v_vA-qlbyildzL-vfVoT_kiziDb7s-j_sVv4Jpt
+6R4q_tnWQVu5U3x_YPYllu3Z-aF8Illri6YMWD53L_przRVs63nyCIr5zVbcSlZigTVHVzuXpAtSu0XMz--qV_gUxqy-iGNJBtm3MOtOnieR-EUVVnu
+}
+
+AWSEntityColoring(ECSContainer2)
+!define ECSContainer2(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ECSContainer2, ECSContainer2)
+!define ECSContainer2(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ECSContainer2, ECSContainer2)
+!define ECSContainer2Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ECSContainer2, ECSContainer2)
+!define ECSContainer2Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ECSContainer2, ECSContainer2)
+
+sprite $ECSContainer3 [64x64/16z] {
+xTR5WSKm54DHwHcK_XiU3gDXFlgiSyC6lBMceMKZ0AW00Ae0V_fWMKBVEsHnDNiItqW2t7tRP7_Oek_l8Ye0sW44HVJbRa_juEK-s4f8wHrMtDM-zQttNF49
+_OvBVVduWxbUa8BhsTL-H8aONUxjZvUy_KdeetfTfrvCxtlfVRI5cDO7ZEWz44hxszx_MlL-V_q2R0EmltwbgzQNxnyA480A5E_VtbhJV08
+}
+
+AWSEntityColoring(ECSContainer3)
+!define ECSContainer3(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ECSContainer3, ECSContainer3)
+!define ECSContainer3(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ECSContainer3, ECSContainer3)
+!define ECSContainer3Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ECSContainer3, ECSContainer3)
+!define ECSContainer3Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ECSContainer3, ECSContainer3)
+
+sprite $ECSService [64x64/16z] {
+xTS5TiCm381X2opf_YVU70q3aklGeFzupVV0-5gE2j8YZTeHRNlkyJNqJ66S-PAKUJZ08ssdAjGAF6gGMJ2AxabDaqmbyaeO9uc74fTvtE-1wtQgsdvmu5ax
+ucrVEsOXzEaeWYQ-tEv9F1ZqeXwFUn7Pu-NjET5Pz9ZNdNw-cXdxny-KTuu_3NfWR-_w-wyUQ0f7VTqvVwAsS_q80BRdY6TXz_elE_TFsRD_bRbEpy6iIyul
+TYvuo_fxUX9jNNT_cRvcNtsjye2Vij7xosyP6Tn_Nk_-XyZ3XxVMwdE1DqQK-FwAlQkFyzTvhqVN_Ujl7hPas7lrT5yopnJ6YKyBFVLutFbU-gXU
+}
+
+AWSEntityColoring(ECSService)
+!define ECSService(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ECSService, ECSService)
+!define ECSService(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ECSService, ECSService)
+!define ECSServiceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ECSService, ECSService)
+!define ECSServiceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ECSService, ECSService)
+
+sprite $ECSforKubernetes [64x64/16z] {
+xPNhhiCm28DDGg3l_yJdHAuKCOcDiRzbjxRXox1pkx9uuWdt_qyVjm5t6TQZVG8m0p2zGIiWidaHY7wBBm7qcfkVkn2nxuIpQFAy7rONpkp3t_LuMVZYDVdm
+-5EOiFJ8nxBoi9X3_iMMGka9_y46UsrSs7peqJKVIsLniTgecZPenjlh84P76LRWenDB8EeLFh69CxZCpxjWTz9-cr7a7RmmAb0Ppi7mAYzK0IN7nzBXYRVv
+ZQ-hpnlnBZ-8jtdmgiqFuQ3_ed_-mby6w2yyExZvrU1F1rpGrVb_4er_xFUghAy_zosOlpv5TmPaTTQ_0XlbHj3PVw16_JRmvVx7VVHShB6Q-oyBUNTqdPgP
+JjdHY54uU4zwy35JdvzmPdd_9medNFa4PrgXuueDvQCxoIuApwhD5HLjo8JNRKY4bssWy6uieOPs-BlIdtZY3m
+}
+
+AWSEntityColoring(ECSforKubernetes)
+!define ECSforKubernetes(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ECSforKubernetes, ECSforKubernetes)
+!define ECSforKubernetes(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ECSforKubernetes, ECSforKubernetes)
+!define ECSforKubernetesParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ECSforKubernetes, ECSforKubernetes)
+!define ECSforKubernetesParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ECSforKubernetes, ECSforKubernetes)
+
+sprite $ElasticBeanstalk [64x64/16z] {
+xPM74gDQ34FbAlx_YzzSF1aklKrvkulI4v_W9XXM-lJf4vcPV4gd2Ph4-O2c0L0p4m3EsxX0eYWweBoDsuHG8Rp5AspePT0xUAp25Jum8gzclmnCm010ylRX
+qprR1O2v0ddE6wBl7G0bQmP-fPCAThYu2tH8rc-8Krx0HIaJ5R0Jce69jwetOLqZyx1vqg-R_dYTxNNku_F_T_ZqKc8SJ261M7ucOm4umBtM-oeV4IoRxZjT
+P3TUkghbaBfHBsKpWNuwAG360ujihLXkyzuvEAjm4RPipA8l88xvWFuIQdn8hV49dx0-e1eYKbiJ2kqiSjo_YM_r6tpQfgQT_bLWjt5U-GlObLVLROhuXIWq
+qW1ky2dRwVV-eABEDnppZyc6T1oOC0KGDJOdrOc_-XTCWmof0i0F_Qke_LQmQPmVKDdabGiICuiljPca0OtZZGkYowYQAQ738r7UyDM_TyU7DhtWI_Qu_kIe
+n_mpSEBv9_D3vh2dJvy-_GS
+}
+
+AWSEntityColoring(ElasticBeanstalk)
+!define ElasticBeanstalk(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ElasticBeanstalk, ElasticBeanstalk)
+!define ElasticBeanstalk(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ElasticBeanstalk, ElasticBeanstalk)
+!define ElasticBeanstalkParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ElasticBeanstalk, ElasticBeanstalk)
+!define ElasticBeanstalkParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ElasticBeanstalk, ElasticBeanstalk)
+
+sprite $ElasticBeanstalkApplication [64x64/16z] {
+xTDNbjim341HeZxkVyDfCxOAb0CwlGY_zXKgnoy9KJFt27VJLwb5iWzx0QldVBWv9yn9B6lBDqY6cOg8ECLtEaosNbZs-aN7SLe9a4l9lsWPXt28NF8EfDPl
+fYpv0Bmi4j01iPIzdac2ZHLlbpo-I05lk5voXnnBFi4lQvAtZrjRVNwz9eFc0G5IH_z8wo1TUYzyQocXxLuAtvRMdQzIzxlZseq_wdnYbzExyG7NVArzXQXS
+Tdk8xlBrp97wSp_zchrsLmEoP2-tKQFqLxANqonHrvidxatwu-kGCzUjkNxybGkWZG-GPpAYlg7UFnkfF1gzdQTpIgP0ZbKVW9tcGen5BtcQbB6LqtlbC7Zn
+15B7eZ-KAXOSahT-llrRHCqZUTCorlsS9Bi86-kH729TI-hEHsH6X5kXIpx7wt7xsz_-zhSNbV6NnKS
+}
+
+AWSEntityColoring(ElasticBeanstalkApplication)
+!define ElasticBeanstalkApplication(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ElasticBeanstalkApplication, ElasticBeanstalkApplication)
+!define ElasticBeanstalkApplication(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ElasticBeanstalkApplication, ElasticBeanstalkApplication)
+!define ElasticBeanstalkApplicationParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ElasticBeanstalkApplication, ElasticBeanstalkApplication)
+!define ElasticBeanstalkApplicationParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ElasticBeanstalkApplication, ElasticBeanstalkApplication)
+
+sprite $ElasticBeanstalkDeployment [64x64/16z] {
+xPO7ReL034HnVTp_n1627SLAxtLI_-9dZxU9xHrbaLMLOOz7cNiSSX_ZsJkNEXuiq83KcnHhwFhZTs2VBFiEUbW0wNOKyGA8MJaMt5qPXzXXTTeJi0BoTcyd
+M-6ceSE0gNgV_qQvsidPM_de1bXyGYiIrtE_tPlDVe06M__RmdSbk99Q0oLQ3HDnOGKkV5U2X3YIoyYSZzhov0rAvjdbmA1FdwFuYhJ59_ZgEA0IM4LiAsgR
+qjmKNAsiUVBjz1KhBBSjxk06n2OGLR3hm_Ah9rCDUVxj0z923qG1TrJGA_RauzcyDeiAlvGFRHQ_mEVw5-uw03QY1g-DCUG8rxeLsEHLYxYBnyW-mWQln1FF
+kzc1oIjwsZVXCtjgUF0D_Z1kq88W1gyZDl0na68qguDFdJl521zDpzlAp7G1-WEuUfu9MduikOFFU5Dv1LptgqSsoFpq9vMw7pMbyNJWympD3Cr-sJXc85tH
+tCqdUqFcxZfTAQztSP_Sb4xdN8bXvndyGLapfz9avpby87oix3Fv16hIKBOzZyzXrQBrQl4iVjThX7bK8_gv_BxJrTqibHf_PdrffrFmS_bkwExvHlPydb7m
+h_3__3__p__pyKRU8cpx0Re1
+}
+
+AWSEntityColoring(ElasticBeanstalkDeployment)
+!define ElasticBeanstalkDeployment(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ElasticBeanstalkDeployment, ElasticBeanstalkDeployment)
+!define ElasticBeanstalkDeployment(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ElasticBeanstalkDeployment, ElasticBeanstalkDeployment)
+!define ElasticBeanstalkDeploymentParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ElasticBeanstalkDeployment, ElasticBeanstalkDeployment)
+!define ElasticBeanstalkDeploymentParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ElasticBeanstalkDeployment, ElasticBeanstalkDeployment)
+
+sprite $ElasticContainerService [64x64/16z] {
+xPRRhWCX24KtAkpp_rzyedCXaTemqrVflSvoM2IYVylOiOFz-Jgi22d5tj6i0Cm0LBwW6o3IUG6aFSLLWChQ-Vu1iMVYGDS-UF-T5nVjtqx-pASn9tvUUlDU
+3qsaBbvlvrqg9nvvB-eIzXmZ7zrYs3oeqddHkROBYOPYaqib2yBVRSLRl56qjWG_Aj4OofBYuorPNIB1trTFnKZo13IEAi0iBv-6vIT-yvlNjxolYYHlwpqb
+j_ugmrQgPoFGRxolrZQj_vxz-2AP_gNY4cm3LXdP5wJxNxdxd-YOPw1QTCKNdbzTmWhSXTMpYc68_H-Ocgz04nklctid_9h0Qe-aJTDLPWuUYw7C8OBjB4DC
+JVJ1-IFy5oVDbq4bIkNBO47yYGHh5CzBi0NnHnAkyIBOHEpN0_mwTkpu1m
+}
+
+AWSEntityColoring(ElasticContainerService)
+!define ElasticContainerService(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ElasticContainerService, ElasticContainerService)
+!define ElasticContainerService(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ElasticContainerService, ElasticContainerService)
+!define ElasticContainerServiceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ElasticContainerService, ElasticContainerService)
+!define ElasticContainerServiceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ElasticContainerService, ElasticContainerService)
+
+sprite $Fargate [64x64/16z] {
+xPQ7Qkqm40Ld-_x_5p-i22nUZ2CxX7g7UiiSbTt5xh_ZmuVCNzaA-ZeX54H0uuLSCSogaHBrqFR3plCKulNGjkNSQOyI5BJ-YxJvtGR5zzNIW6rVZFK0NtVu
+n5-kODvbj3xmpnAKCoiXp_pP0lCWJ_r9W4_hbTyYtK_yobpz4gdLpwoV6i_kVBjjGmSqxlnGmA_jKh3gll5l6zcGxBxt3rAmwrkltl6xBYkHPwgGt_qyKusy
+Mxy3B6kjVwL1zDtwxKWkXH3po1J933TPhZs5wmeOM2uJkw9HqpQmlYO4nBFcbjrqOCjN0XBNzhciMcHLBrHbc2uRkOiG1Y8w4PdVdF8TbU6cmeAeUMJrDjLT
+LJce6cBjow7dEPV9pFsdXx1EQXgm-oGqaEmKreP6imFO2510J3dz4a1DTlqmG7tn9KQUxVdLZdSTVfhNrnGfsR7h1t7ugG2MXs_Khk_ZZmwWuGAGXr-supk8
+CllFCfK35NJa_4pQb-epH20K7hn2bAjNvpY8H2dLQVhq9IX64RJF9_TBNzxv2HPeAE_ySc6WqU-eKB3iNv3LVyQ73_y
+}
+
+AWSEntityColoring(Fargate)
+!define Fargate(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, Fargate, Fargate)
+!define Fargate(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, Fargate, Fargate)
+!define FargateParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, Fargate, Fargate)
+!define FargateParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, Fargate, Fargate)
+
+sprite $Lambda [64x64/16z] {
+xPQ7QWGn44CrFV__m-bcPHy63-b5ARTDw1qZXhtxLlhNloecjVsAIT7t-vNkaBw_fhDuap-XVVzycc_o1xJlPmcoxNyBW2BhMQDF1D3fZzO0W7Nyhl8e1U82
+g8R_Tl3U0hXjNW7LzmS3UDVDWtyxW7K1t1S0QG4aa6y1KC2cvcKB8262cWPldJrY28TDpKj89xuA1D1SP0P_jHRQ0CFK1k3uKLe626WZVdmQlBL92Tcw01pF
+0ArDkdOc8Gs0qLawD4HZamPiEIG0Xnt6yzTL1X0HZOETGOVKF0S0-C7Eed5pywegu2VnkHuEvTRFcHpAntl_cYaBre6VSkYGkBP-pgIX4y21dp8DiPdBtf-0
+NwzjjGucNcKxluFaQo_vti6BQwrmoxtle7_zwm4
+}
+
+AWSEntityColoring(Lambda)
+!define Lambda(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, Lambda, Lambda)
+!define Lambda(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, Lambda, Lambda)
+!define LambdaParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, Lambda, Lambda)
+!define LambdaParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, Lambda, Lambda)
+
+sprite $LambdaLambdaFunction [64x64/16z] {
+jPU7ZiGm24GNOaZ-_uUtU6szmvghretA5XY64Yluzg-m9_x8F2BpxCYCutTHlELr5bpP_AVi8w-fsvwOULnv_8mzv8p_R2JqVGJlMirLJJqdB0gjiqqRxMtz
+WXvFUzZdTkiEdrfVkVipIdv43UUl6apJXydFWX0YzWazXaJ6X73clpLkp1ITV4N3GfKGdGv_8X5RVDV1vKtn3pMnv4_QQf9_Urfahxm6dB_Xay31Btoo-iH7
+Mnmlp0Hm1L6YbeduClc6QwrWwH6c2Hk_HG945JEo5mWQIxE8AfuHaDycuENRYcyIG3LBU35v5uSMcgdqpMWHfQm5sCZJHNUSoUiE-GWV-eIaJA1g17Mifkjq
+6YzE4SGyGvJMWzFu5ASetlmJFlAPvvh08OgKxUzr6mamJ3M0oiUtjypbAVgSZ-kWYeTOy8MyIi0Ll_QFMNsVG4oTKFA3AayHy-CngF9yItsA8FByeaeVcJmM
+db_EJvMd47sCEJyCe8eWN4vHFb7QJnre5Fdo47SuvJDP9TzMUul8Q_pmOUSRyaGY0JnyLSKrX3oJXqzGVBKyau9FL-lx2o5g8YtulB_g-zEqF7d13-HvVyTy
+ynxj6WJixMtfAVB-Bll32QOyTk3i3tL_oK_NjcAodexQYGpS5c0PlgkTc09YVzFxeuRU7_N-Ag7tLxq_2uZzUMD_jxtxm_xzPV_-j7z_sxy_xjzVz-_F-tW
+}
+
+AWSEntityColoring(LambdaLambdaFunction)
+!define LambdaLambdaFunction(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, LambdaLambdaFunction, LambdaLambdaFunction)
+!define LambdaLambdaFunction(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, LambdaLambdaFunction, LambdaLambdaFunction)
+!define LambdaLambdaFunctionParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, LambdaLambdaFunction, LambdaLambdaFunction)
+!define LambdaLambdaFunctionParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, LambdaLambdaFunction, LambdaLambdaFunction)
+
+sprite $Lightsail [64x64/16z] {
+xLO74iCW39DjRF7_3tU0kvV9xLxKcGGDDlq_iMF73iO9t4WE4mo8RT1m0Q1sWW8GN_HMG3rT6GP8h9W3-b2U1jGZjFl28PwIhUv-DYTJ335rYWaY2RHnQO3m
+TlytqYSKTkOf59QvX9NqcjsFSmSGGabZApJ1A3p0DkKi9QTMnJunokfPxXRWHnE-50de395NzZi-7o_zBZX5-8kl3sdIK17vos_a73NalA12-50h-p84GaIf
+8c4YpKKi04sx1h_zLlbUu9Vpn-rtG_i9EDGLtDX_lHkp_zR7JuFHe17G-lZD7aVCEH7YALwRFzJKizwWGuy0V_6pC4DXqTVdRpOPNQ3UNzQF-lf5uSlwvRs0
+N34P_MdzB2_0zdxzjfKDGEDXL1lAxXaMzhX_ULy1syF-YSQ-2BeA9jIvzVZW7i7-bzYnOySH
+}
+
+AWSEntityColoring(Lightsail)
+!define Lightsail(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, Lightsail, Lightsail)
+!define Lightsail(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, Lightsail, Lightsail)
+!define LightsailParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, Lightsail, Lightsail)
+!define LightsailParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, Lightsail, Lightsail)
+
+sprite $Outposts [64x64/16z] {
+xPO7RWCn30INHKlz_yMHQSCWZ7PKUg9nByFgSlDlSZZ4C5LrRkeKtB7OqGUW8u8kqEZh1CPCGc5zNrDFGk2c7htqMbkv8Pq0VajV2XWqMAjyrcgOGQ8p_FGh
+BhneX-A-Cuu2BwSt21zXAdOr_MFK3d5xue9njNb_bC6Nfnkx-qQVqASVRWkdntL_2lpf8p6muHCmaba_auYil_VJeSLdovynRB7ya8twape_eyUUNzZBhtB3
+9Rx7dv5irr_uL_xnZ-_mA7ZN9rvW_n1A192y0iRiebXO1bf4stTThBJKXSNyOnmERm
+}
+
+AWSEntityColoring(Outposts)
+!define Outposts(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, Outposts, Outposts)
+!define Outposts(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, Outposts, Outposts)
+!define OutpostsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, Outposts, Outposts)
+!define OutpostsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, Outposts, Outposts)
+
+sprite $ServerlessApplicationRepository [64x64/16z] {
+xPHNOkGm34F1pljVU3VXDCOnFUKdJM-g2o0Hb9pVYyLYiGWJPbQBrzI2CwGlE1X0OXu21iZoIHJGEFsn4C2U7jqlHbQ7Jnb4oQ_wCdWc0u5cqzSFXpABFpOy
+nKQVX1FoK7ZQ_tkSAX0FetPfXE5D_yQR9gI4yKWGX6XwQkrhSvk9hW-BT71US73a8KP0RFDi_m7s70a6s6hWoitPGdlghdJK1GRx9JUEStxacncE1dekpq32
+uCgFn3ydP5DqVcrXVUdkdTuIwJYujL0cVLbFkxu09BqEwWH72dK06_GNf1_0az4PzH8NCkECGQgqkA6mm_gthfjB5SqUkuq9GArTQKjyVd1rRBlpzM01xSv0
+rJ_Uv3aRaFg6UCClQ7Lln1dtOCyZN8LdH3s_1ul5Ol4V
+}
+
+AWSEntityColoring(ServerlessApplicationRepository)
+!define ServerlessApplicationRepository(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ServerlessApplicationRepository, ServerlessApplicationRepository)
+!define ServerlessApplicationRepository(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ServerlessApplicationRepository, ServerlessApplicationRepository)
+!define ServerlessApplicationRepositoryParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ServerlessApplicationRepository, ServerlessApplicationRepository)
+!define ServerlessApplicationRepositoryParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ServerlessApplicationRepository, ServerlessApplicationRepository)
+
+sprite $VMwareCloudOnAWS [64x64/16z] {
+xTG5ZkH058DX-v5z_nDlDftIK6f8FEfFqFY72lm7FJqzIUjDPSuFsyaW6JNsuB_o3pHn80unZfm6nj-b0A9rcE9rvaBz8ETuQI1j2-5l2eGqYuSeMwJyBOsG
+0qjxYB69x_Mw_fsdGDaDoeGaVwsGjacV6cKxK2PSbByKcBEVEEIZ7vH05y9V4QYpRnpuw5qp23lGN_VXizVfwgyR6OI_C5Xz7sRrJlHwjjvJ4U6Frx-6Bm2s
+juP0pgEVElIZbmJwC1L0Q9S3APz8lTos-78TdW3bMu6oRte7Y9bL9MBxwExx1a2KBvkdcEXDBmA8yQMHlX7GfdSpnrOnj5_BtFUMhS2Xpvu_EVz5883Szudn
+I--N_g862MsdSIDVUlJyLtZf7PZ2RFT24VtIB-Mb49Pi4VAT1dgzpKM-21WV54ZVAo17lg5hTcgA27cZ2V3EE15k4a39M-eWFYeNA16CLM_fXXiOw-2VKVVr
+OCQ_4iXfWkFV4N48-RTKMUE_wEdfwHy
+}
+
+AWSEntityColoring(VMwareCloudOnAWS)
+!define VMwareCloudOnAWS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, VMwareCloudOnAWS, VMwareCloudOnAWS)
+!define VMwareCloudOnAWS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, VMwareCloudOnAWS, VMwareCloudOnAWS)
+!define VMwareCloudOnAWSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, VMwareCloudOnAWS, VMwareCloudOnAWS)
+!define VMwareCloudOnAWSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, VMwareCloudOnAWS, VMwareCloudOnAWS)
+

--- a/awslib/CustomerEngagement/Connect.puml
+++ b/awslib/CustomerEngagement/Connect.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Connect [64x64/16z] {
+xPL7kgOm30HRSfHwxd_T2GO1m_U8Qshr1ygs4lOz7nyV35xQLhEgvcha2zqIWcnyh5T0QpUtNWJI-50lG7Lo9C4BKFb8Rv3ExLSqFebTCFI07R3xjM16uJwU
+x2sdt7bdUuZlKSXKYrlH5_vGZzojAJAlZxz4lubOo_WYC5xv6i_GIbaYvdoEmWkTYaYxO5DwZgP68i-pLp3lpuJIrWCNrKe3j3fF6rSYoGB_bT0PBGaKLWMa
+yqHVbcT2haij8MOG9oqVjYDxhBs4FnUC1gKBHe8Q3gh0XBRLIrkJeKYA55N8UpyscMimUhwIh4WnGq2Qjpre0_PfNVOaIURAfR5C1vgPSzzY-ywjdEPFW1g1
+eriND9ARDBSJlw1uGULIacYZQxzCVbiRbGMQ8FjvRZpC7pkGi4GeSAPTllIWW3eiLe5Khh_P_y-pGuz6NyUSUAGwuizRtUIm0JEISsLQGBLihwCc9qES8AK6
+VHrSzZfH52X-1BrWHTQVCnPIfnz3QwtLWOJFhj0wqQxkGoxCFbc1_E8-ddnw0jg1Tksp2tHK_uq_ybcS_iwdfRYzN_bDuftn1aMS_HqIRzENb1ndVyTbhtny
+VFm1
+}
+
+AWSEntityColoring(Connect)
+!define Connect(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, Connect, Connect)
+!define Connect(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, Connect, Connect)
+!define ConnectParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, Connect, Connect)
+!define ConnectParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, Connect, Connect)

--- a/awslib/CustomerEngagement/CustomerEngagement.puml
+++ b/awslib/CustomerEngagement/CustomerEngagement.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CustomerEngagement [64x64/16z] {
+xTO5WiCm34HHoQoP-zztWtQvqJBzChmmoLVrd-wlAh5uoo9X-49lkF3mHVlr_j_RLHxF8jTL7lTPwqL5YiS7NWHrUGMiZSplcMIKFt_yu6bmUxOwQbym_x0H
+3dds-lh7tW5lkHSaBrM7Pn7j1PqJTNczNWpRF937F6_iHePbNOfp_7qtZaIMgNh8ay0-oSngY15HYfa1pprBZ9X8cTzicr48qZXro2SHCv6ql5czg7NxVFmQ
+WA1beW6Bpn6T-zVVyeAtUNoUFzrhIA-NazqLc5vylifU115aAZWyKBUAQeEcwLrpUUvPbAoLKoxV8xAC7_mUODNw5W_-bUkNV-_imcUOitRcNz7xUGdnDOKn
+MdrLyXjw0G
+}
+
+AWSEntityColoring(CustomerEngagement)
+!define CustomerEngagement(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, CustomerEngagement, CustomerEngagement)
+!define CustomerEngagement(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, CustomerEngagement, CustomerEngagement)
+!define CustomerEngagementParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, CustomerEngagement, CustomerEngagement)
+!define CustomerEngagementParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, CustomerEngagement, CustomerEngagement)

--- a/awslib/CustomerEngagement/Pinpoint.puml
+++ b/awslib/CustomerEngagement/Pinpoint.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Pinpoint [64x64/16z] {
+xLQ7bWCX21n05Bp__zvhE-bPzdhDfAxFaOxCluaRRiZe_eW-yWtaSCKUwl5AjW7GvkCHtXH0p3bCfCNSHhOpaU5jJWS4GD-a3u6CUOuE6PaTsDB00P-Nq8NO
+OLjq2Zz5GfTVaIrw74ZnY2IVScl-ED2pAwFNyuc7N3PK-gU0ogS346lD183ddSDopk265RITwq8X7lpl0Wq3O0gqWXwGdHbeUPeGC1T0o_0RbOkBD15WtEMp
+BxCGlulHETqWqAI9iHuxvo-DxAPgVQR1w9h3flKKIqZIXyzGXJqhbKTA5YdMuNH2YymmG8y5AtBD_7QiXj89vEy5jxKCeDo471LAAioMasY0hvMmBmV7GZG4
+wQShSy0t-8rcKekTOzeR-BDdoQ_r9mhzQ_yHbV-supVxUVpYfVbZp9-eycSxVvVLAd_h-dd6QVtKzQleLzf_xfHyG__e86t0tjQ_M3I2U5l_d7lNlAb_Kozw
+uGttnoFO_TzoVv5EyrvvVnAZe1VtTx5Up0_5ublc5sL2l7b-ilZ4-QsU7oFdtyGDDpm
+}
+
+AWSEntityColoring(Pinpoint)
+!define Pinpoint(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, Pinpoint, Pinpoint)
+!define Pinpoint(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, Pinpoint, Pinpoint)
+!define PinpointParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, Pinpoint, Pinpoint)
+!define PinpointParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, Pinpoint, Pinpoint)

--- a/awslib/CustomerEngagement/SESEmail.puml
+++ b/awslib/CustomerEngagement/SESEmail.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SESEmail [64x64/16z] {
+xPO73YCn24KfBl3lV-3L86z68oHYPtlvwUNPvZ6DLlw7jQdmftGpHAP-GelXbNwEAm3lmgpZam44mFZwtW4vv3tcbAR4J0gCCxm3asW0c8v61Z-UNgW1S01A
+0v13UPFOBtIkaOvwE81sGPCkdaaFUGFu8XkHm-bu_e320GCpT0hHt0a_UOdMpV2FdKIZyU8Lw6iHP5xdvZtu9R7Hs2fVVF6tFvz0FCsDdZlWYm_rWWisO0jl
+02OxWbV0Y7HQP-fpw7jyxQIB9p_RPNa2Q7Jp2c187C5uxr3ZGdJpr1756o1RvepfmPCQ4E4jSqGtlw9zZD5uqzpDfvZnEtDFlhlHdHvoQdDFVZogPWEWjRad
+t-6SIYpDrNnqSrJcCfzdCgxCrJo9XwXihkQJnMIkv7EvoTm-J_woE00ud_5H030vp6MVcSy2s_MaThrB-cfU4HEohQbJ-sg-FqgV3vybdzLtoqseUJR0jTnz
+CbziUkcdac-vLNado7orwsKrcSy_ruVFpDU7dcmnyzbSOJ7psLnfySaNvWgBBxumLrYyUKdcTYpAue7uT7ozxy3Y0LS-ottzC_1vOlvlvBb_7gPVdF_v0W
+}
+
+AWSEntityColoring(SESEmail)
+!define SESEmail(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, SESEmail, SESEmail)
+!define SESEmail(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, SESEmail, SESEmail)
+!define SESEmailParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, SESEmail, SESEmail)
+!define SESEmailParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, SESEmail, SESEmail)

--- a/awslib/CustomerEngagement/SimpleEmailServiceSES.puml
+++ b/awslib/CustomerEngagement/SimpleEmailServiceSES.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SimpleEmailServiceSES [64x64/16z] {
+xPQ7qkCW38HND27s_T_tpXfhSEOWvDhKx5_YzY495iNZF-chhtZh3zbXNN-gcv_y9csQ1RSagv6_G_VYMAcjrU83bKv-Ybi1fFPPVwy25EDdk0gaZMSuSZI1
+A3-WHmNguExw4S-GldoANP2F0sIaNPsqX7m8Nv3s8JWI2j_X2hcYSwah0u5oZvl0QxUbV0uym3xxUaTPI7o0kgt01_TF0v3AYmI0EUWfxi8t1W_bGuhWsRO9
+c8TtlcYO9QoZnNbFmDRX6og33xDCImNFYiObdz4dJtFgjfrnyXrvNO1u-ZT_PqtUbGG_dviAAdFo7WYe5V2q9iyCutBrofDd0ue0Ke369r_GLxoYFla2A2rd
+emBboLVecc-J7ydtuPNulN4dtyvyaYjao5SmdVcPFv3qHGbOvx-UlvLEysVJ5zf28YsaqsV6hNzSP4Xa7Z-Us_ftFwOh_BlVFsU-ed6_Vy_v2-nT_xZKQWYe
+eHPP5XxxrrApVvtw9tA_9H97sVbj_mpZtlx_jVxR_s7ZJGNcxGwfytN-sHEy8TekUzVi_fN3ZyNye0A07n-_WJEAgSyI6m0q-iog5UG377D0AWgfa5e5IXOe
+6RMV-Em12vdGoOv45aydd_bOOBUIY9-BcoRiSH8Lo78jv8n_BPjaGFdX-nEoSSpw1oq3ulXP7EQlYp7_VaYp4VXHZ4zJDSR97xv1Z_-chxxw0G
+}
+
+AWSEntityColoring(SimpleEmailServiceSES)
+!define SimpleEmailServiceSES(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, SimpleEmailServiceSES, SimpleEmailServiceSES)
+!define SimpleEmailServiceSES(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, SimpleEmailServiceSES, SimpleEmailServiceSES)
+!define SimpleEmailServiceSESParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, SimpleEmailServiceSES, SimpleEmailServiceSES)
+!define SimpleEmailServiceSESParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, SimpleEmailServiceSES, SimpleEmailServiceSES)

--- a/awslib/CustomerEngagement/all.puml
+++ b/awslib/CustomerEngagement/all.puml
@@ -1,0 +1,74 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $Connect [64x64/16z] {
+xPL7kgOm30HRSfHwxd_T2GO1m_U8Qshr1ygs4lOz7nyV35xQLhEgvcha2zqIWcnyh5T0QpUtNWJI-50lG7Lo9C4BKFb8Rv3ExLSqFebTCFI07R3xjM16uJwU
+x2sdt7bdUuZlKSXKYrlH5_vGZzojAJAlZxz4lubOo_WYC5xv6i_GIbaYvdoEmWkTYaYxO5DwZgP68i-pLp3lpuJIrWCNrKe3j3fF6rSYoGB_bT0PBGaKLWMa
+yqHVbcT2haij8MOG9oqVjYDxhBs4FnUC1gKBHe8Q3gh0XBRLIrkJeKYA55N8UpyscMimUhwIh4WnGq2Qjpre0_PfNVOaIURAfR5C1vgPSzzY-ywjdEPFW1g1
+eriND9ARDBSJlw1uGULIacYZQxzCVbiRbGMQ8FjvRZpC7pkGi4GeSAPTllIWW3eiLe5Khh_P_y-pGuz6NyUSUAGwuizRtUIm0JEISsLQGBLihwCc9qES8AK6
+VHrSzZfH52X-1BrWHTQVCnPIfnz3QwtLWOJFhj0wqQxkGoxCFbc1_E8-ddnw0jg1Tksp2tHK_uq_ybcS_iwdfRYzN_bDuftn1aMS_HqIRzENb1ndVyTbhtny
+VFm1
+}
+
+AWSEntityColoring(Connect)
+!define Connect(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, Connect, Connect)
+!define Connect(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, Connect, Connect)
+!define ConnectParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, Connect, Connect)
+!define ConnectParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, Connect, Connect)
+
+sprite $CustomerEngagement [64x64/16z] {
+xTO5WiCm34HHoQoP-zztWtQvqJBzChmmoLVrd-wlAh5uoo9X-49lkF3mHVlr_j_RLHxF8jTL7lTPwqL5YiS7NWHrUGMiZSplcMIKFt_yu6bmUxOwQbym_x0H
+3dds-lh7tW5lkHSaBrM7Pn7j1PqJTNczNWpRF937F6_iHePbNOfp_7qtZaIMgNh8ay0-oSngY15HYfa1pprBZ9X8cTzicr48qZXro2SHCv6ql5czg7NxVFmQ
+WA1beW6Bpn6T-zVVyeAtUNoUFzrhIA-NazqLc5vylifU115aAZWyKBUAQeEcwLrpUUvPbAoLKoxV8xAC7_mUODNw5W_-bUkNV-_imcUOitRcNz7xUGdnDOKn
+MdrLyXjw0G
+}
+
+AWSEntityColoring(CustomerEngagement)
+!define CustomerEngagement(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, CustomerEngagement, CustomerEngagement)
+!define CustomerEngagement(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, CustomerEngagement, CustomerEngagement)
+!define CustomerEngagementParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, CustomerEngagement, CustomerEngagement)
+!define CustomerEngagementParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, CustomerEngagement, CustomerEngagement)
+
+sprite $Pinpoint [64x64/16z] {
+xLQ7bWCX21n05Bp__zvhE-bPzdhDfAxFaOxCluaRRiZe_eW-yWtaSCKUwl5AjW7GvkCHtXH0p3bCfCNSHhOpaU5jJWS4GD-a3u6CUOuE6PaTsDB00P-Nq8NO
+OLjq2Zz5GfTVaIrw74ZnY2IVScl-ED2pAwFNyuc7N3PK-gU0ogS346lD183ddSDopk265RITwq8X7lpl0Wq3O0gqWXwGdHbeUPeGC1T0o_0RbOkBD15WtEMp
+BxCGlulHETqWqAI9iHuxvo-DxAPgVQR1w9h3flKKIqZIXyzGXJqhbKTA5YdMuNH2YymmG8y5AtBD_7QiXj89vEy5jxKCeDo471LAAioMasY0hvMmBmV7GZG4
+wQShSy0t-8rcKekTOzeR-BDdoQ_r9mhzQ_yHbV-supVxUVpYfVbZp9-eycSxVvVLAd_h-dd6QVtKzQleLzf_xfHyG__e86t0tjQ_M3I2U5l_d7lNlAb_Kozw
+uGttnoFO_TzoVv5EyrvvVnAZe1VtTx5Up0_5ublc5sL2l7b-ilZ4-QsU7oFdtyGDDpm
+}
+
+AWSEntityColoring(Pinpoint)
+!define Pinpoint(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, Pinpoint, Pinpoint)
+!define Pinpoint(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, Pinpoint, Pinpoint)
+!define PinpointParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, Pinpoint, Pinpoint)
+!define PinpointParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, Pinpoint, Pinpoint)
+
+sprite $SESEmail [64x64/16z] {
+xPO73YCn24KfBl3lV-3L86z68oHYPtlvwUNPvZ6DLlw7jQdmftGpHAP-GelXbNwEAm3lmgpZam44mFZwtW4vv3tcbAR4J0gCCxm3asW0c8v61Z-UNgW1S01A
+0v13UPFOBtIkaOvwE81sGPCkdaaFUGFu8XkHm-bu_e320GCpT0hHt0a_UOdMpV2FdKIZyU8Lw6iHP5xdvZtu9R7Hs2fVVF6tFvz0FCsDdZlWYm_rWWisO0jl
+02OxWbV0Y7HQP-fpw7jyxQIB9p_RPNa2Q7Jp2c187C5uxr3ZGdJpr1756o1RvepfmPCQ4E4jSqGtlw9zZD5uqzpDfvZnEtDFlhlHdHvoQdDFVZogPWEWjRad
+t-6SIYpDrNnqSrJcCfzdCgxCrJo9XwXihkQJnMIkv7EvoTm-J_woE00ud_5H030vp6MVcSy2s_MaThrB-cfU4HEohQbJ-sg-FqgV3vybdzLtoqseUJR0jTnz
+CbziUkcdac-vLNado7orwsKrcSy_ruVFpDU7dcmnyzbSOJ7psLnfySaNvWgBBxumLrYyUKdcTYpAue7uT7ozxy3Y0LS-ottzC_1vOlvlvBb_7gPVdF_v0W
+}
+
+AWSEntityColoring(SESEmail)
+!define SESEmail(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, SESEmail, SESEmail)
+!define SESEmail(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, SESEmail, SESEmail)
+!define SESEmailParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, SESEmail, SESEmail)
+!define SESEmailParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, SESEmail, SESEmail)
+
+sprite $SimpleEmailServiceSES [64x64/16z] {
+xPQ7qkCW38HND27s_T_tpXfhSEOWvDhKx5_YzY495iNZF-chhtZh3zbXNN-gcv_y9csQ1RSagv6_G_VYMAcjrU83bKv-Ybi1fFPPVwy25EDdk0gaZMSuSZI1
+A3-WHmNguExw4S-GldoANP2F0sIaNPsqX7m8Nv3s8JWI2j_X2hcYSwah0u5oZvl0QxUbV0uym3xxUaTPI7o0kgt01_TF0v3AYmI0EUWfxi8t1W_bGuhWsRO9
+c8TtlcYO9QoZnNbFmDRX6og33xDCImNFYiObdz4dJtFgjfrnyXrvNO1u-ZT_PqtUbGG_dviAAdFo7WYe5V2q9iyCutBrofDd0ue0Ke369r_GLxoYFla2A2rd
+emBboLVecc-J7ydtuPNulN4dtyvyaYjao5SmdVcPFv3qHGbOvx-UlvLEysVJ5zf28YsaqsV6hNzSP4Xa7Z-Us_ftFwOh_BlVFsU-ed6_Vy_v2-nT_xZKQWYe
+eHPP5XxxrrApVvtw9tA_9H97sVbj_mpZtlx_jVxR_s7ZJGNcxGwfytN-sHEy8TekUzVi_fN3ZyNye0A07n-_WJEAgSyI6m0q-iog5UG377D0AWgfa5e5IXOe
+6RMV-Em12vdGoOv45aydd_bOOBUIY9-BcoRiSH8Lo78jv8n_BPjaGFdX-nEoSSpw1oq3ulXP7EQlYp7_VaYp4VXHZ4zJDSR97xv1Z_-chxxw0G
+}
+
+AWSEntityColoring(SimpleEmailServiceSES)
+!define SimpleEmailServiceSES(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, SimpleEmailServiceSES, SimpleEmailServiceSES)
+!define SimpleEmailServiceSES(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, SimpleEmailServiceSES, SimpleEmailServiceSES)
+!define SimpleEmailServiceSESParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, SimpleEmailServiceSES, SimpleEmailServiceSES)
+!define SimpleEmailServiceSESParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, SimpleEmailServiceSES, SimpleEmailServiceSES)
+

--- a/awslib/Database/Aurora.puml
+++ b/awslib/Database/Aurora.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Aurora [64x64/16z] {
+xPQ9acen24GRaa2W__zxtu9nrynzQstsZ9fBrIcAnOxvZ_NHH-IVyQCd_uGNH1uNbywF0m0w3w8PCKjHJvaq1MJm09tJck0iqU6drWdo23sagDR76BrhFVLW
+feq3k0lGB6xg3-y2Z4FpemCZI3vqm-IsTPinAlnL6ePWNkFn3W_eCxt6vpoV3Svt_Flyjk9X3TtUykYlwp_pd020u6jUgl_pqlzS_TVYIzxG_MtzQGe0sdeV
+lRVJ_4SOx53zoje_nLdInaoo-2FzNnLddDP_xV_Y6L8VUxxqyFLR_5nxjEMVTU4TZNkUMxv3DZW3yheuzk9J0ESkFtgIJtHQxGyD2iqTNyFEI-TO9rS0HeOW
+6eox-WS07JxZ50WV3K3hCB9XS4A26vun52KHMOS-gty3cbL3SZE_ifpHcug8QXjUvOIdhSmTBRcTFn_ghyE0B0jfqE26VnOPxO8pEyIJ1tcIEJlGWbUF1jIJ
+ZvFcY_tZ75q1iUHji07IkZtFtyZ7pGCW3xR6Q1N-sh-OqxjK-7OVowOyllIl6cQcAyHvctm4IRxqhwVxorWjCovSq88yw5ywlAOm0UF2H_A0VxbVxc_E4HDm
+9bCnUDY_UECV3Wcoe_Ft_8S3ZRur06ZkxZ_5L4o-vzlBrf0E19CEsHeeGzPYyuAkzRUAA7Rfrsf8inah4AVjK-SgGt8hSdOvkO-gBWTglefQ_hzLBL1lnOfe
+jvbSpEN-sUkf_XlroV__8tglZpxw3W
+}
+
+AWSEntityColoring(Aurora)
+!define Aurora(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, Aurora, Aurora)
+!define Aurora(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, Aurora, Aurora)
+!define AuroraParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, Aurora, Aurora)
+!define AuroraParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, Aurora, Aurora)

--- a/awslib/Database/DMSDatabaseMigrationWorkflow.puml
+++ b/awslib/Database/DMSDatabaseMigrationWorkflow.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DMSDatabaseMigrationWorkflow [64x64/16z] {
+pPO7kYCn28E7Zhd_VRSGJteiRr-zNdxYRn0MnnyIYvfxV9UR2jC-Ik8vwbdfibL3uiQErgr62A8vBs2OCX7rSOXOR5RDTGNj_p5-MrgxjW4yU74wNnSOLGgU
+JbNHn_9LVW1fbIpuGBnLwO8lHpZWQoXzD9Pc0RuLIk_WjW3WpQVpmbLuIjHFrdNDwq6MzK5fT0ZY-wWl0pJIjOs5-IbYKMlTJM_p0lY5uEldB_k7VjK_zhd2
+jd_uxQssunyRPxzCX9deqJzXq3-wy0yVlECV-Kt-qRRFZ_Z7Vj4_Wm3le7_9Ave2zpzaUNs3yryk3-LteLW5UPKy6nPksZAFivr3SV_uqmKqN3RxJsAHuuuS
+CUrput7-44yHp9_z_1kB_CFv6o30Vot_ILKVze-ZzR1_g2eldxz4BVQVdh4LZ_Ola5z9joUH7Y_x7myuVwiiqO7dp-YP9tVfviVU_8NG0z_Vpx68DMyw-nHL
+JdJqkrRDBWHJ9iXFpSS6titVsNamVwmn5kipvEUSXbzaVkSPT7xmFPh_03pbvlx8cVBAS-Byby-vQCW_hLHwnujt-QtzCLqVCpDZDAqmlzd7rJpPwf_FWq5-
+RYelchSQviy4yCYB8cvh6UJ1x_yeVp3J1zuM_mD5gdpyf_eA
+}
+
+AWSEntityColoring(DMSDatabaseMigrationWorkflow)
+!define DMSDatabaseMigrationWorkflow(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DMSDatabaseMigrationWorkflow, DMSDatabaseMigrationWorkflow)
+!define DMSDatabaseMigrationWorkflow(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DMSDatabaseMigrationWorkflow, DMSDatabaseMigrationWorkflow)
+!define DMSDatabaseMigrationWorkflowParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DMSDatabaseMigrationWorkflow, DMSDatabaseMigrationWorkflow)
+!define DMSDatabaseMigrationWorkflowParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DMSDatabaseMigrationWorkflow, DMSDatabaseMigrationWorkflow)

--- a/awslib/Database/Database.puml
+++ b/awslib/Database/Database.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Database [64x64/16z] {
+xPO3ekL0403RlFzzD_nuxhKg6bKqX5_5V_2y8h1DKG1wzwsdr8LVCpf_iF_Vxm-C_KL9L-45KS_g7lcTYW18n4oqXZHxuYkWUExVK9Kk23hm6QpUlteB6l2h
+VWTurmNj4FsYxv3NVeA_xbDqVx8xQE8Zi5UzrxupuCHF8m0IjGMLDMmvyhlIX13NN1BBuVUVLRzmXeR-1J_L__Rwb-eBlMJY0_dd_ky44pyOWDKZ5y9rZSN4
+hqvZX0Daoww9drkVpTWu8lFwwuC_h_wr-q9ldVZ0SNQW_HeC4zy8K3oo5Z9S4CWcVbK87daBA56p-j-htst1zmOmhxz-Orn_TOChVpv__9pvQpv_pkVl-VhX
+9wnV1bpu__qX5xvM3ebF_bVm_NmW_Xe8uGI_2lWR-08
+}
+
+AWSEntityColoring(Database)
+!define Database(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, Database, Database)
+!define Database(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, Database, Database)
+!define DatabaseParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, Database, Database)
+!define DatabaseParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, Database, Database)

--- a/awslib/Database/DatabaseMigrationService.puml
+++ b/awslib/Database/DatabaseMigrationService.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DatabaseMigrationService [64x64/16z] {
+xTLL0Ymf38NXG8JadFtlT-YQAzKEr-rxQVtB0Jpnpp_ytvUsgCgf2jiR8TAroGTD8y6TElebwsgJzYOYFS3Ll6QjKG0FG8MAQ15hkcXTdJB9LEbOmY56tf-J
+IdAf3t7Y3brYjPS0YHCI8Hkzz2Zm4rHqsUXTHQIRnvZ2zHARh_U3vLrEUXJ7JZyXH_WK8y5fgp_UV89fix_pZVlzvoVMUnaahf3PDdhH14-GjlFyM1TfwYDh
+oX7QHBhjNBzXJKwQ3Mm-FyZXffFvI7p1yyEJt-pvKH0tI5llHVDs_YoLzRuzchyt-Z7kruyH6psHSLw_F3Ul_ztwkTiVUDY_V_5Lup-br_tuhov9B35fKQSZ
+dogQ65QvY6XauL1vt7x7CfOtkMZJ_s-yY7KaCanxcxfQ9CYj6hW-_-DbDHzQl3yb7LpiJVA-Jx7Lte-Urd1vGJCUlM_sAdLvAT7DtkxwlUDFBzpsA4zktB-x
+7YJsLEAGXIz2NhtU--UV_m
+}
+
+AWSEntityColoring(DatabaseMigrationService)
+!define DatabaseMigrationService(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DatabaseMigrationService, DatabaseMigrationService)
+!define DatabaseMigrationService(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DatabaseMigrationService, DatabaseMigrationService)
+!define DatabaseMigrationServiceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DatabaseMigrationService, DatabaseMigrationService)
+!define DatabaseMigrationServiceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DatabaseMigrationService, DatabaseMigrationService)

--- a/awslib/Database/DenseComputeNodeResource2.puml
+++ b/awslib/Database/DenseComputeNodeResource2.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DenseComputeNodeResource2 [64x64/16z] {
+nPS7pkGW34Onnksx_u4tB4Y4FqgcUCkReleejcdbRqEBRtJ78kXZdN26l_5D1lgbBsLGapxdVKtwSChvY9Rn0u1cuYy0l7xW6w0ya1v_Za_cG8wVzKVs_Xmu
+i5FBWRoRXmR0AZCxO7pGTJ979phwf2imOqUdfSSuGyzJRsialdotWJ_uDO2evpJ8PHN8lTz-n8W2gE_xkdAqpu2QNtoD2oF07TqAoT3PVS8ZjAftSlN3ReZf
+KxEXUcku-hVrB00j6R0Ulwil3xvOp9vh0DpzHeFTRsQcF79axZBzATFS0BRwstn5HsVoWU4FUQLLwxrlz3iu15YbEdsXil2vXSY4o-RtB6lldcugh0BXUxnt
+N-15uUN67nEoSkitH37OhLzyJFgn_uJV_oGn_e3q3DUluXSoTfG0L8m-pjz1SE_5SK0VrW_LWpBWrke7zPjOFudrczW_qljNVl_Cxz_vyoDzVkNFp-pvdRm_
+9EulgVjJylwMl3_cxg_9-_F_lB_h_to_rF_pVZl3sVThylty5_W5
+}
+
+AWSEntityColoring(DenseComputeNodeResource2)
+!define DenseComputeNodeResource2(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DenseComputeNodeResource2, DenseComputeNodeResource2)
+!define DenseComputeNodeResource2(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DenseComputeNodeResource2, DenseComputeNodeResource2)
+!define DenseComputeNodeResource2Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DenseComputeNodeResource2, DenseComputeNodeResource2)
+!define DenseComputeNodeResource2Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DenseComputeNodeResource2, DenseComputeNodeResource2)

--- a/awslib/Database/DenseStorageNodeResource2.puml
+++ b/awslib/Database/DenseStorageNodeResource2.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DenseStorageNodeResource2 [64x64/16z] {
+nPU5qgim44QpMV_U_tr_IJE33RImLyv8zG2nbVQteOKdUc0XwRPEMCDFVDSNzj3N-RONVQxxLlGHLFEHKl4JW5NcNm54l-4xOFn20MwSTyP0WVt-8_zy39pO
+CfvSFrq70U2TcGDm_k5N9m_yah_ObMx0d3jQ7Jt66heUkYnF4eiV_Y8k_9v0zlKowE4KwBalkpcY1FhdlXtMQ8w090w-vG40o85jDf83sFk4IsZPlPEZdtv2
+Jf_4CGWH77rf9oX0YmpucB-3hnU-UiuxzmJurnTwiVN5tOt7kyZGwMFAD0F0Vlyjlk4N6qkLoCKVyi00w-U-qvYSX3RgquTIMuWPGdJ2RUEtvh2Ma7QompgG
+iPtlhQ-8vaWvyPlELJZp1JcEJlIZFuWnwClxDp80zCWt-1odFdh-XCxRwFtvInqHnLGCuFlh1o1vLXnsU_zG_s6yOP7URkpVmlafdDz2_AZ7hthyhCVlUlue
+vwzw_gpcxsBzKAXVIlLJiNuhre-r-hLOF__F-jt-P__I_q__jeQh_MknV_uBV0C
+}
+
+AWSEntityColoring(DenseStorageNodeResource2)
+!define DenseStorageNodeResource2(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DenseStorageNodeResource2, DenseStorageNodeResource2)
+!define DenseStorageNodeResource2(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DenseStorageNodeResource2, DenseStorageNodeResource2)
+!define DenseStorageNodeResource2Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DenseStorageNodeResource2, DenseStorageNodeResource2)
+!define DenseStorageNodeResource2Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DenseStorageNodeResource2, DenseStorageNodeResource2)

--- a/awslib/Database/DocumentDBwithMongoDBcompat.puml
+++ b/awslib/Database/DocumentDBwithMongoDBcompat.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DocumentDBwithMongoDBcompat [64x64/16z] {
+xTO5kkqm24NX3O4GsFEVx_jgLuurVMxhklodtbA_MV_x7zVUlxc8AwDRqwLcFRB82pfTiIOYM5DFSf9d0z0yHjPIZl3rDyaf7e16lMyrboeK24xm18Ay_pq3
+I9vxVxOO1dp2DumdFc4Jtj2ATH-hJNf85CbwZsI5OD8R81vPFAeCN_IappG18CtSkxkrzIVFclLa3L_KdgX7LcMFAixuROipnrAMxQUn23GvvTUufz0ZQ77Q
+7wcy8OCLlyARx04IlEu5xo-0pfVUoNkljPLGGUSh3qloYMV2XY3umYjWe_ZUPmy1x9NFBe0qxp56ZX5r-BKc8YUU5QPuAmv_e3prPEM8xcRcFNVFBeEcoNDV
+zMZx1Kb7d_Bt-vy5BGxuL_fo69dG-YhF00QB3NhY-vFb6vnL2Z_ny28VRpyvO3pn0kbPxy_Vz_qlnNw-_uS3KEiZiweow_0DWuPnll-pDxmNYh7wxCaHTUv9
+rkY-3W3DHjVDa-l7vVEFLOi_cl1t2KH4LRQkUrieeBAcdT_q_Bu-Ft1kVfYVNxvzVlhs-UtRvyVv-VLtxN__-m8
+}
+
+AWSEntityColoring(DocumentDBwithMongoDBcompat)
+!define DocumentDBwithMongoDBcompat(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DocumentDBwithMongoDBcompat, DocumentDBwithMongoDBcompat)
+!define DocumentDBwithMongoDBcompat(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DocumentDBwithMongoDBcompat, DocumentDBwithMongoDBcompat)
+!define DocumentDBwithMongoDBcompatParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DocumentDBwithMongoDBcompat, DocumentDBwithMongoDBcompat)
+!define DocumentDBwithMongoDBcompatParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DocumentDBwithMongoDBcompat, DocumentDBwithMongoDBcompat)

--- a/awslib/Database/DynamoDB.puml
+++ b/awslib/Database/DynamoDB.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DynamoDB [64x64/16z] {
+xPP7bkiu40IpOChb_Uyx3P8DIEE0xtQALHl5AqaCcFm3VFZ0RtvApGYtWSVz-pbCrofObAQHFBQr091IMrVLtkhu5TKETHEWghzzVXya1riTQF7-EiOBkK5W
+ZxnqmQBnVySxAlCTDfHwqyhUb_ZxU4ZoeS5tFiIIV1klyrT8vcu-K3IID_VuzUKsxlpc5O3KhkRkyJgU5RxtoLZv-HW_URw9ZQyzcM7QM-jlumr51niVS2Pl
+nlZfTzm4_wyVj_xsvUSap4o1dlyD5T2vNXc03EpvdLdGkUaVqYoIWoZ31lHsXjwuwxyBW38UODuK1AUUs_wPrWe0bDiAb6TwHTtt5_SZ3ZVx_aYTKsSUziyl
+LdLBF-XVkh_kFY8vQ2X3t_ORxUg_gPb_SILreg_-S_MFoWPZig74qW_wzsi1D4z1a1qIZ3DVPly3HtrqBxb7uAxlGUkjhwrnqsz_FQzO40fnEX07ljw7JQm5
+N1IuTFZoj_tBTNmP3NBfLHLr-fl-lJyFiB02C6OaxuwslZW7L__gAPUUIHgEV41d_qCQEideMFvv_rwCpB06oFBt_QCy_PlsMW183pdpv_wnADsJUUhtzjt_
+5whccMJceLzd_vCSB7_NZsl-4x8VznzpvfJJAoJui_UdNe0I_BNx6t_b_aZ-gVlh_lxyv_ZmuIy
+}
+
+AWSEntityColoring(DynamoDB)
+!define DynamoDB(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DynamoDB, DynamoDB)
+!define DynamoDB(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DynamoDB, DynamoDB)
+!define DynamoDBParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DynamoDB, DynamoDB)
+!define DynamoDBParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DynamoDB, DynamoDB)

--- a/awslib/Database/DynamoDBAttribute.puml
+++ b/awslib/Database/DynamoDBAttribute.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DynamoDBAttribute [64x64/16z] {
+xTTNSiOm201Xa2m1U__xfddqzqQK7kyhyxbNcKvlTNSioerSnBcHtl4X4lUzjSlvwhrTpePVv7AsUfFBBSCt6McjHH_rxSHhSrxpvLs-1YClUT-0w4jT3A1c
+VGMQoclQWPBp6h0SJZpd6pJPPr1JFWWvg81bl4ANmvp8-7fw4NRGdAyplaokNy5czbySLFPLw2c_WCa-XvBmgsWoCZ39-G9OaTUgGsZIImNmthi3KIJhfJWZ
+KybxaMe1H2yYMJzQtmbfVrZUkrqkLXzsEV-OzuzxNCr4BAxchlBDpM___FjxulpDNpzvl_dDRtxpcv_zVvh-Vvj_Vy_-lyx-Fq_t3
+}
+
+AWSEntityColoring(DynamoDBAttribute)
+!define DynamoDBAttribute(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DynamoDBAttribute, DynamoDBAttribute)
+!define DynamoDBAttribute(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DynamoDBAttribute, DynamoDBAttribute)
+!define DynamoDBAttributeParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DynamoDBAttribute, DynamoDBAttribute)
+!define DynamoDBAttributeParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DynamoDBAttribute, DynamoDBAttribute)

--- a/awslib/Database/DynamoDBAttributes.puml
+++ b/awslib/Database/DynamoDBAttributes.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DynamoDBAttributes [64x64/16z] {
+nPS5WWDH24F3V05o__kkpTQTL5vTNXN5nnbNw40VLm1Wl482oIlOK_nfEnRRuQllTfwvyGV-iHaP0nisFiupZlt6FtAf-SklwqccbNmdn-QYu1iP-2KPHNzi
+jABloliZoBRUFKj-8-aZI5h9n-1AGyr72p9zGTK7R37WKPzvdat-vNcUax_mAqnW-XK07Rl6pOTXl480yVhw5-CykVevpXCRlsE3zT7jtlZfn_5dpbzcDNw3
+AxFc3pAQzIHRoK-chMNOAxvjFdWmF-0Bdr_u_QJ_JuqVDNxb_D7pLwqVQlrIKUkt-Flf_Klldth_rkS7VNxHvoSZ_GFpep2_AlEpFh_h-uEyl-ZxqwVtFtL_
+_JZV
+}
+
+AWSEntityColoring(DynamoDBAttributes)
+!define DynamoDBAttributes(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DynamoDBAttributes, DynamoDBAttributes)
+!define DynamoDBAttributes(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DynamoDBAttributes, DynamoDBAttributes)
+!define DynamoDBAttributesParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DynamoDBAttributes, DynamoDBAttributes)
+!define DynamoDBAttributesParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DynamoDBAttributes, DynamoDBAttributes)

--- a/awslib/Database/DynamoDBGSI.puml
+++ b/awslib/Database/DynamoDBGSI.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DynamoDBGSI [64x64/16z] {
+xPS5he0m44IdNhZ_VRzqXmIt9K5VT99zwDQWnhHWRATfM56tC4Yj5E3gUSmXVWg5H3y8z6EO8ZM-Hy6BNqaoz2r6OJth2c7KTvWYhF0_toxxqHKYVKcUVd2Z
+iFxy_eLh0TXMCZ1k7Xn0Q06uLh8mOPvhZFzW2at_IBBqlPb2qNzN6Z_V-C-faDa_IQ2VqnJvcFxBkI8v6yII97fOfX5OVpBwvzUFNyN_k_Fu_SQlUlu-V_tM
+hfzQjFk7Kx-VTlzsxlZ_VEtvINr-Et_yQy_FQdu1
+}
+
+AWSEntityColoring(DynamoDBGSI)
+!define DynamoDBGSI(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DynamoDBGSI, DynamoDBGSI)
+!define DynamoDBGSI(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DynamoDBGSI, DynamoDBGSI)
+!define DynamoDBGSIParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DynamoDBGSI, DynamoDBGSI)
+!define DynamoDBGSIParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DynamoDBGSI, DynamoDBGSI)

--- a/awslib/Database/DynamoDBItem.puml
+++ b/awslib/Database/DynamoDBItem.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DynamoDBItem [64x64/16z] {
+xTS5hkL034JHQhHT-r_mM7eC0SlpELUipWbJ8rrPQtCOXIife5ofR7W3RDlBU9-Ul8xtoSLtl4zENl2-Vl5Zho-rjO9B8-YxafuELt5VbPUinNsZ9xtrQNGH
+zTNHB81NtB45lTulrKah8Tz8mQtX9kI5hBZBQ25lLDmtdGPy8UVphTSolYLz9slc-CLfn4-ouPORHSHN1my3x05_4e9B3XKnNynD0xmg96lGevehdNCglOQe
+Hn5Uqegmz-eqnoODYFjJfqz6sB_jvbNUPoTlyZxzFzyVLLjC0B75L0k-kEJ-vyvV_lhbxv-uF_pX3t_umsVdJ-dvM_xxdPs_PkVFwVu1
+}
+
+AWSEntityColoring(DynamoDBItem)
+!define DynamoDBItem(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DynamoDBItem, DynamoDBItem)
+!define DynamoDBItem(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DynamoDBItem, DynamoDBItem)
+!define DynamoDBItemParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DynamoDBItem, DynamoDBItem)
+!define DynamoDBItemParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DynamoDBItem, DynamoDBItem)

--- a/awslib/Database/DynamoDBItems.puml
+++ b/awslib/Database/DynamoDBItems.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DynamoDBItems [64x64/16z] {
+nPS5OYjH30FbXxRkVzyFNIfi0rPWmZ118zvElq03Mhy00EC50WXUm1xY3pjdBlwqWs87O_CxpjbyR7GF7xRVkjClmGzgphSWOmR9al8xERUBZE-CzPAMyOFp
+q8Jtdqb_B4-ifET-VvBU9ycQyb6vq97pKMQGNf7r0Ii6_F0Pvt3nVtluCVcBUO41Z7a1GCSkSVNXoz_V0Nz-_VD-JYn-z7DyyzkjyMEjDyD6kpV-1lypBHc_
+WmkUyoiPpQgJFUNFfV1QC59-qBUlOQglVtxzzzF_FpL-rFYLyqVFNxL-gFLBHQtVqk-dzY-XVshzMvqVvFb5dP-a-UtDywEJfi_F-lokxm_o_gBlJ-_U_zJz
+zUty1G
+}
+
+AWSEntityColoring(DynamoDBItems)
+!define DynamoDBItems(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DynamoDBItems, DynamoDBItems)
+!define DynamoDBItems(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DynamoDBItems, DynamoDBItems)
+!define DynamoDBItemsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DynamoDBItems, DynamoDBItems)
+!define DynamoDBItemsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DynamoDBItems, DynamoDBItems)

--- a/awslib/Database/DynamoDBTable.puml
+++ b/awslib/Database/DynamoDBTable.puml
@@ -1,0 +1,12 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DynamoDBTable [64x64/16z] {
+xPT50eH030HxFF3__wu5lMMsSQWJLdWCD6vAjswYExoT4f3Q2jmYVabAxlnae_H-XE8xty54xFq49TJvQUu_ll_Jpq59dH-3YTpv-_w_25C05oh00gGf3ZvL
+S8puJqw9dU-TYOl4p-DBKQJpYmrPvlyJQGR48qfZHSHXP_Zxv-EN_NvF_9pKf_Ft_lMRhPyiRF-mw_jZ-pUcVtpYZ_VP-OcUt_QFVtP-fda3
+}
+
+AWSEntityColoring(DynamoDBTable)
+!define DynamoDBTable(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DynamoDBTable, DynamoDBTable)
+!define DynamoDBTable(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DynamoDBTable, DynamoDBTable)
+!define DynamoDBTableParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DynamoDBTable, DynamoDBTable)
+!define DynamoDBTableParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DynamoDBTable, DynamoDBTable)

--- a/awslib/Database/ElastiCache.puml
+++ b/awslib/Database/ElastiCache.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ElastiCache [64x64/16z] {
+xTC7agim381XMSLgzx_l4tQ62M_CnapVyc-bV0cOA7v4V_sL3rfvj-ryvGcsevL7ODcA0TU-QMvaRUrD05nnH4uuqdC7uwWxWDXw_Jjq1cYj0UZhB_-_Wpf8
+PgnA1M6miPGwriY0vmu67HVjXzSr7up1CtBuZFJXCvBF7MI0dWkS0a197tqIWEJw-SNLHwYPHbnzoDtpYtnv1ZVFZ5UPjNdwZ5iVqrSPAeGDgeOa6cFlyF7P
+fn5CMZKu8ijzBqL5FLwv2WB8ha-5ff7lzv-X29gRNg1FVFrmofQtA0_YHQg87Bb0-R3F7h1yXQBc7k5ku_OFJ_39An6Nruvm2RkMPwB-bS-PW6MuTYQiYBjw
+f9MVtNldIgRFo_rFtxaIRtTUeSBfhqsFSAHttZkmcPKdpymtdEbKtYg6VkTdS_rPlTWiNFcr_hELpqupBayD01gnLFpQA2yqwxbwWJC12sKiDcl86bR-BBxg
+yECSjv6FrpvyR7Mk__kxFV7h-Tdtv_oSXGiyyHLoDw_E-Tdtw_bvk7vkdOaGwPoVPpulFVVN7lc-df-UiHcjveTYjum-HWQ9Zt1iI6Hibs7oFZ-Y-_gyvND-
+niR3BlFpG_lhhty
+}
+
+AWSEntityColoring(ElastiCache)
+!define ElastiCache(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, ElastiCache, ElastiCache)
+!define ElastiCache(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, ElastiCache, ElastiCache)
+!define ElastiCacheParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, ElastiCache, ElastiCache)
+!define ElastiCacheParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, ElastiCache, ElastiCache)

--- a/awslib/Database/ElastiCacheCacheNode.puml
+++ b/awslib/Database/ElastiCacheCacheNode.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ElastiCacheCacheNode [64x64/16z] {
+xPVLOaCn24093l__mIlKlVVEjvoNw8bNW8zYB0BE8OjSH1WTxM6v0XjxtJFJLHQWhGneBDCH5eAUQPsZ7caflMhQJO-m0jmj8D9X5PvHwyZKTRvcZlPbdIyt
+V1BbRcCe1giWe8og8XXIu7tVCYEnpwOKZ8nmaAeQgLKT4NJNvyhsND5tur4YyD7dX-lts6VKjLRHBI_x8ssVGOtsZZwyuYli1A2D8mVVDxGV4VhSDuUHSkAR
+ghPl8lHy_H5cwIV-U67zxK51DP_dlllhvo-L7I3PWn34mli3ouZayDrc-lt4Y--d8LKUZ9qbW24g1ADdhLeknXr_0T_eJt_wqv_-zAS__VV-Vtxd__VtnW_l
+ZL_U6J-zDtvxP_putlZr_V7p-ta3
+}
+
+AWSEntityColoring(ElastiCacheCacheNode)
+!define ElastiCacheCacheNode(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, ElastiCacheCacheNode, ElastiCacheCacheNode)
+!define ElastiCacheCacheNode(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, ElastiCacheCacheNode, ElastiCacheCacheNode)
+!define ElastiCacheCacheNodeParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, ElastiCacheCacheNode, ElastiCacheCacheNode)
+!define ElastiCacheCacheNodeParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, ElastiCacheCacheNode, ElastiCacheCacheNode)

--- a/awslib/Database/ElastiCacheForMemcached.puml
+++ b/awslib/Database/ElastiCacheForMemcached.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ElastiCacheForMemcached [64x64/16z] {
+xTO7RlGu38PXacBJT_y3RoJ2YjSOnLEsx_-cSG8ya0rN-j_77qH4XWyoei07nVHXRnM7xqflf7tusdybajLpiwBsdsHCtB3IpTpECtN0X6O6DCNApxDXPUUv
+pSKh1ap7prTMVitsFTjvLa0EBu2kpzFNpENvM6FDvTlX0v1bdlG2vFmWqO6aL_qyxY5r_dNUUTjwpdN-ETD3JypryyWJ6SftejzxLgL2ivfLvUAfF_3ateX8
+pBDtp7fFdwTASx_nbGOU54hLZRTZsGntC_V8upzsxpddMYPCfrXgcvBlV8nbobvYxK3U-3gjDd40yhDlWDCs0zhj-d3UBE_uqJSk3yGOBxW5K9xROm_Oy5M6
+QPDPKui4gaOA_EYr9HwMgdjFvkvjUY9MpujrPQ8slBYxqTLNvIjkJTLCjJMXMVdgucN6vNULPwduv0CpUyOhgixVFWzVXsQNdZtaxBj-9SFN1aIcB-VrGJ6y
+w2Y-FTo1xkxMwlYdrHO9LL9tkaHv7oKGA7zqEd-OSfegQexoTW91fFtYpNlMOf2rF8AekTN-h-h1pQiw_ZI6B3IA6jVnvnLTApzAz5YNf9_zfQrFAPNeyexl
+v80Ce_oqRsS_MGtbzHdVvV3aW05wUEctlevLApySnj_o3Zpd0Pw-Y1u-d_EHIABo7EbqU4r_nYj9Ax_YDuxVt-oZvydtxYzwOZh7zAI_VtxkU_RvlM-zF-Zs
+_U6cs_UN-xZMkfRAz6pShkzlZUdrU4RxVlKR
+}
+
+AWSEntityColoring(ElastiCacheForMemcached)
+!define ElastiCacheForMemcached(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, ElastiCacheForMemcached, ElastiCacheForMemcached)
+!define ElastiCacheForMemcached(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, ElastiCacheForMemcached, ElastiCacheForMemcached)
+!define ElastiCacheForMemcachedParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, ElastiCacheForMemcached, ElastiCacheForMemcached)
+!define ElastiCacheForMemcachedParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, ElastiCacheForMemcached, ElastiCacheForMemcached)

--- a/awslib/Database/ElastiCacheForRedis.puml
+++ b/awslib/Database/ElastiCacheForRedis.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ElastiCacheForRedis [64x64/16z] {
+xTK7Zkiu48JXZcIpxd_WbKkcQ0Xo7EHz_wHs-40FGK7olq__qCOJVoX5ElvGf-_vKttwaV93CUZp_d_OqMTpt9tORLB7KJoP_N4M06720eZ0KNkSSytvE3iN
+trCWu_QpbVHhpZNduno0JUz078_fzrbthtEDDTFxNBu0M-Ophq0f5o-UWsyzprsvx7_rcS-dNhakVOfSUb7bpwKdeHzoyXeXJ9cm23jv6MVFWQV2ijKOO6DK
+IpuP8UyyvuwBEl5xdtFPwgrbjjPhFfFllHRNIbDvI6t_JANlF2zdbOiq1b1ll76D9sa7xBLteCdJ4l2twwFfjTQ6bpvTwO7kUiRg7Q1NZsiF93shdk76FB8N
+xlbyvydxuSCBbrN4uUFinTnTwKKqMfri2-KYBkfRSl8p-ZrrZyYCS3TXksSdRybi-SleBVVymHTOVk8Jz_J2Ev3F_R5_pARNpPTjgJZtbdcDMzLzSUwVtMhB
+Omm0Ool4kDbfVFUiSsUpG1zZYmAxNwtpC-BcApCRU4dem_cPqLjVSVtM1W3wDa-MYWoCbZVlVMLoYlkltieEBuENLhZk-_yoUhPyqM_zvXM0_kQxgbhdDdte
+7SZ3puQkfzxxOIVV9hVnYGUwttrvj7KUE_21PwFxtB-nVtmTm6U-5xPoUhzl7u3gd_ZaKL_dvuvQio_sN-Nm1jGt-v_dyzU0_CMFiOzQe_HxBwgdwPr_U_-i
+jrxg-VqxUVz-anQsAbtb8VNayyFaNTgmDwhttbhhlSQw4Zv8it1HfSgdgITNFJv9kihNgTgMlf3_-Wy
+}
+
+AWSEntityColoring(ElastiCacheForRedis)
+!define ElastiCacheForRedis(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, ElastiCacheForRedis, ElastiCacheForRedis)
+!define ElastiCacheForRedis(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, ElastiCacheForRedis, ElastiCacheForRedis)
+!define ElastiCacheForRedisParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, ElastiCacheForRedis, ElastiCacheForRedis)
+!define ElastiCacheForRedisParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, ElastiCacheForRedis, ElastiCacheForRedis)

--- a/awslib/Database/Neptune.puml
+++ b/awslib/Database/Neptune.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Neptune [64x64/16z] {
+xPQ7ZiCm34CfoRO6__zxRpZDxKmSTjcPyLn89bZLF-kff_YXMsnb-5Ja-_4bkAARu4EYpPCyYsSN06AjZpVrPWe0BNWETm7Cyslz6Ls0LZo13w0doP_jS86T
+m1E8Fqjb6GOFUKVdvj9sXczRl9_ZqV_QRjBb90yT-TLsytiOS8xl3O2Do7bSLHcZ2Q1-ZlU7WI2Yxrg-crUTuyTqZ3TxaA9jH97Ci_nQSrNcv_TlFBdFh-AV
+-y_Av2P_w1-c0NQVBuCg6Y_wjsJXcL2MIFtDI_9FkXXzvQKIMpp4VxUNeMWV1mq2TFxDwpHmyOkgIY7mbL28Z4t_JQkBTOyf7qqx1RfsbWEjYZl-os62hseS
+07H2J22vwp-I5JvwUrTV4Zp2bWNOPkb7_kDNpUCoM5THQDKXlv60W01sdUTywx2iL0nUurbPhEavFknNLqAo2pGgnWCKEShFN-Tq5exrzu_oixxbfo7O83RQ
+HlrR-KcI2pzVB0NqgF_EUEIdgfcgbWC2NJindS_vtCxF64q5K-8S0akcD3Ac-HWg_JW_yqthxY_vorXoHm44Z_QVv9U3oUSxpuGOdDVpZmwD6W90yyR_TmS0
+1Rfxylhy410VW0R96_CBEvppxURyD32s-UFvZGdq3adUd1_fYw5kpw_CsVZxy_Cy_5SzzTGh
+}
+
+AWSEntityColoring(Neptune)
+!define Neptune(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, Neptune, Neptune)
+!define Neptune(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, Neptune, Neptune)
+!define NeptuneParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, Neptune, Neptune)
+!define NeptuneParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, Neptune, Neptune)

--- a/awslib/Database/QLDB.puml
+++ b/awslib/Database/QLDB.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $QLDB [64x64/16z] {
+xPO5ZiGm34M_CU3xttVhTg8ETPLg6Rxe3RnYOhl_glpdFt6Tyt9lnKr5HCrhoozEsBqe0I1UGabijSUqNWYafIMdrAeBWMjC-Wgf_Ugc8xaGF6RiC7Z4atjI
+p5q1QJn_AAHlz6NEX_TuiFFw9tq2btwrQXAR4sZIzyeWoLMpfLKJG9hC-j6hCPPG9e6jHPpmS_tMNC2gvcLR3MVy9G_RvvJ_cBVxFEbRF9I05KkvuCY1psFv
+k5f6hUrOhp2U-v2rN8I1ja0S0_aAZyuFM5OSfTvAAJMCTwGhFF2zAK3QbHjXYQS_a6oW7_fPBfGNlw2snc8Wsd5y-ug_xhT8VrssHKHNv4HRKLxrbwJl5vzv
+-8dpVW6BG0r4TKC7ZMyd_70HqPxFRo3Pm4FVXW_pDSmxaWsK8vzQh7vbkiJRCxIZzKTbMu3NlN37_TkZ-YiWgocDz6erGdLs_rO1m6gUCMK0VgP-hMSK9cI8
+nUh9-Z5kkRKs-ElhbyYR--TR-_SRvuStpYzld9_UDh-zRNxypVdFVru
+}
+
+AWSEntityColoring(QLDB)
+!define QLDB(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, QLDB, QLDB)
+!define QLDB(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, QLDB, QLDB)
+!define QLDBParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, QLDB, QLDB)
+!define QLDBParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, QLDB, QLDB)

--- a/awslib/Database/RDS.puml
+++ b/awslib/Database/RDS.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $RDS [64x64/16z] {
+xPO7SiCm30IF3Ut-_zx4DcMBcH6Keapt9kvSi84b_eStRxZnrn8g4uyCtJYChTYm93uD6yh45psht-N6EFDRVDV_QBal3IqO9zpr9fcliGV8zT2qVku1SfsI
+-xD4njJF_3WBm7xNi_eZp6SRXLlv5yyQUZ0YNFqu_lfAXgcCteUe1RVlbWBdK5l1YzADyIiwKDfGDLCTzr1ZgJzdAqD5jRN_Mg4CT_8xstinKj2S2zuWP4Et
+qmXyj5llFj14pM-OZWP06AC0tPdhLb1aJd6hMAXj9eUKU_XCLs048sQAk8xUQcrzgC_aYc0CG9Xk3pFszByWJukQRZ1rwjCNBeLsVyvDKdrbl7oCVGB3-j9g
+jiC6K35M7oYrZnkz5c3r1VgzBqi2bwQo-EFOTvJWKWN3pLJD_6l_e-0m1pZGWhk_7XUxJtPqnY7r6U0uVvyPMkCOUaNHcDK1TRpojsxZnz22ccNmpAug3xyV
+v6z81Vhf1cqDKExvUsFFtmeqOvn1sl0aVpdsvPj3flj7a7_Ulthy2jflzizy_xwHxDyNpW-Bk71-NJy_BvxVb-yFL-ylr-vFr-vlAjE_Vd_y_VtLPQANxy__
+mvitdm
+}
+
+AWSEntityColoring(RDS)
+!define RDS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, RDS, RDS)
+!define RDS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, RDS, RDS)
+!define RDSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, RDS, RDS)
+!define RDSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, RDS, RDS)

--- a/awslib/Database/RDSonVMware.puml
+++ b/awslib/Database/RDSonVMware.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $RDSonVMware [64x64/16z] {
+xTG5Sjr048JXdeM1xlkVDw29vO0aGwNOd-7Xlrkp3_X_VFcYziR3ufrenMiPX-Gr1PgBLpHmiAVUmxt4I-4Uwur-yd7-jCVU9oR5Eqh0nqCVx0KUSZtrhcE1
+fvpF_Vq2gYFd06zK52dEK0SdjlKpPmJlw5VO_ofyhxLtv9yFYE_X0oTRARvNxpA1iJqoCtmP47hdpc8KbHYb4ns3uaxfpTeDBYMma-owOlxi0vYfvpm7iF9d
+_zEOSyrXnrNsaIoATtgBagZ4ZcKusDXfrgFPCSZZ6qnzRKjaLLPHuj6JuiJWhO4GUVQl2EEvWEjs-wdpAbOKZvRbuznLXV7q_Z_xddpEy_nUcDttwxNVkRg4
+pJw_jtgMeSxvlS-lplDhsht95Jb6YTqllJg7bW9Mufq52whd7vuyL6uxUeaB2F7U1aOSlVK13Zkk77rjWwNuG3dHx_zTFeVzD5QKMNyzRugFn5nvz99uK9-V
+QkmItwIUtxoenboOweVUIGvWpBrzhsd0AFs1Rr7j0JIRGJ5QU_Z-r7czCYCYUuv0Qw6BEbUAAjjYargiKc3vYtNT1rmgG_SdRS0ouABwDsxxVtDnmHOmuHmp
+BEQWt_LnvgycHYaCS68uVE2-trVvfAWQSAsTC_Uwxt6-xKvc54anI8cYf8T-_f3wis_YYxi-qUAovrFVgf6VxDN-wlMFwFvTpFnliJxG3rnvVvznXU-cI_m_
+ldpv3W
+}
+
+AWSEntityColoring(RDSonVMware)
+!define RDSonVMware(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, RDSonVMware, RDSonVMware)
+!define RDSonVMware(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, RDSonVMware, RDSonVMware)
+!define RDSonVMwareParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, RDSonVMware, RDSonVMware)
+!define RDSonVMwareParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, RDSonVMware, RDSonVMware)

--- a/awslib/Database/Timestream.puml
+++ b/awslib/Database/Timestream.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Timestream [64x64/16z] {
+xTO5akGm38LXWILBUlU_xpgfPWYiQmhx7sZymk3watxz0l3VSCWSNPwVmnNUX6cDfNaKS5nd6rJKl8_SL8Yu1N2CPrk-NOLRLM5CcZZ4cRs0jpNgp87QJ_Zp
+V532-nf17Ly_2ipuVippnoqD11_qr1B0CqOQ7VJXJEfHzR3xN8aiZlb4BLydqMQZfa94ueKyvWEN0rY5HwBD8u4J_du2FJmxuz-QypZbtm_VrZ4rVpOiLLwk
+Hy8S-EeLUFLk8g895naGHhJXIHDuyQwjaHYf39cywOsfHU6sst1P_i4CfHJC6LlRhuo9rNjcZJ8NltxaA9In9B2v_L1XGjSusLQ0fMHkiUFNhrP6zr6FOiz0
+eTk8EPMwvVv51jU6RnHmuf4CgKI1K_j_a2xjUZ3AfiyF7gNKKOZLkLcUFFwwAGM2A02OexvxV_VUgPMIaoYP6PDjUEh0g_TMA2MfKcOcaWqlfF5yuxuSFsM5
+MX8fVFVPcSHw5Yuj_gaiR9__lJ4HYxQHQZ6hFAQQsBj-PhUsAcrb-jAU7s5jVRmyHqhWqbzUFtFBJz-_vySFy-EN-V7J_FXjVlmuFtwT7p_Fz-lNFm
+}
+
+AWSEntityColoring(Timestream)
+!define Timestream(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, Timestream, Timestream)
+!define Timestream(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, Timestream, Timestream)
+!define TimestreamParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, Timestream, Timestream)
+!define TimestreamParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, Timestream, Timestream)

--- a/awslib/Database/all.puml
+++ b/awslib/Database/all.puml
@@ -1,0 +1,325 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $Aurora [64x64/16z] {
+xPQ9acen24GRaa2W__zxtu9nrynzQstsZ9fBrIcAnOxvZ_NHH-IVyQCd_uGNH1uNbywF0m0w3w8PCKjHJvaq1MJm09tJck0iqU6drWdo23sagDR76BrhFVLW
+feq3k0lGB6xg3-y2Z4FpemCZI3vqm-IsTPinAlnL6ePWNkFn3W_eCxt6vpoV3Svt_Flyjk9X3TtUykYlwp_pd020u6jUgl_pqlzS_TVYIzxG_MtzQGe0sdeV
+lRVJ_4SOx53zoje_nLdInaoo-2FzNnLddDP_xV_Y6L8VUxxqyFLR_5nxjEMVTU4TZNkUMxv3DZW3yheuzk9J0ESkFtgIJtHQxGyD2iqTNyFEI-TO9rS0HeOW
+6eox-WS07JxZ50WV3K3hCB9XS4A26vun52KHMOS-gty3cbL3SZE_ifpHcug8QXjUvOIdhSmTBRcTFn_ghyE0B0jfqE26VnOPxO8pEyIJ1tcIEJlGWbUF1jIJ
+ZvFcY_tZ75q1iUHji07IkZtFtyZ7pGCW3xR6Q1N-sh-OqxjK-7OVowOyllIl6cQcAyHvctm4IRxqhwVxorWjCovSq88yw5ywlAOm0UF2H_A0VxbVxc_E4HDm
+9bCnUDY_UECV3Wcoe_Ft_8S3ZRur06ZkxZ_5L4o-vzlBrf0E19CEsHeeGzPYyuAkzRUAA7Rfrsf8inah4AVjK-SgGt8hSdOvkO-gBWTglefQ_hzLBL1lnOfe
+jvbSpEN-sUkf_XlroV__8tglZpxw3W
+}
+
+AWSEntityColoring(Aurora)
+!define Aurora(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, Aurora, Aurora)
+!define Aurora(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, Aurora, Aurora)
+!define AuroraParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, Aurora, Aurora)
+!define AuroraParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, Aurora, Aurora)
+
+sprite $DMSDatabaseMigrationWorkflow [64x64/16z] {
+pPO7kYCn28E7Zhd_VRSGJteiRr-zNdxYRn0MnnyIYvfxV9UR2jC-Ik8vwbdfibL3uiQErgr62A8vBs2OCX7rSOXOR5RDTGNj_p5-MrgxjW4yU74wNnSOLGgU
+JbNHn_9LVW1fbIpuGBnLwO8lHpZWQoXzD9Pc0RuLIk_WjW3WpQVpmbLuIjHFrdNDwq6MzK5fT0ZY-wWl0pJIjOs5-IbYKMlTJM_p0lY5uEldB_k7VjK_zhd2
+jd_uxQssunyRPxzCX9deqJzXq3-wy0yVlECV-Kt-qRRFZ_Z7Vj4_Wm3le7_9Ave2zpzaUNs3yryk3-LteLW5UPKy6nPksZAFivr3SV_uqmKqN3RxJsAHuuuS
+CUrput7-44yHp9_z_1kB_CFv6o30Vot_ILKVze-ZzR1_g2eldxz4BVQVdh4LZ_Ola5z9joUH7Y_x7myuVwiiqO7dp-YP9tVfviVU_8NG0z_Vpx68DMyw-nHL
+JdJqkrRDBWHJ9iXFpSS6titVsNamVwmn5kipvEUSXbzaVkSPT7xmFPh_03pbvlx8cVBAS-Byby-vQCW_hLHwnujt-QtzCLqVCpDZDAqmlzd7rJpPwf_FWq5-
+RYelchSQviy4yCYB8cvh6UJ1x_yeVp3J1zuM_mD5gdpyf_eA
+}
+
+AWSEntityColoring(DMSDatabaseMigrationWorkflow)
+!define DMSDatabaseMigrationWorkflow(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DMSDatabaseMigrationWorkflow, DMSDatabaseMigrationWorkflow)
+!define DMSDatabaseMigrationWorkflow(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DMSDatabaseMigrationWorkflow, DMSDatabaseMigrationWorkflow)
+!define DMSDatabaseMigrationWorkflowParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DMSDatabaseMigrationWorkflow, DMSDatabaseMigrationWorkflow)
+!define DMSDatabaseMigrationWorkflowParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DMSDatabaseMigrationWorkflow, DMSDatabaseMigrationWorkflow)
+
+sprite $Database [64x64/16z] {
+xPO3ekL0403RlFzzD_nuxhKg6bKqX5_5V_2y8h1DKG1wzwsdr8LVCpf_iF_Vxm-C_KL9L-45KS_g7lcTYW18n4oqXZHxuYkWUExVK9Kk23hm6QpUlteB6l2h
+VWTurmNj4FsYxv3NVeA_xbDqVx8xQE8Zi5UzrxupuCHF8m0IjGMLDMmvyhlIX13NN1BBuVUVLRzmXeR-1J_L__Rwb-eBlMJY0_dd_ky44pyOWDKZ5y9rZSN4
+hqvZX0Daoww9drkVpTWu8lFwwuC_h_wr-q9ldVZ0SNQW_HeC4zy8K3oo5Z9S4CWcVbK87daBA56p-j-htst1zmOmhxz-Orn_TOChVpv__9pvQpv_pkVl-VhX
+9wnV1bpu__qX5xvM3ebF_bVm_NmW_Xe8uGI_2lWR-08
+}
+
+AWSEntityColoring(Database)
+!define Database(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, Database, Database)
+!define Database(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, Database, Database)
+!define DatabaseParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, Database, Database)
+!define DatabaseParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, Database, Database)
+
+sprite $DatabaseMigrationService [64x64/16z] {
+xTLL0Ymf38NXG8JadFtlT-YQAzKEr-rxQVtB0Jpnpp_ytvUsgCgf2jiR8TAroGTD8y6TElebwsgJzYOYFS3Ll6QjKG0FG8MAQ15hkcXTdJB9LEbOmY56tf-J
+IdAf3t7Y3brYjPS0YHCI8Hkzz2Zm4rHqsUXTHQIRnvZ2zHARh_U3vLrEUXJ7JZyXH_WK8y5fgp_UV89fix_pZVlzvoVMUnaahf3PDdhH14-GjlFyM1TfwYDh
+oX7QHBhjNBzXJKwQ3Mm-FyZXffFvI7p1yyEJt-pvKH0tI5llHVDs_YoLzRuzchyt-Z7kruyH6psHSLw_F3Ul_ztwkTiVUDY_V_5Lup-br_tuhov9B35fKQSZ
+dogQ65QvY6XauL1vt7x7CfOtkMZJ_s-yY7KaCanxcxfQ9CYj6hW-_-DbDHzQl3yb7LpiJVA-Jx7Lte-Urd1vGJCUlM_sAdLvAT7DtkxwlUDFBzpsA4zktB-x
+7YJsLEAGXIz2NhtU--UV_m
+}
+
+AWSEntityColoring(DatabaseMigrationService)
+!define DatabaseMigrationService(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DatabaseMigrationService, DatabaseMigrationService)
+!define DatabaseMigrationService(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DatabaseMigrationService, DatabaseMigrationService)
+!define DatabaseMigrationServiceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DatabaseMigrationService, DatabaseMigrationService)
+!define DatabaseMigrationServiceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DatabaseMigrationService, DatabaseMigrationService)
+
+sprite $DenseComputeNodeResource2 [64x64/16z] {
+nPS7pkGW34Onnksx_u4tB4Y4FqgcUCkReleejcdbRqEBRtJ78kXZdN26l_5D1lgbBsLGapxdVKtwSChvY9Rn0u1cuYy0l7xW6w0ya1v_Za_cG8wVzKVs_Xmu
+i5FBWRoRXmR0AZCxO7pGTJ979phwf2imOqUdfSSuGyzJRsialdotWJ_uDO2evpJ8PHN8lTz-n8W2gE_xkdAqpu2QNtoD2oF07TqAoT3PVS8ZjAftSlN3ReZf
+KxEXUcku-hVrB00j6R0Ulwil3xvOp9vh0DpzHeFTRsQcF79axZBzATFS0BRwstn5HsVoWU4FUQLLwxrlz3iu15YbEdsXil2vXSY4o-RtB6lldcugh0BXUxnt
+N-15uUN67nEoSkitH37OhLzyJFgn_uJV_oGn_e3q3DUluXSoTfG0L8m-pjz1SE_5SK0VrW_LWpBWrke7zPjOFudrczW_qljNVl_Cxz_vyoDzVkNFp-pvdRm_
+9EulgVjJylwMl3_cxg_9-_F_lB_h_to_rF_pVZl3sVThylty5_W5
+}
+
+AWSEntityColoring(DenseComputeNodeResource2)
+!define DenseComputeNodeResource2(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DenseComputeNodeResource2, DenseComputeNodeResource2)
+!define DenseComputeNodeResource2(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DenseComputeNodeResource2, DenseComputeNodeResource2)
+!define DenseComputeNodeResource2Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DenseComputeNodeResource2, DenseComputeNodeResource2)
+!define DenseComputeNodeResource2Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DenseComputeNodeResource2, DenseComputeNodeResource2)
+
+sprite $DenseStorageNodeResource2 [64x64/16z] {
+nPU5qgim44QpMV_U_tr_IJE33RImLyv8zG2nbVQteOKdUc0XwRPEMCDFVDSNzj3N-RONVQxxLlGHLFEHKl4JW5NcNm54l-4xOFn20MwSTyP0WVt-8_zy39pO
+CfvSFrq70U2TcGDm_k5N9m_yah_ObMx0d3jQ7Jt66heUkYnF4eiV_Y8k_9v0zlKowE4KwBalkpcY1FhdlXtMQ8w090w-vG40o85jDf83sFk4IsZPlPEZdtv2
+Jf_4CGWH77rf9oX0YmpucB-3hnU-UiuxzmJurnTwiVN5tOt7kyZGwMFAD0F0Vlyjlk4N6qkLoCKVyi00w-U-qvYSX3RgquTIMuWPGdJ2RUEtvh2Ma7QompgG
+iPtlhQ-8vaWvyPlELJZp1JcEJlIZFuWnwClxDp80zCWt-1odFdh-XCxRwFtvInqHnLGCuFlh1o1vLXnsU_zG_s6yOP7URkpVmlafdDz2_AZ7hthyhCVlUlue
+vwzw_gpcxsBzKAXVIlLJiNuhre-r-hLOF__F-jt-P__I_q__jeQh_MknV_uBV0C
+}
+
+AWSEntityColoring(DenseStorageNodeResource2)
+!define DenseStorageNodeResource2(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DenseStorageNodeResource2, DenseStorageNodeResource2)
+!define DenseStorageNodeResource2(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DenseStorageNodeResource2, DenseStorageNodeResource2)
+!define DenseStorageNodeResource2Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DenseStorageNodeResource2, DenseStorageNodeResource2)
+!define DenseStorageNodeResource2Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DenseStorageNodeResource2, DenseStorageNodeResource2)
+
+sprite $DocumentDBwithMongoDBcompat [64x64/16z] {
+xTO5kkqm24NX3O4GsFEVx_jgLuurVMxhklodtbA_MV_x7zVUlxc8AwDRqwLcFRB82pfTiIOYM5DFSf9d0z0yHjPIZl3rDyaf7e16lMyrboeK24xm18Ay_pq3
+I9vxVxOO1dp2DumdFc4Jtj2ATH-hJNf85CbwZsI5OD8R81vPFAeCN_IappG18CtSkxkrzIVFclLa3L_KdgX7LcMFAixuROipnrAMxQUn23GvvTUufz0ZQ77Q
+7wcy8OCLlyARx04IlEu5xo-0pfVUoNkljPLGGUSh3qloYMV2XY3umYjWe_ZUPmy1x9NFBe0qxp56ZX5r-BKc8YUU5QPuAmv_e3prPEM8xcRcFNVFBeEcoNDV
+zMZx1Kb7d_Bt-vy5BGxuL_fo69dG-YhF00QB3NhY-vFb6vnL2Z_ny28VRpyvO3pn0kbPxy_Vz_qlnNw-_uS3KEiZiweow_0DWuPnll-pDxmNYh7wxCaHTUv9
+rkY-3W3DHjVDa-l7vVEFLOi_cl1t2KH4LRQkUrieeBAcdT_q_Bu-Ft1kVfYVNxvzVlhs-UtRvyVv-VLtxN__-m8
+}
+
+AWSEntityColoring(DocumentDBwithMongoDBcompat)
+!define DocumentDBwithMongoDBcompat(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DocumentDBwithMongoDBcompat, DocumentDBwithMongoDBcompat)
+!define DocumentDBwithMongoDBcompat(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DocumentDBwithMongoDBcompat, DocumentDBwithMongoDBcompat)
+!define DocumentDBwithMongoDBcompatParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DocumentDBwithMongoDBcompat, DocumentDBwithMongoDBcompat)
+!define DocumentDBwithMongoDBcompatParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DocumentDBwithMongoDBcompat, DocumentDBwithMongoDBcompat)
+
+sprite $DynamoDB [64x64/16z] {
+xPP7bkiu40IpOChb_Uyx3P8DIEE0xtQALHl5AqaCcFm3VFZ0RtvApGYtWSVz-pbCrofObAQHFBQr091IMrVLtkhu5TKETHEWghzzVXya1riTQF7-EiOBkK5W
+ZxnqmQBnVySxAlCTDfHwqyhUb_ZxU4ZoeS5tFiIIV1klyrT8vcu-K3IID_VuzUKsxlpc5O3KhkRkyJgU5RxtoLZv-HW_URw9ZQyzcM7QM-jlumr51niVS2Pl
+nlZfTzm4_wyVj_xsvUSap4o1dlyD5T2vNXc03EpvdLdGkUaVqYoIWoZ31lHsXjwuwxyBW38UODuK1AUUs_wPrWe0bDiAb6TwHTtt5_SZ3ZVx_aYTKsSUziyl
+LdLBF-XVkh_kFY8vQ2X3t_ORxUg_gPb_SILreg_-S_MFoWPZig74qW_wzsi1D4z1a1qIZ3DVPly3HtrqBxb7uAxlGUkjhwrnqsz_FQzO40fnEX07ljw7JQm5
+N1IuTFZoj_tBTNmP3NBfLHLr-fl-lJyFiB02C6OaxuwslZW7L__gAPUUIHgEV41d_qCQEideMFvv_rwCpB06oFBt_QCy_PlsMW183pdpv_wnADsJUUhtzjt_
+5whccMJceLzd_vCSB7_NZsl-4x8VznzpvfJJAoJui_UdNe0I_BNx6t_b_aZ-gVlh_lxyv_ZmuIy
+}
+
+AWSEntityColoring(DynamoDB)
+!define DynamoDB(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DynamoDB, DynamoDB)
+!define DynamoDB(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DynamoDB, DynamoDB)
+!define DynamoDBParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DynamoDB, DynamoDB)
+!define DynamoDBParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DynamoDB, DynamoDB)
+
+sprite $DynamoDBAttribute [64x64/16z] {
+xTTNSiOm201Xa2m1U__xfddqzqQK7kyhyxbNcKvlTNSioerSnBcHtl4X4lUzjSlvwhrTpePVv7AsUfFBBSCt6McjHH_rxSHhSrxpvLs-1YClUT-0w4jT3A1c
+VGMQoclQWPBp6h0SJZpd6pJPPr1JFWWvg81bl4ANmvp8-7fw4NRGdAyplaokNy5czbySLFPLw2c_WCa-XvBmgsWoCZ39-G9OaTUgGsZIImNmthi3KIJhfJWZ
+KybxaMe1H2yYMJzQtmbfVrZUkrqkLXzsEV-OzuzxNCr4BAxchlBDpM___FjxulpDNpzvl_dDRtxpcv_zVvh-Vvj_Vy_-lyx-Fq_t3
+}
+
+AWSEntityColoring(DynamoDBAttribute)
+!define DynamoDBAttribute(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DynamoDBAttribute, DynamoDBAttribute)
+!define DynamoDBAttribute(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DynamoDBAttribute, DynamoDBAttribute)
+!define DynamoDBAttributeParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DynamoDBAttribute, DynamoDBAttribute)
+!define DynamoDBAttributeParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DynamoDBAttribute, DynamoDBAttribute)
+
+sprite $DynamoDBAttributes [64x64/16z] {
+nPS5WWDH24F3V05o__kkpTQTL5vTNXN5nnbNw40VLm1Wl482oIlOK_nfEnRRuQllTfwvyGV-iHaP0nisFiupZlt6FtAf-SklwqccbNmdn-QYu1iP-2KPHNzi
+jABloliZoBRUFKj-8-aZI5h9n-1AGyr72p9zGTK7R37WKPzvdat-vNcUax_mAqnW-XK07Rl6pOTXl480yVhw5-CykVevpXCRlsE3zT7jtlZfn_5dpbzcDNw3
+AxFc3pAQzIHRoK-chMNOAxvjFdWmF-0Bdr_u_QJ_JuqVDNxb_D7pLwqVQlrIKUkt-Flf_Klldth_rkS7VNxHvoSZ_GFpep2_AlEpFh_h-uEyl-ZxqwVtFtL_
+_JZV
+}
+
+AWSEntityColoring(DynamoDBAttributes)
+!define DynamoDBAttributes(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DynamoDBAttributes, DynamoDBAttributes)
+!define DynamoDBAttributes(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DynamoDBAttributes, DynamoDBAttributes)
+!define DynamoDBAttributesParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DynamoDBAttributes, DynamoDBAttributes)
+!define DynamoDBAttributesParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DynamoDBAttributes, DynamoDBAttributes)
+
+sprite $DynamoDBGSI [64x64/16z] {
+xPS5he0m44IdNhZ_VRzqXmIt9K5VT99zwDQWnhHWRATfM56tC4Yj5E3gUSmXVWg5H3y8z6EO8ZM-Hy6BNqaoz2r6OJth2c7KTvWYhF0_toxxqHKYVKcUVd2Z
+iFxy_eLh0TXMCZ1k7Xn0Q06uLh8mOPvhZFzW2at_IBBqlPb2qNzN6Z_V-C-faDa_IQ2VqnJvcFxBkI8v6yII97fOfX5OVpBwvzUFNyN_k_Fu_SQlUlu-V_tM
+hfzQjFk7Kx-VTlzsxlZ_VEtvINr-Et_yQy_FQdu1
+}
+
+AWSEntityColoring(DynamoDBGSI)
+!define DynamoDBGSI(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DynamoDBGSI, DynamoDBGSI)
+!define DynamoDBGSI(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DynamoDBGSI, DynamoDBGSI)
+!define DynamoDBGSIParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DynamoDBGSI, DynamoDBGSI)
+!define DynamoDBGSIParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DynamoDBGSI, DynamoDBGSI)
+
+sprite $DynamoDBItem [64x64/16z] {
+xTS5hkL034JHQhHT-r_mM7eC0SlpELUipWbJ8rrPQtCOXIife5ofR7W3RDlBU9-Ul8xtoSLtl4zENl2-Vl5Zho-rjO9B8-YxafuELt5VbPUinNsZ9xtrQNGH
+zTNHB81NtB45lTulrKah8Tz8mQtX9kI5hBZBQ25lLDmtdGPy8UVphTSolYLz9slc-CLfn4-ouPORHSHN1my3x05_4e9B3XKnNynD0xmg96lGevehdNCglOQe
+Hn5Uqegmz-eqnoODYFjJfqz6sB_jvbNUPoTlyZxzFzyVLLjC0B75L0k-kEJ-vyvV_lhbxv-uF_pX3t_umsVdJ-dvM_xxdPs_PkVFwVu1
+}
+
+AWSEntityColoring(DynamoDBItem)
+!define DynamoDBItem(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DynamoDBItem, DynamoDBItem)
+!define DynamoDBItem(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DynamoDBItem, DynamoDBItem)
+!define DynamoDBItemParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DynamoDBItem, DynamoDBItem)
+!define DynamoDBItemParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DynamoDBItem, DynamoDBItem)
+
+sprite $DynamoDBItems [64x64/16z] {
+nPS5OYjH30FbXxRkVzyFNIfi0rPWmZ118zvElq03Mhy00EC50WXUm1xY3pjdBlwqWs87O_CxpjbyR7GF7xRVkjClmGzgphSWOmR9al8xERUBZE-CzPAMyOFp
+q8Jtdqb_B4-ifET-VvBU9ycQyb6vq97pKMQGNf7r0Ii6_F0Pvt3nVtluCVcBUO41Z7a1GCSkSVNXoz_V0Nz-_VD-JYn-z7DyyzkjyMEjDyD6kpV-1lypBHc_
+WmkUyoiPpQgJFUNFfV1QC59-qBUlOQglVtxzzzF_FpL-rFYLyqVFNxL-gFLBHQtVqk-dzY-XVshzMvqVvFb5dP-a-UtDywEJfi_F-lokxm_o_gBlJ-_U_zJz
+zUty1G
+}
+
+AWSEntityColoring(DynamoDBItems)
+!define DynamoDBItems(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DynamoDBItems, DynamoDBItems)
+!define DynamoDBItems(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DynamoDBItems, DynamoDBItems)
+!define DynamoDBItemsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DynamoDBItems, DynamoDBItems)
+!define DynamoDBItemsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DynamoDBItems, DynamoDBItems)
+
+sprite $DynamoDBTable [64x64/16z] {
+xPT50eH030HxFF3__wu5lMMsSQWJLdWCD6vAjswYExoT4f3Q2jmYVabAxlnae_H-XE8xty54xFq49TJvQUu_ll_Jpq59dH-3YTpv-_w_25C05oh00gGf3ZvL
+S8puJqw9dU-TYOl4p-DBKQJpYmrPvlyJQGR48qfZHSHXP_Zxv-EN_NvF_9pKf_Ft_lMRhPyiRF-mw_jZ-pUcVtpYZ_VP-OcUt_QFVtP-fda3
+}
+
+AWSEntityColoring(DynamoDBTable)
+!define DynamoDBTable(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DynamoDBTable, DynamoDBTable)
+!define DynamoDBTable(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DynamoDBTable, DynamoDBTable)
+!define DynamoDBTableParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DynamoDBTable, DynamoDBTable)
+!define DynamoDBTableParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DynamoDBTable, DynamoDBTable)
+
+sprite $ElastiCache [64x64/16z] {
+xTC7agim381XMSLgzx_l4tQ62M_CnapVyc-bV0cOA7v4V_sL3rfvj-ryvGcsevL7ODcA0TU-QMvaRUrD05nnH4uuqdC7uwWxWDXw_Jjq1cYj0UZhB_-_Wpf8
+PgnA1M6miPGwriY0vmu67HVjXzSr7up1CtBuZFJXCvBF7MI0dWkS0a197tqIWEJw-SNLHwYPHbnzoDtpYtnv1ZVFZ5UPjNdwZ5iVqrSPAeGDgeOa6cFlyF7P
+fn5CMZKu8ijzBqL5FLwv2WB8ha-5ff7lzv-X29gRNg1FVFrmofQtA0_YHQg87Bb0-R3F7h1yXQBc7k5ku_OFJ_39An6Nruvm2RkMPwB-bS-PW6MuTYQiYBjw
+f9MVtNldIgRFo_rFtxaIRtTUeSBfhqsFSAHttZkmcPKdpymtdEbKtYg6VkTdS_rPlTWiNFcr_hELpqupBayD01gnLFpQA2yqwxbwWJC12sKiDcl86bR-BBxg
+yECSjv6FrpvyR7Mk__kxFV7h-Tdtv_oSXGiyyHLoDw_E-Tdtw_bvk7vkdOaGwPoVPpulFVVN7lc-df-UiHcjveTYjum-HWQ9Zt1iI6Hibs7oFZ-Y-_gyvND-
+niR3BlFpG_lhhty
+}
+
+AWSEntityColoring(ElastiCache)
+!define ElastiCache(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, ElastiCache, ElastiCache)
+!define ElastiCache(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, ElastiCache, ElastiCache)
+!define ElastiCacheParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, ElastiCache, ElastiCache)
+!define ElastiCacheParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, ElastiCache, ElastiCache)
+
+sprite $ElastiCacheCacheNode [64x64/16z] {
+xPVLOaCn24093l__mIlKlVVEjvoNw8bNW8zYB0BE8OjSH1WTxM6v0XjxtJFJLHQWhGneBDCH5eAUQPsZ7caflMhQJO-m0jmj8D9X5PvHwyZKTRvcZlPbdIyt
+V1BbRcCe1giWe8og8XXIu7tVCYEnpwOKZ8nmaAeQgLKT4NJNvyhsND5tur4YyD7dX-lts6VKjLRHBI_x8ssVGOtsZZwyuYli1A2D8mVVDxGV4VhSDuUHSkAR
+ghPl8lHy_H5cwIV-U67zxK51DP_dlllhvo-L7I3PWn34mli3ouZayDrc-lt4Y--d8LKUZ9qbW24g1ADdhLeknXr_0T_eJt_wqv_-zAS__VV-Vtxd__VtnW_l
+ZL_U6J-zDtvxP_putlZr_V7p-ta3
+}
+
+AWSEntityColoring(ElastiCacheCacheNode)
+!define ElastiCacheCacheNode(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, ElastiCacheCacheNode, ElastiCacheCacheNode)
+!define ElastiCacheCacheNode(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, ElastiCacheCacheNode, ElastiCacheCacheNode)
+!define ElastiCacheCacheNodeParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, ElastiCacheCacheNode, ElastiCacheCacheNode)
+!define ElastiCacheCacheNodeParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, ElastiCacheCacheNode, ElastiCacheCacheNode)
+
+sprite $ElastiCacheForMemcached [64x64/16z] {
+xTO7RlGu38PXacBJT_y3RoJ2YjSOnLEsx_-cSG8ya0rN-j_77qH4XWyoei07nVHXRnM7xqflf7tusdybajLpiwBsdsHCtB3IpTpECtN0X6O6DCNApxDXPUUv
+pSKh1ap7prTMVitsFTjvLa0EBu2kpzFNpENvM6FDvTlX0v1bdlG2vFmWqO6aL_qyxY5r_dNUUTjwpdN-ETD3JypryyWJ6SftejzxLgL2ivfLvUAfF_3ateX8
+pBDtp7fFdwTASx_nbGOU54hLZRTZsGntC_V8upzsxpddMYPCfrXgcvBlV8nbobvYxK3U-3gjDd40yhDlWDCs0zhj-d3UBE_uqJSk3yGOBxW5K9xROm_Oy5M6
+QPDPKui4gaOA_EYr9HwMgdjFvkvjUY9MpujrPQ8slBYxqTLNvIjkJTLCjJMXMVdgucN6vNULPwduv0CpUyOhgixVFWzVXsQNdZtaxBj-9SFN1aIcB-VrGJ6y
+w2Y-FTo1xkxMwlYdrHO9LL9tkaHv7oKGA7zqEd-OSfegQexoTW91fFtYpNlMOf2rF8AekTN-h-h1pQiw_ZI6B3IA6jVnvnLTApzAz5YNf9_zfQrFAPNeyexl
+v80Ce_oqRsS_MGtbzHdVvV3aW05wUEctlevLApySnj_o3Zpd0Pw-Y1u-d_EHIABo7EbqU4r_nYj9Ax_YDuxVt-oZvydtxYzwOZh7zAI_VtxkU_RvlM-zF-Zs
+_U6cs_UN-xZMkfRAz6pShkzlZUdrU4RxVlKR
+}
+
+AWSEntityColoring(ElastiCacheForMemcached)
+!define ElastiCacheForMemcached(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, ElastiCacheForMemcached, ElastiCacheForMemcached)
+!define ElastiCacheForMemcached(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, ElastiCacheForMemcached, ElastiCacheForMemcached)
+!define ElastiCacheForMemcachedParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, ElastiCacheForMemcached, ElastiCacheForMemcached)
+!define ElastiCacheForMemcachedParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, ElastiCacheForMemcached, ElastiCacheForMemcached)
+
+sprite $ElastiCacheForRedis [64x64/16z] {
+xTK7Zkiu48JXZcIpxd_WbKkcQ0Xo7EHz_wHs-40FGK7olq__qCOJVoX5ElvGf-_vKttwaV93CUZp_d_OqMTpt9tORLB7KJoP_N4M06720eZ0KNkSSytvE3iN
+trCWu_QpbVHhpZNduno0JUz078_fzrbthtEDDTFxNBu0M-Ophq0f5o-UWsyzprsvx7_rcS-dNhakVOfSUb7bpwKdeHzoyXeXJ9cm23jv6MVFWQV2ijKOO6DK
+IpuP8UyyvuwBEl5xdtFPwgrbjjPhFfFllHRNIbDvI6t_JANlF2zdbOiq1b1ll76D9sa7xBLteCdJ4l2twwFfjTQ6bpvTwO7kUiRg7Q1NZsiF93shdk76FB8N
+xlbyvydxuSCBbrN4uUFinTnTwKKqMfri2-KYBkfRSl8p-ZrrZyYCS3TXksSdRybi-SleBVVymHTOVk8Jz_J2Ev3F_R5_pARNpPTjgJZtbdcDMzLzSUwVtMhB
+Omm0Ool4kDbfVFUiSsUpG1zZYmAxNwtpC-BcApCRU4dem_cPqLjVSVtM1W3wDa-MYWoCbZVlVMLoYlkltieEBuENLhZk-_yoUhPyqM_zvXM0_kQxgbhdDdte
+7SZ3puQkfzxxOIVV9hVnYGUwttrvj7KUE_21PwFxtB-nVtmTm6U-5xPoUhzl7u3gd_ZaKL_dvuvQio_sN-Nm1jGt-v_dyzU0_CMFiOzQe_HxBwgdwPr_U_-i
+jrxg-VqxUVz-anQsAbtb8VNayyFaNTgmDwhttbhhlSQw4Zv8it1HfSgdgITNFJv9kihNgTgMlf3_-Wy
+}
+
+AWSEntityColoring(ElastiCacheForRedis)
+!define ElastiCacheForRedis(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, ElastiCacheForRedis, ElastiCacheForRedis)
+!define ElastiCacheForRedis(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, ElastiCacheForRedis, ElastiCacheForRedis)
+!define ElastiCacheForRedisParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, ElastiCacheForRedis, ElastiCacheForRedis)
+!define ElastiCacheForRedisParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, ElastiCacheForRedis, ElastiCacheForRedis)
+
+sprite $Neptune [64x64/16z] {
+xPQ7ZiCm34CfoRO6__zxRpZDxKmSTjcPyLn89bZLF-kff_YXMsnb-5Ja-_4bkAARu4EYpPCyYsSN06AjZpVrPWe0BNWETm7Cyslz6Ls0LZo13w0doP_jS86T
+m1E8Fqjb6GOFUKVdvj9sXczRl9_ZqV_QRjBb90yT-TLsytiOS8xl3O2Do7bSLHcZ2Q1-ZlU7WI2Yxrg-crUTuyTqZ3TxaA9jH97Ci_nQSrNcv_TlFBdFh-AV
+-y_Av2P_w1-c0NQVBuCg6Y_wjsJXcL2MIFtDI_9FkXXzvQKIMpp4VxUNeMWV1mq2TFxDwpHmyOkgIY7mbL28Z4t_JQkBTOyf7qqx1RfsbWEjYZl-os62hseS
+07H2J22vwp-I5JvwUrTV4Zp2bWNOPkb7_kDNpUCoM5THQDKXlv60W01sdUTywx2iL0nUurbPhEavFknNLqAo2pGgnWCKEShFN-Tq5exrzu_oixxbfo7O83RQ
+HlrR-KcI2pzVB0NqgF_EUEIdgfcgbWC2NJindS_vtCxF64q5K-8S0akcD3Ac-HWg_JW_yqthxY_vorXoHm44Z_QVv9U3oUSxpuGOdDVpZmwD6W90yyR_TmS0
+1Rfxylhy410VW0R96_CBEvppxURyD32s-UFvZGdq3adUd1_fYw5kpw_CsVZxy_Cy_5SzzTGh
+}
+
+AWSEntityColoring(Neptune)
+!define Neptune(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, Neptune, Neptune)
+!define Neptune(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, Neptune, Neptune)
+!define NeptuneParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, Neptune, Neptune)
+!define NeptuneParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, Neptune, Neptune)
+
+sprite $QLDB [64x64/16z] {
+xPO5ZiGm34M_CU3xttVhTg8ETPLg6Rxe3RnYOhl_glpdFt6Tyt9lnKr5HCrhoozEsBqe0I1UGabijSUqNWYafIMdrAeBWMjC-Wgf_Ugc8xaGF6RiC7Z4atjI
+p5q1QJn_AAHlz6NEX_TuiFFw9tq2btwrQXAR4sZIzyeWoLMpfLKJG9hC-j6hCPPG9e6jHPpmS_tMNC2gvcLR3MVy9G_RvvJ_cBVxFEbRF9I05KkvuCY1psFv
+k5f6hUrOhp2U-v2rN8I1ja0S0_aAZyuFM5OSfTvAAJMCTwGhFF2zAK3QbHjXYQS_a6oW7_fPBfGNlw2snc8Wsd5y-ug_xhT8VrssHKHNv4HRKLxrbwJl5vzv
+-8dpVW6BG0r4TKC7ZMyd_70HqPxFRo3Pm4FVXW_pDSmxaWsK8vzQh7vbkiJRCxIZzKTbMu3NlN37_TkZ-YiWgocDz6erGdLs_rO1m6gUCMK0VgP-hMSK9cI8
+nUh9-Z5kkRKs-ElhbyYR--TR-_SRvuStpYzld9_UDh-zRNxypVdFVru
+}
+
+AWSEntityColoring(QLDB)
+!define QLDB(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, QLDB, QLDB)
+!define QLDB(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, QLDB, QLDB)
+!define QLDBParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, QLDB, QLDB)
+!define QLDBParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, QLDB, QLDB)
+
+sprite $RDS [64x64/16z] {
+xPO7SiCm30IF3Ut-_zx4DcMBcH6Keapt9kvSi84b_eStRxZnrn8g4uyCtJYChTYm93uD6yh45psht-N6EFDRVDV_QBal3IqO9zpr9fcliGV8zT2qVku1SfsI
+-xD4njJF_3WBm7xNi_eZp6SRXLlv5yyQUZ0YNFqu_lfAXgcCteUe1RVlbWBdK5l1YzADyIiwKDfGDLCTzr1ZgJzdAqD5jRN_Mg4CT_8xstinKj2S2zuWP4Et
+qmXyj5llFj14pM-OZWP06AC0tPdhLb1aJd6hMAXj9eUKU_XCLs048sQAk8xUQcrzgC_aYc0CG9Xk3pFszByWJukQRZ1rwjCNBeLsVyvDKdrbl7oCVGB3-j9g
+jiC6K35M7oYrZnkz5c3r1VgzBqi2bwQo-EFOTvJWKWN3pLJD_6l_e-0m1pZGWhk_7XUxJtPqnY7r6U0uVvyPMkCOUaNHcDK1TRpojsxZnz22ccNmpAug3xyV
+v6z81Vhf1cqDKExvUsFFtmeqOvn1sl0aVpdsvPj3flj7a7_Ulthy2jflzizy_xwHxDyNpW-Bk71-NJy_BvxVb-yFL-ylr-vFr-vlAjE_Vd_y_VtLPQANxy__
+mvitdm
+}
+
+AWSEntityColoring(RDS)
+!define RDS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, RDS, RDS)
+!define RDS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, RDS, RDS)
+!define RDSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, RDS, RDS)
+!define RDSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, RDS, RDS)
+
+sprite $RDSonVMware [64x64/16z] {
+xTG5Sjr048JXdeM1xlkVDw29vO0aGwNOd-7Xlrkp3_X_VFcYziR3ufrenMiPX-Gr1PgBLpHmiAVUmxt4I-4Uwur-yd7-jCVU9oR5Eqh0nqCVx0KUSZtrhcE1
+fvpF_Vq2gYFd06zK52dEK0SdjlKpPmJlw5VO_ofyhxLtv9yFYE_X0oTRARvNxpA1iJqoCtmP47hdpc8KbHYb4ns3uaxfpTeDBYMma-owOlxi0vYfvpm7iF9d
+_zEOSyrXnrNsaIoATtgBagZ4ZcKusDXfrgFPCSZZ6qnzRKjaLLPHuj6JuiJWhO4GUVQl2EEvWEjs-wdpAbOKZvRbuznLXV7q_Z_xddpEy_nUcDttwxNVkRg4
+pJw_jtgMeSxvlS-lplDhsht95Jb6YTqllJg7bW9Mufq52whd7vuyL6uxUeaB2F7U1aOSlVK13Zkk77rjWwNuG3dHx_zTFeVzD5QKMNyzRugFn5nvz99uK9-V
+QkmItwIUtxoenboOweVUIGvWpBrzhsd0AFs1Rr7j0JIRGJ5QU_Z-r7czCYCYUuv0Qw6BEbUAAjjYargiKc3vYtNT1rmgG_SdRS0ouABwDsxxVtDnmHOmuHmp
+BEQWt_LnvgycHYaCS68uVE2-trVvfAWQSAsTC_Uwxt6-xKvc54anI8cYf8T-_f3wis_YYxi-qUAovrFVgf6VxDN-wlMFwFvTpFnliJxG3rnvVvznXU-cI_m_
+ldpv3W
+}
+
+AWSEntityColoring(RDSonVMware)
+!define RDSonVMware(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, RDSonVMware, RDSonVMware)
+!define RDSonVMware(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, RDSonVMware, RDSonVMware)
+!define RDSonVMwareParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, RDSonVMware, RDSonVMware)
+!define RDSonVMwareParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, RDSonVMware, RDSonVMware)
+
+sprite $Timestream [64x64/16z] {
+xTO5akGm38LXWILBUlU_xpgfPWYiQmhx7sZymk3watxz0l3VSCWSNPwVmnNUX6cDfNaKS5nd6rJKl8_SL8Yu1N2CPrk-NOLRLM5CcZZ4cRs0jpNgp87QJ_Zp
+V532-nf17Ly_2ipuVippnoqD11_qr1B0CqOQ7VJXJEfHzR3xN8aiZlb4BLydqMQZfa94ueKyvWEN0rY5HwBD8u4J_du2FJmxuz-QypZbtm_VrZ4rVpOiLLwk
+Hy8S-EeLUFLk8g895naGHhJXIHDuyQwjaHYf39cywOsfHU6sst1P_i4CfHJC6LlRhuo9rNjcZJ8NltxaA9In9B2v_L1XGjSusLQ0fMHkiUFNhrP6zr6FOiz0
+eTk8EPMwvVv51jU6RnHmuf4CgKI1K_j_a2xjUZ3AfiyF7gNKKOZLkLcUFFwwAGM2A02OexvxV_VUgPMIaoYP6PDjUEh0g_TMA2MfKcOcaWqlfF5yuxuSFsM5
+MX8fVFVPcSHw5Yuj_gaiR9__lJ4HYxQHQZ6hFAQQsBj-PhUsAcrb-jAU7s5jVRmyHqhWqbzUFtFBJz-_vySFy-EN-V7J_FXjVlmuFtwT7p_Fz-lNFm
+}
+
+AWSEntityColoring(Timestream)
+!define Timestream(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, Timestream, Timestream)
+!define Timestream(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, Timestream, Timestream)
+!define TimestreamParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, Timestream, Timestream)
+!define TimestreamParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, Timestream, Timestream)
+

--- a/awslib/DeveloperTools/Cloud9.puml
+++ b/awslib/DeveloperTools/Cloud9.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Cloud9 [64x64/16z] {
+xPH5bkmm40HJM13tF--78RVbvZTBnzhniiZAN-RavEI4JzwLmqPhVLZoZXvTNvIHlAoRLBf5X7MfE2_gKvh99z6boMlfbv5Wal5AxvAJ6xWKGC9JVjTWxQV5
+QBKxJyMNNAdwf3ypl5qyyBcF4M55WuT-k-YU3FSaiq-0A0eU-LMnzT8aLVyU7UFXAicgJIzgSsphmDK2xjbMzPFFK0DCZMsrQivjlKdDBiO-sNVaeqeZRz5K
+7Ivy8vE-JHJIYZgtLbUJtIewmDZTBr5ltVEo7apgPht8bdkkkMERxdguHL8jSfOJ2V80TZWlmYsoBfzl3Qt-yJg0K3tCoPxC1-YQtF3lzuztSsjh_BRGbNfy
+E2IrMEApb5iFLytTjs5pUgvD3NLktb_mW1mgmSq3LhUuWuzozq6VHO_eSVyF7kqEVGRaFNX4_Wud9oSdVm4
+}
+
+AWSEntityColoring(Cloud9)
+!define Cloud9(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, Cloud9, Cloud9)
+!define Cloud9(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, Cloud9, Cloud9)
+!define Cloud9Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, Cloud9, Cloud9)
+!define Cloud9Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, Cloud9, Cloud9)

--- a/awslib/DeveloperTools/CodeBuild.puml
+++ b/awslib/DeveloperTools/CodeBuild.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CodeBuild [64x64/16z] {
+xPK7hkCm34I7gjJC_U-x4OKO3ZOklw7cfRW-aQ0QVuKF7pJXz-aFXYxW4MfuOFMSHXtxfU6ID7JeToBr1nb0zXvu0s3DrqK1p7NYPua5Le12JToGyvGc3SX0
+qvdlQUQu_iKALAv_gG9TFSuF_VKuia0VA_BAObJOcES9cJhmTrrWc9GQP4nod9Ueue5_a_xEjnGHVPBWhoJqtHN_GsuFa0nL3nAe5p9uFGmTPHWAmtz16KEy
+G0D58-hxVL_CIFo-pnY1zh_FcpvZs1btY6veb6xvfChEbqPBQsGDwOwlRfilUG6G-wWs3vIkV7LW-H9xNe6rFp_rOvv5_TMB0R1IIr1BMjFWrAymr_8JtZDq
+x6VOqERxy2VFiv5F_9nZSZvzepQsqtBY0vdYpfz8yvcrPPtxXUAhBzOMLMs3-hglaM4KpTmYjw_blzO-gg76nDBoxzSlhHODOytCSx-em5px-42JEhAe1hZ2
+lpb-ZAi19RXOW7OPFwBqVVtTcYDH3URQ-PVpP_chP5ra3U_AZuXxdng8asLT-rJPV4rOcZOk_IZKyk5loET-TBDzU_vgfEVwhLxVqkxk7phWnFTj__ew6cl_
+9B_j0rsJR_kvjubzqzymVeU-uVmEqWR_dWyV_W4
+}
+
+AWSEntityColoring(CodeBuild)
+!define CodeBuild(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, CodeBuild, CodeBuild)
+!define CodeBuild(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, CodeBuild, CodeBuild)
+!define CodeBuildParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, CodeBuild, CodeBuild)
+!define CodeBuildParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, CodeBuild, CodeBuild)

--- a/awslib/DeveloperTools/CodeCommit.puml
+++ b/awslib/DeveloperTools/CodeCommit.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CodeCommit [64x64/16z] {
+xPHNOkim30INdTYv_tbVYfGUEWfVFZq_RXXB0h7mNt7d3e3t8SO8l4sJfEvDg4gj9NNsz50A22LlmL33fchol_upU_S_bJpQ8zs_XARKgjITz4ImStwfy-JN
+EVQEm3pxHnEfwJloiiCfOrjvI8Ebhx7s_Umpj2oY_-ItRaQQFB7ZWusPhRPWmp_Bz4HdpsSezTcboPvVD82kkkSxfMCYokzyV98LcFaB7m-boMjL2KVMkEhZ
+8adL9rdAKl4hSDilogDdjRFCBIdryxtDh9CRFbFP44d1nnl5urYF0sxuG_tSFnzz8ciUYx5srlwvlyeddo6LC4qzfCxI3sd2KFhGQDgJX9qKJAcpx5-NIfO6
+7_ogR7mC8bCQAz_q9EMttyx2eXmuQuBRBTyuPUC33iUuAdkgG1IbmQNvXUZv61vSA-LeHGckxOzP9LNpsjld7uRnJ_vvQQKMu0FgiKUua5-YIYh3uF19pvVp
+EyzBVoZaUdwJkc5TkFQF_9uBQyC_yxlfd_brKh3Xh_FxaGlvtV3N-Vs6SJs_fNr3kPxV1SlyHXY_CHPu1VWzBF3VSEVE0m
+}
+
+AWSEntityColoring(CodeCommit)
+!define CodeCommit(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, CodeCommit, CodeCommit)
+!define CodeCommit(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, CodeCommit, CodeCommit)
+!define CodeCommitParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, CodeCommit, CodeCommit)
+!define CodeCommitParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, CodeCommit, CodeCommit)

--- a/awslib/DeveloperTools/CodeDeploy.puml
+++ b/awslib/DeveloperTools/CodeDeploy.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CodeDeploy [64x64/16z] {
+xPNRqiGe28GR5H3w_TztAyQ9_qLI4xTsx-Rx3mEZ3KsE-J_numSd_rARqTtTUunaKnrM1HEf5ZiLcBqUCW5KpqzKJxwL7-fY4O9ETaY45Q1qlckkGF4a6uoP
+D3IUZbhoXRn2B9aCb1mK19DqGGb-aqUPkwYZ_JGmAZV8bmBCWZfT2iw02JaNgLyBr8-S7PKvO4Nd6IbACXzOwyl-740_OKDxrezpjPfUOQ1opUTyTW-x5aNo
+OiNiAFa0_REsUYulApO-w2kSgqzR-eREhmOOaEHWU35-CjgHpEmy6pUCNU6grfCqEBERcWVfK3BSL7sTZSMQh69Gd8fkWa6D3is6WMWy3I27Kjsj0jfGW6hk
+LW154OXwTvKZV1WVuic3Niw-8qd3WPvBmqVdZTxNzum2bEHQkMOc6-3t-ig_Pdnb1icLrISzzDh5WlXRhLmnNMxrcIRh6KNzsz_HPZBcrxo5KIyBz6lYlyNe
+iySjdClBykGQHcU36vOzuzZgUU7wkGzaJVLaOVfZJbR2_k89p6GMkQE-V8ynW1iv4FaA1khAugCgEthEIP8gdIFRrRCNPwOWFBclfm5A6jHHazlw1jYSkg0c
+D_K1AC-RagF0ffuE-FcmP5R8_lmEz439-UBUrIUzPeEH5PhCRNqo0vAPuIFRrYSLUXRQrmz2anSx-k9su6uBsT3V8laMjpjwleNtv7_CZn__
+}
+
+AWSEntityColoring(CodeDeploy)
+!define CodeDeploy(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, CodeDeploy, CodeDeploy)
+!define CodeDeploy(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, CodeDeploy, CodeDeploy)
+!define CodeDeployParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, CodeDeploy, CodeDeploy)
+!define CodeDeployParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, CodeDeploy, CodeDeploy)

--- a/awslib/DeveloperTools/CodePipeline.puml
+++ b/awslib/DeveloperTools/CodePipeline.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CodePipeline [64x64/16z] {
+xTO5sjmm38JXaK6sPkv_tbByF-s2DqgPlcLumyJlrl_-fqJSfXY9GZlkXaJcsd2W-MaDS3tZ0Kmbca3eYHzeOY8rZEVUSzv_J__V3zr4lZtVDdQ-zfkeqRj_
+UhwfxlnjHhMtvzksuu_vHK76UhvjC_w0XHA58PvugiDydEQ6BZwj8rNd9eLxHVLDwySGTwsLkslzU77ZaZQRQD97V9ilHdsDFvGcgdZPYyr295KnQ8swvCMA
+Jru1OnHKwe8N2yen-WwNM552QQyrmeyPGXGRR2hh-O5BDoSLDHZJliF6mIgcI6eQUjxB0J-MNbcJ0LVQ7w2JwWVem13JVatmr5fw4pR5IvwAyNdf-HGlUafa
+mOBwgkr_ed1rtQ_f_YOlyHlywhhVbVDj-ARHplt0ouPuqdZPjrv2ytlsl_-z1m
+}
+
+AWSEntityColoring(CodePipeline)
+!define CodePipeline(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, CodePipeline, CodePipeline)
+!define CodePipeline(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, CodePipeline, CodePipeline)
+!define CodePipelineParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, CodePipeline, CodePipeline)
+!define CodePipelineParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, CodePipeline, CodePipeline)

--- a/awslib/DeveloperTools/CodeStar.puml
+++ b/awslib/DeveloperTools/CodeStar.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CodeStar [64x64/16z] {
+xLQ7akmW39CBnUZ-_tjV266kiJdsjMchhHx65fRBfFrBlF023_o1Twkb17_RFHG7Cd_NNM0voVC1Hivq9B97YSDuXjP7pYBTZGc5BVRr3eKK3ly3p2XlZk2s
+tW4u3rEx4sdGOZl-3CC15_Xf5cXjBQ5ZYr-XNMya3ji10IGYgSRFz1dUfTTthcAYAJPxa2D9blU2izllndqWAiwVYiIbEjczt3G27MNMUt5Q10VqiOwiaDfQ
+XYpPWHJLOJS99404g5oUPHwmSRe6YubuS5tRDiHTYlDTRmvMYSkS_dlJo9PRXs14clTlD_Sd-QwMTXvcf6Q5x_hPO_qOgVAzLXOdVLHW1AW_r2yB_3fBG2Px
+iaxMRep-CHZvIFeUV6ez8erYTUB28IuqSdk055tYmIH8tH5wMSuPU6Ip0ccm79mkLp-p0FxUuPBlbxNK6I2YDpA75hF3H_mb35OZ0TSDAjCeeLOkIhmO7kE1
+VFKdsOjtzT86hgdj4hzl8ouwUzU_nST1OhZ8wCIz-tzcOnsJVJTx1f_wVOSWjrPb3Czj_TQxgpEFVhuPsUA-hY_JHGozNS0TAxsPXxW1soic6Kd5ohG3sgFv
+pl89qHmXfzx-OR6chD0Dxi29r5fL33KTuZXWmHr_AmhZ662UKuTWb58Rj_ZzRMvPaMkRQUm_oKNCUdV_gtc3RHTi34WdJF0vZC-1kUjjMD3k1bWkwtrClV_t
+a_C-NdZX5m
+}
+
+AWSEntityColoring(CodeStar)
+!define CodeStar(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, CodeStar, CodeStar)
+!define CodeStar(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, CodeStar, CodeStar)
+!define CodeStarParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, CodeStar, CodeStar)
+!define CodeStarParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, CodeStar, CodeStar)

--- a/awslib/DeveloperTools/CommandLineInterface.puml
+++ b/awslib/DeveloperTools/CommandLineInterface.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CommandLineInterface [64x64/16z] {
+xTO5heGm58NXMxl6_jVxNCOEEQ6HaVw1-8VJDf-YrIe6NTpoAdHwstSt8k_8QqPyRbyxJh4l9OTOI3leUqzj7cqSyriIRT3NHbMHPqD-1DL0NfDAdzt7dDTY
+Srx4PdmQE03XmG5O3mv0UtW0tkC3y1uVWFSvfCnuAw9JzmyuuG6d_J_tquBq_pohdEIa_-Uf_QJWFBvtqW_0MP_-WEFdydZz5FbRxAwVK9Q_zPtvFmRAypS3
+wyV7RBLw1m
+}
+
+AWSEntityColoring(CommandLineInterface)
+!define CommandLineInterface(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, CommandLineInterface, CommandLineInterface)
+!define CommandLineInterface(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, CommandLineInterface, CommandLineInterface)
+!define CommandLineInterfaceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, CommandLineInterface, CommandLineInterface)
+!define CommandLineInterfaceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, CommandLineInterface, CommandLineInterface)

--- a/awslib/DeveloperTools/DeveloperTools.puml
+++ b/awslib/DeveloperTools/DeveloperTools.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DeveloperTools [64x64/16z] {
+xTO7qgim40DWQS7WbUv_tpS49napPUVzlIczVAA3yLdv2--lnBBzRneGJx_vVwEBr__5-JNzdxTbwngFfz8xbsXfNtGB8BRQEycLMBgdcINMlI5gxuLfRSGg
+FSD8Pp1TUd6rP6rupe4RqaaU7PkBwQ-ylPmz8spMoH7bycFte-VvrOQ3io6hzR_4xQK_5i0TknioWxdNlcEpBKN8uukGam3JA-lzPmLRFqIaxrpErjA9vifB
+-qf4dWM3IxQjOBhsjZfvAz23g_T6Tglou-UpWBpp1U2QLk7dWWwaVV8zPQlsSm4ZyyRxmAM_5X3i1vV-qtU2gS0M6Fn_l3kYay5k1V9__TZhRbEsuZ_dV_1n
+CCq5jRSUkmqNpGMrjnenk7TC1RKVvxhzkTTD1RKN8stVUUzJGUdTaDRMqYUthmNr-JC3O9vSkXHK7hl8J3JtS-FD1UdADp9z-1rfNGguL3x0SQreb7GfQ2pN
+NmmkhhuKM17r_ZVuyJJjpsE3b5w1jezptLIm1NQhzetpkMuK16DK5jxAbAqv7e_QI_O7Zt_-_Fzczatvd-cJVq7UpYEMboI8U_YYu2Va7m
+}
+
+AWSEntityColoring(DeveloperTools)
+!define DeveloperTools(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DeveloperTools, DeveloperTools)
+!define DeveloperTools(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DeveloperTools, DeveloperTools)
+!define DeveloperToolsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DeveloperTools, DeveloperTools)
+!define DeveloperToolsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DeveloperTools, DeveloperTools)

--- a/awslib/DeveloperTools/ToolsAndSDKs.puml
+++ b/awslib/DeveloperTools/ToolsAndSDKs.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ToolsAndSDKs [64x64/16z] {
+xPPdbiCm28H5hChS_xmflF0KVgZWxONTT7ss6D5uRF_sRy2RQCwPSPf6kOHmAS0vkXqXn1Z2qG0_pkb-xmhK-nuIm-qu1SeCytRN-atjLdRn9aw_B8T8qR3l
+k1MTWR8d0xXORwqYXR5sF3OCt58Pfew_hW3CXpgL0ONkZZFC1Sroy5q6AXZmZwiphCjM3F1ZXoC-1jMkIww7qJKCSSnNMTwZlm6jPu14LPtnJR2C7d8z697b
+GctEFqIk6l8s6TfHW1NF34QztvoDxlSjL32OrpmBhv6YKIKyR_DH8qMZAlhuh0cZwPHzV08uXq2bK0YPWUJbdnj_kd625-4Uie5FyM94ylBdUAsLH5fJ7Jpt
+_27g-SFxlERlWzVyTV2zVX3r-k7WjNw9QVrQyeTiSrW_rR43u_fD1RFw_LponlxXw5yn3lhNPlya6lJFpVvDPFktTtuWUcqc_lc5oCmlxlc92FhsrFn6T6f-
+KwV5DFe_TNxrpy_--VtV_kq6
+}
+
+AWSEntityColoring(ToolsAndSDKs)
+!define ToolsAndSDKs(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, ToolsAndSDKs, ToolsAndSDKs)
+!define ToolsAndSDKs(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, ToolsAndSDKs, ToolsAndSDKs)
+!define ToolsAndSDKsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, ToolsAndSDKs, ToolsAndSDKs)
+!define ToolsAndSDKsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, ToolsAndSDKs, ToolsAndSDKs)

--- a/awslib/DeveloperTools/XRay.puml
+++ b/awslib/DeveloperTools/XRay.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $XRay [64x64/16z] {
+xPO54kim44FbtRKNTF_pVl8q4q_QDFbCRo0eWsIgtv3__8UJhrLNZDxxoE9NgOTW8dw_14O3T4JuK42ID-KEM78I2ZZlrGuu7n9o0C4xVMzhXNIqkXu6Euo7
+D-Lcuv8HYNPml676CNZ5lCvQuG0qObmfWFRCBUaa6OUc7Q7WMJSvZNZR059mbgmMUPgz0balO0AjdwNG0Udr6jUp56XelZf4aijZzfS5qD5o_Rlo4qkNoMYl
+nhCi7rXk3G2QBOsYG_dS7U5UtO0cgjA0jLk7Y8yZZwM0nUn_6A35tNpmv_hD6AP0WjpwBBjbX0F-hdw1BNqkWzGRVK2v1MdaFeVvQZT5plndGFQrXrTnbqv3
+ydd-KqPT6aX3Sejjkpb2WmJ9XEpQFlMFsCWuMGyDiE3OZL2pXtw-3ZjRHUWDHaNmuLjhcpwWx40xMyvP7jiI4hde4qBNT_iHMO8vXc3SwQiWTMKHFzDVWOha
+KS-4Njr1_9dUqQ_f7SQgT6XcQvaApohQrOrq3b313YacMXqusGAxxkX5GsTTfC795KUxTGG8dhuvXmCOvFOuds-UOJGUnuRxXvXY223T8xmB8C6w1yiLcCn9
+SnSolN_2a_ocCophD-K___a8
+}
+
+AWSEntityColoring(XRay)
+!define XRay(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, XRay, XRay)
+!define XRay(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, XRay, XRay)
+!define XRayParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, XRay, XRay)
+!define XRayParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, XRay, XRay)

--- a/awslib/DeveloperTools/all.puml
+++ b/awslib/DeveloperTools/all.puml
@@ -1,0 +1,144 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $Cloud9 [64x64/16z] {
+xPH5bkmm40HJM13tF--78RVbvZTBnzhniiZAN-RavEI4JzwLmqPhVLZoZXvTNvIHlAoRLBf5X7MfE2_gKvh99z6boMlfbv5Wal5AxvAJ6xWKGC9JVjTWxQV5
+QBKxJyMNNAdwf3ypl5qyyBcF4M55WuT-k-YU3FSaiq-0A0eU-LMnzT8aLVyU7UFXAicgJIzgSsphmDK2xjbMzPFFK0DCZMsrQivjlKdDBiO-sNVaeqeZRz5K
+7Ivy8vE-JHJIYZgtLbUJtIewmDZTBr5ltVEo7apgPht8bdkkkMERxdguHL8jSfOJ2V80TZWlmYsoBfzl3Qt-yJg0K3tCoPxC1-YQtF3lzuztSsjh_BRGbNfy
+E2IrMEApb5iFLytTjs5pUgvD3NLktb_mW1mgmSq3LhUuWuzozq6VHO_eSVyF7kqEVGRaFNX4_Wud9oSdVm4
+}
+
+AWSEntityColoring(Cloud9)
+!define Cloud9(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, Cloud9, Cloud9)
+!define Cloud9(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, Cloud9, Cloud9)
+!define Cloud9Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, Cloud9, Cloud9)
+!define Cloud9Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, Cloud9, Cloud9)
+
+sprite $CodeBuild [64x64/16z] {
+xPK7hkCm34I7gjJC_U-x4OKO3ZOklw7cfRW-aQ0QVuKF7pJXz-aFXYxW4MfuOFMSHXtxfU6ID7JeToBr1nb0zXvu0s3DrqK1p7NYPua5Le12JToGyvGc3SX0
+qvdlQUQu_iKALAv_gG9TFSuF_VKuia0VA_BAObJOcES9cJhmTrrWc9GQP4nod9Ueue5_a_xEjnGHVPBWhoJqtHN_GsuFa0nL3nAe5p9uFGmTPHWAmtz16KEy
+G0D58-hxVL_CIFo-pnY1zh_FcpvZs1btY6veb6xvfChEbqPBQsGDwOwlRfilUG6G-wWs3vIkV7LW-H9xNe6rFp_rOvv5_TMB0R1IIr1BMjFWrAymr_8JtZDq
+x6VOqERxy2VFiv5F_9nZSZvzepQsqtBY0vdYpfz8yvcrPPtxXUAhBzOMLMs3-hglaM4KpTmYjw_blzO-gg76nDBoxzSlhHODOytCSx-em5px-42JEhAe1hZ2
+lpb-ZAi19RXOW7OPFwBqVVtTcYDH3URQ-PVpP_chP5ra3U_AZuXxdng8asLT-rJPV4rOcZOk_IZKyk5loET-TBDzU_vgfEVwhLxVqkxk7phWnFTj__ew6cl_
+9B_j0rsJR_kvjubzqzymVeU-uVmEqWR_dWyV_W4
+}
+
+AWSEntityColoring(CodeBuild)
+!define CodeBuild(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, CodeBuild, CodeBuild)
+!define CodeBuild(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, CodeBuild, CodeBuild)
+!define CodeBuildParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, CodeBuild, CodeBuild)
+!define CodeBuildParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, CodeBuild, CodeBuild)
+
+sprite $CodeCommit [64x64/16z] {
+xPHNOkim30INdTYv_tbVYfGUEWfVFZq_RXXB0h7mNt7d3e3t8SO8l4sJfEvDg4gj9NNsz50A22LlmL33fchol_upU_S_bJpQ8zs_XARKgjITz4ImStwfy-JN
+EVQEm3pxHnEfwJloiiCfOrjvI8Ebhx7s_Umpj2oY_-ItRaQQFB7ZWusPhRPWmp_Bz4HdpsSezTcboPvVD82kkkSxfMCYokzyV98LcFaB7m-boMjL2KVMkEhZ
+8adL9rdAKl4hSDilogDdjRFCBIdryxtDh9CRFbFP44d1nnl5urYF0sxuG_tSFnzz8ciUYx5srlwvlyeddo6LC4qzfCxI3sd2KFhGQDgJX9qKJAcpx5-NIfO6
+7_ogR7mC8bCQAz_q9EMttyx2eXmuQuBRBTyuPUC33iUuAdkgG1IbmQNvXUZv61vSA-LeHGckxOzP9LNpsjld7uRnJ_vvQQKMu0FgiKUua5-YIYh3uF19pvVp
+EyzBVoZaUdwJkc5TkFQF_9uBQyC_yxlfd_brKh3Xh_FxaGlvtV3N-Vs6SJs_fNr3kPxV1SlyHXY_CHPu1VWzBF3VSEVE0m
+}
+
+AWSEntityColoring(CodeCommit)
+!define CodeCommit(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, CodeCommit, CodeCommit)
+!define CodeCommit(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, CodeCommit, CodeCommit)
+!define CodeCommitParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, CodeCommit, CodeCommit)
+!define CodeCommitParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, CodeCommit, CodeCommit)
+
+sprite $CodeDeploy [64x64/16z] {
+xPNRqiGe28GR5H3w_TztAyQ9_qLI4xTsx-Rx3mEZ3KsE-J_numSd_rARqTtTUunaKnrM1HEf5ZiLcBqUCW5KpqzKJxwL7-fY4O9ETaY45Q1qlckkGF4a6uoP
+D3IUZbhoXRn2B9aCb1mK19DqGGb-aqUPkwYZ_JGmAZV8bmBCWZfT2iw02JaNgLyBr8-S7PKvO4Nd6IbACXzOwyl-740_OKDxrezpjPfUOQ1opUTyTW-x5aNo
+OiNiAFa0_REsUYulApO-w2kSgqzR-eREhmOOaEHWU35-CjgHpEmy6pUCNU6grfCqEBERcWVfK3BSL7sTZSMQh69Gd8fkWa6D3is6WMWy3I27Kjsj0jfGW6hk
+LW154OXwTvKZV1WVuic3Niw-8qd3WPvBmqVdZTxNzum2bEHQkMOc6-3t-ig_Pdnb1icLrISzzDh5WlXRhLmnNMxrcIRh6KNzsz_HPZBcrxo5KIyBz6lYlyNe
+iySjdClBykGQHcU36vOzuzZgUU7wkGzaJVLaOVfZJbR2_k89p6GMkQE-V8ynW1iv4FaA1khAugCgEthEIP8gdIFRrRCNPwOWFBclfm5A6jHHazlw1jYSkg0c
+D_K1AC-RagF0ffuE-FcmP5R8_lmEz439-UBUrIUzPeEH5PhCRNqo0vAPuIFRrYSLUXRQrmz2anSx-k9su6uBsT3V8laMjpjwleNtv7_CZn__
+}
+
+AWSEntityColoring(CodeDeploy)
+!define CodeDeploy(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, CodeDeploy, CodeDeploy)
+!define CodeDeploy(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, CodeDeploy, CodeDeploy)
+!define CodeDeployParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, CodeDeploy, CodeDeploy)
+!define CodeDeployParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, CodeDeploy, CodeDeploy)
+
+sprite $CodePipeline [64x64/16z] {
+xTO5sjmm38JXaK6sPkv_tbByF-s2DqgPlcLumyJlrl_-fqJSfXY9GZlkXaJcsd2W-MaDS3tZ0Kmbca3eYHzeOY8rZEVUSzv_J__V3zr4lZtVDdQ-zfkeqRj_
+UhwfxlnjHhMtvzksuu_vHK76UhvjC_w0XHA58PvugiDydEQ6BZwj8rNd9eLxHVLDwySGTwsLkslzU77ZaZQRQD97V9ilHdsDFvGcgdZPYyr295KnQ8swvCMA
+Jru1OnHKwe8N2yen-WwNM552QQyrmeyPGXGRR2hh-O5BDoSLDHZJliF6mIgcI6eQUjxB0J-MNbcJ0LVQ7w2JwWVem13JVatmr5fw4pR5IvwAyNdf-HGlUafa
+mOBwgkr_ed1rtQ_f_YOlyHlywhhVbVDj-ARHplt0ouPuqdZPjrv2ytlsl_-z1m
+}
+
+AWSEntityColoring(CodePipeline)
+!define CodePipeline(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, CodePipeline, CodePipeline)
+!define CodePipeline(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, CodePipeline, CodePipeline)
+!define CodePipelineParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, CodePipeline, CodePipeline)
+!define CodePipelineParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, CodePipeline, CodePipeline)
+
+sprite $CodeStar [64x64/16z] {
+xLQ7akmW39CBnUZ-_tjV266kiJdsjMchhHx65fRBfFrBlF023_o1Twkb17_RFHG7Cd_NNM0voVC1Hivq9B97YSDuXjP7pYBTZGc5BVRr3eKK3ly3p2XlZk2s
+tW4u3rEx4sdGOZl-3CC15_Xf5cXjBQ5ZYr-XNMya3ji10IGYgSRFz1dUfTTthcAYAJPxa2D9blU2izllndqWAiwVYiIbEjczt3G27MNMUt5Q10VqiOwiaDfQ
+XYpPWHJLOJS99404g5oUPHwmSRe6YubuS5tRDiHTYlDTRmvMYSkS_dlJo9PRXs14clTlD_Sd-QwMTXvcf6Q5x_hPO_qOgVAzLXOdVLHW1AW_r2yB_3fBG2Px
+iaxMRep-CHZvIFeUV6ez8erYTUB28IuqSdk055tYmIH8tH5wMSuPU6Ip0ccm79mkLp-p0FxUuPBlbxNK6I2YDpA75hF3H_mb35OZ0TSDAjCeeLOkIhmO7kE1
+VFKdsOjtzT86hgdj4hzl8ouwUzU_nST1OhZ8wCIz-tzcOnsJVJTx1f_wVOSWjrPb3Czj_TQxgpEFVhuPsUA-hY_JHGozNS0TAxsPXxW1soic6Kd5ohG3sgFv
+pl89qHmXfzx-OR6chD0Dxi29r5fL33KTuZXWmHr_AmhZ662UKuTWb58Rj_ZzRMvPaMkRQUm_oKNCUdV_gtc3RHTi34WdJF0vZC-1kUjjMD3k1bWkwtrClV_t
+a_C-NdZX5m
+}
+
+AWSEntityColoring(CodeStar)
+!define CodeStar(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, CodeStar, CodeStar)
+!define CodeStar(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, CodeStar, CodeStar)
+!define CodeStarParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, CodeStar, CodeStar)
+!define CodeStarParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, CodeStar, CodeStar)
+
+sprite $CommandLineInterface [64x64/16z] {
+xTO5heGm58NXMxl6_jVxNCOEEQ6HaVw1-8VJDf-YrIe6NTpoAdHwstSt8k_8QqPyRbyxJh4l9OTOI3leUqzj7cqSyriIRT3NHbMHPqD-1DL0NfDAdzt7dDTY
+Srx4PdmQE03XmG5O3mv0UtW0tkC3y1uVWFSvfCnuAw9JzmyuuG6d_J_tquBq_pohdEIa_-Uf_QJWFBvtqW_0MP_-WEFdydZz5FbRxAwVK9Q_zPtvFmRAypS3
+wyV7RBLw1m
+}
+
+AWSEntityColoring(CommandLineInterface)
+!define CommandLineInterface(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, CommandLineInterface, CommandLineInterface)
+!define CommandLineInterface(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, CommandLineInterface, CommandLineInterface)
+!define CommandLineInterfaceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, CommandLineInterface, CommandLineInterface)
+!define CommandLineInterfaceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, CommandLineInterface, CommandLineInterface)
+
+sprite $DeveloperTools [64x64/16z] {
+xTO7qgim40DWQS7WbUv_tpS49napPUVzlIczVAA3yLdv2--lnBBzRneGJx_vVwEBr__5-JNzdxTbwngFfz8xbsXfNtGB8BRQEycLMBgdcINMlI5gxuLfRSGg
+FSD8Pp1TUd6rP6rupe4RqaaU7PkBwQ-ylPmz8spMoH7bycFte-VvrOQ3io6hzR_4xQK_5i0TknioWxdNlcEpBKN8uukGam3JA-lzPmLRFqIaxrpErjA9vifB
+-qf4dWM3IxQjOBhsjZfvAz23g_T6Tglou-UpWBpp1U2QLk7dWWwaVV8zPQlsSm4ZyyRxmAM_5X3i1vV-qtU2gS0M6Fn_l3kYay5k1V9__TZhRbEsuZ_dV_1n
+CCq5jRSUkmqNpGMrjnenk7TC1RKVvxhzkTTD1RKN8stVUUzJGUdTaDRMqYUthmNr-JC3O9vSkXHK7hl8J3JtS-FD1UdADp9z-1rfNGguL3x0SQreb7GfQ2pN
+NmmkhhuKM17r_ZVuyJJjpsE3b5w1jezptLIm1NQhzetpkMuK16DK5jxAbAqv7e_QI_O7Zt_-_Fzczatvd-cJVq7UpYEMboI8U_YYu2Va7m
+}
+
+AWSEntityColoring(DeveloperTools)
+!define DeveloperTools(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, DeveloperTools, DeveloperTools)
+!define DeveloperTools(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, DeveloperTools, DeveloperTools)
+!define DeveloperToolsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, DeveloperTools, DeveloperTools)
+!define DeveloperToolsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, DeveloperTools, DeveloperTools)
+
+sprite $ToolsAndSDKs [64x64/16z] {
+xPPdbiCm28H5hChS_xmflF0KVgZWxONTT7ss6D5uRF_sRy2RQCwPSPf6kOHmAS0vkXqXn1Z2qG0_pkb-xmhK-nuIm-qu1SeCytRN-atjLdRn9aw_B8T8qR3l
+k1MTWR8d0xXORwqYXR5sF3OCt58Pfew_hW3CXpgL0ONkZZFC1Sroy5q6AXZmZwiphCjM3F1ZXoC-1jMkIww7qJKCSSnNMTwZlm6jPu14LPtnJR2C7d8z697b
+GctEFqIk6l8s6TfHW1NF34QztvoDxlSjL32OrpmBhv6YKIKyR_DH8qMZAlhuh0cZwPHzV08uXq2bK0YPWUJbdnj_kd625-4Uie5FyM94ylBdUAsLH5fJ7Jpt
+_27g-SFxlERlWzVyTV2zVX3r-k7WjNw9QVrQyeTiSrW_rR43u_fD1RFw_LponlxXw5yn3lhNPlya6lJFpVvDPFktTtuWUcqc_lc5oCmlxlc92FhsrFn6T6f-
+KwV5DFe_TNxrpy_--VtV_kq6
+}
+
+AWSEntityColoring(ToolsAndSDKs)
+!define ToolsAndSDKs(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, ToolsAndSDKs, ToolsAndSDKs)
+!define ToolsAndSDKs(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, ToolsAndSDKs, ToolsAndSDKs)
+!define ToolsAndSDKsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, ToolsAndSDKs, ToolsAndSDKs)
+!define ToolsAndSDKsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, ToolsAndSDKs, ToolsAndSDKs)
+
+sprite $XRay [64x64/16z] {
+xPO54kim44FbtRKNTF_pVl8q4q_QDFbCRo0eWsIgtv3__8UJhrLNZDxxoE9NgOTW8dw_14O3T4JuK42ID-KEM78I2ZZlrGuu7n9o0C4xVMzhXNIqkXu6Euo7
+D-Lcuv8HYNPml676CNZ5lCvQuG0qObmfWFRCBUaa6OUc7Q7WMJSvZNZR059mbgmMUPgz0balO0AjdwNG0Udr6jUp56XelZf4aijZzfS5qD5o_Rlo4qkNoMYl
+nhCi7rXk3G2QBOsYG_dS7U5UtO0cgjA0jLk7Y8yZZwM0nUn_6A35tNpmv_hD6AP0WjpwBBjbX0F-hdw1BNqkWzGRVK2v1MdaFeVvQZT5plndGFQrXrTnbqv3
+ydd-KqPT6aX3Sejjkpb2WmJ9XEpQFlMFsCWuMGyDiE3OZL2pXtw-3ZjRHUWDHaNmuLjhcpwWx40xMyvP7jiI4hde4qBNT_iHMO8vXc3SwQiWTMKHFzDVWOha
+KS-4Njr1_9dUqQ_f7SQgT6XcQvaApohQrOrq3b313YacMXqusGAxxkX5GsTTfC795KUxTGG8dhuvXmCOvFOuds-UOJGUnuRxXvXY223T8xmB8C6w1yiLcCn9
+SnSolN_2a_ocCophD-K___a8
+}
+
+AWSEntityColoring(XRay)
+!define XRay(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, XRay, XRay)
+!define XRay(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, XRay, XRay)
+!define XRayParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, XRay, XRay)
+!define XRayParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, XRay, XRay)
+

--- a/awslib/EndUserComputing/Appstream2.0.puml
+++ b/awslib/EndUserComputing/Appstream2.0.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Appstream2 [64x64/16z] {
+xTKtTaCn5CHGMizYylxNwu1k5D4uQxeVBWuxxX-nnnvReykDTScFfZSk-LMj7RlOS-lxIg3s_Rtqz1bOzmDu4H1U1AJt0RmCUEy3U1dmtWVmCk2z3-1bm7iV
+m9l0iFvo02wys9VuMLM7irMtVhIBEpZF-pRMoQRsV7YQExU4pnCuRmFUPo3zMC978FnejQmdSE9N4N2UGFeCu6q0dm6y3U0pWBS1V0RmDe3F0Du6y1d0sm0-
+0tWRm6S0RmFu3E1bOE8pWBU1WS_04Iy3hVPfeE5b09y1l0xKnPj9RymBDzFQFsAFFVO6
+}
+
+AWSEntityColoring(Appstream2.0)
+!define Appstream2.0(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Appstream2.0, Appstream2.0)
+!define Appstream2.0(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Appstream2.0, Appstream2.0)
+!define Appstream2.0Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Appstream2.0, Appstream2.0)
+!define Appstream2.0Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Appstream2.0, Appstream2.0)

--- a/awslib/EndUserComputing/EndUserComputing.puml
+++ b/awslib/EndUserComputing/EndUserComputing.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EndUserComputing [64x64/16z] {
+xTO5OiCm38NX9x8bvVxd7HNS5AECj_nb-CA4xsgB3gy4QTKCuE7RbCLYxlEZ_EOtt-rQpHVw1j2LWBRCisJ6HHd2opnPNcjIgdhtoD131DLUyCu0JC0ZebZi
+0zpT0CrHntAlR_-rjJvOtbxM-L20t-4PrdVBcadKgxvXHtQUA6h-T5DXdG8MDMyKmsSI857mwT1JxytGAZuRYD-I_P18IpvTPTSwFsBnbnHzfHUyPRdCktSI
+xyTyD_x8PJu8v-bKsNuD5hEO-yWU-XJut6FMJNzp3ZH6xR7FwBEelF_Eu-_sad4eMzqhQ0Gg-sWsQhvTVtoytxn5DP_v5NsS1ykQc728LeM_q3C
+}
+
+AWSEntityColoring(EndUserComputing)
+!define EndUserComputing(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, EndUserComputing, EndUserComputing)
+!define EndUserComputing(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, EndUserComputing, EndUserComputing)
+!define EndUserComputingParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, EndUserComputing, EndUserComputing)
+!define EndUserComputingParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, EndUserComputing, EndUserComputing)

--- a/awslib/EndUserComputing/WorkDocs.puml
+++ b/awslib/EndUserComputing/WorkDocs.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $WorkDocs [64x64/16z] {
+xPP73iCm30IN145AzF__ctle21kubxcvpBXRobFmyjB3PsYqxvWbUD-y87p0uLDPAG22zhCWua0iyNCGeFn1WF870SeV12X_4A3z6k1z8a3u9K3xH83mIu3s
+YG3Xbm3j4m7Ahm7Uhm7UPmCEqTv48bKiJJHT191l0BGblWXymVbd-ew--p8_SvclUkprcnrx_MR7Nh_giTSViVJwZ_LRM-Rt_ey_CSzl-kcR5m0lsBmVe8d1
+_9KWUfw2bvSF
+}
+
+AWSEntityColoring(WorkDocs)
+!define WorkDocs(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, WorkDocs, WorkDocs)
+!define WorkDocs(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, WorkDocs, WorkDocs)
+!define WorkDocsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, WorkDocs, WorkDocs)
+!define WorkDocsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, WorkDocs, WorkDocs)

--- a/awslib/EndUserComputing/WorkLink.puml
+++ b/awslib/EndUserComputing/WorkLink.puml
@@ -1,0 +1,12 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $WorkLink [64x64/16z] {
+xTO52WCm38NXHzPOxt_VkM-1odpvSSA7Lb9_eompBb7i3RuWJfeyczxB6DpaBPX8ezUFzEcjQAVtcxgy4wuYx_80NGIuyZxn1a_r8e8lS8Y7lCakHXdoTPzD
+UlrLdzucFSik7VACGpJaNNYVtjxVAnyLln_jFdw_sdrLqc3IvXdoaJwzjVbucMhoWh0cxroYsEflb6Kh
+}
+
+AWSEntityColoring(WorkLink)
+!define WorkLink(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, WorkLink, WorkLink)
+!define WorkLink(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, WorkLink, WorkLink)
+!define WorkLinkParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, WorkLink, WorkLink)
+!define WorkLinkParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, WorkLink, WorkLink)

--- a/awslib/EndUserComputing/Workspaces.puml
+++ b/awslib/EndUserComputing/Workspaces.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Workspaces [64x64/16z] {
+xPO73jim34MfnPNxtxUGskyQ4I8ADbR6pnvFt67yu_JJJsftQAj4pIxZd2WH9Rb6IoQgrbqe2dziczRIEJnh_qvCl4TR8yhYVkRx8zxT2BpPaS8iE15UBMKZ
+yFydCHwHbQ0aJ9JrbCA_ZmaGZbhn0uEpuv6IGmZfDS_THZa7xgfFnQcsu1-T6YdarEETIY_ZxPSyxlL8PKfpXHC7l14bTGS_bqdMlD9HRkPvjeWuulCfKvFx
+9UOh4bZAb3xdc2yeO4fFvLFVup4vQMgVJHx-LdjgtstUgceP6CPdoGjHiyU9pqSQCBvBtbgt1LwASRCZ3SqzuD4RWw_M7w7UpMuH3rkTpyxY9xwPPhOL3qar
+LxJ_mPipaKGyXFgTUTVgNFGotrKesHtUMlF6b_ak8wftU9SiInv6x0K_6bBs5j7COnAs5o7unIzui8Z1Jnjaxuy0-6c3HG807e7l2mvtVh71upGa2WAFqa11
+u64QglaDcVf7wgUV_W
+}
+
+AWSEntityColoring(Workspaces)
+!define Workspaces(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Workspaces, Workspaces)
+!define Workspaces(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Workspaces, Workspaces)
+!define WorkspacesParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Workspaces, Workspaces)
+!define WorkspacesParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Workspaces, Workspaces)

--- a/awslib/EndUserComputing/all.puml
+++ b/awslib/EndUserComputing/all.puml
@@ -1,0 +1,64 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $Appstream2 [64x64/16z] {
+xTKtTaCn5CHGMizYylxNwu1k5D4uQxeVBWuxxX-nnnvReykDTScFfZSk-LMj7RlOS-lxIg3s_Rtqz1bOzmDu4H1U1AJt0RmCUEy3U1dmtWVmCk2z3-1bm7iV
+m9l0iFvo02wys9VuMLM7irMtVhIBEpZF-pRMoQRsV7YQExU4pnCuRmFUPo3zMC978FnejQmdSE9N4N2UGFeCu6q0dm6y3U0pWBS1V0RmDe3F0Du6y1d0sm0-
+0tWRm6S0RmFu3E1bOE8pWBU1WS_04Iy3hVPfeE5b09y1l0xKnPj9RymBDzFQFsAFFVO6
+}
+
+AWSEntityColoring(Appstream2.0)
+!define Appstream2.0(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Appstream2.0, Appstream2.0)
+!define Appstream2.0(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Appstream2.0, Appstream2.0)
+!define Appstream2.0Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Appstream2.0, Appstream2.0)
+!define Appstream2.0Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Appstream2.0, Appstream2.0)
+
+sprite $EndUserComputing [64x64/16z] {
+xTO5OiCm38NX9x8bvVxd7HNS5AECj_nb-CA4xsgB3gy4QTKCuE7RbCLYxlEZ_EOtt-rQpHVw1j2LWBRCisJ6HHd2opnPNcjIgdhtoD131DLUyCu0JC0ZebZi
+0zpT0CrHntAlR_-rjJvOtbxM-L20t-4PrdVBcadKgxvXHtQUA6h-T5DXdG8MDMyKmsSI857mwT1JxytGAZuRYD-I_P18IpvTPTSwFsBnbnHzfHUyPRdCktSI
+xyTyD_x8PJu8v-bKsNuD5hEO-yWU-XJut6FMJNzp3ZH6xR7FwBEelF_Eu-_sad4eMzqhQ0Gg-sWsQhvTVtoytxn5DP_v5NsS1ykQc728LeM_q3C
+}
+
+AWSEntityColoring(EndUserComputing)
+!define EndUserComputing(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, EndUserComputing, EndUserComputing)
+!define EndUserComputing(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, EndUserComputing, EndUserComputing)
+!define EndUserComputingParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, EndUserComputing, EndUserComputing)
+!define EndUserComputingParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, EndUserComputing, EndUserComputing)
+
+sprite $WorkDocs [64x64/16z] {
+xPP73iCm30IN145AzF__ctle21kubxcvpBXRobFmyjB3PsYqxvWbUD-y87p0uLDPAG22zhCWua0iyNCGeFn1WF870SeV12X_4A3z6k1z8a3u9K3xH83mIu3s
+YG3Xbm3j4m7Ahm7Uhm7UPmCEqTv48bKiJJHT191l0BGblWXymVbd-ew--p8_SvclUkprcnrx_MR7Nh_giTSViVJwZ_LRM-Rt_ey_CSzl-kcR5m0lsBmVe8d1
+_9KWUfw2bvSF
+}
+
+AWSEntityColoring(WorkDocs)
+!define WorkDocs(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, WorkDocs, WorkDocs)
+!define WorkDocs(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, WorkDocs, WorkDocs)
+!define WorkDocsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, WorkDocs, WorkDocs)
+!define WorkDocsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, WorkDocs, WorkDocs)
+
+sprite $WorkLink [64x64/16z] {
+xTO52WCm38NXHzPOxt_VkM-1odpvSSA7Lb9_eompBb7i3RuWJfeyczxB6DpaBPX8ezUFzEcjQAVtcxgy4wuYx_80NGIuyZxn1a_r8e8lS8Y7lCakHXdoTPzD
+UlrLdzucFSik7VACGpJaNNYVtjxVAnyLln_jFdw_sdrLqc3IvXdoaJwzjVbucMhoWh0cxroYsEflb6Kh
+}
+
+AWSEntityColoring(WorkLink)
+!define WorkLink(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, WorkLink, WorkLink)
+!define WorkLink(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, WorkLink, WorkLink)
+!define WorkLinkParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, WorkLink, WorkLink)
+!define WorkLinkParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, WorkLink, WorkLink)
+
+sprite $Workspaces [64x64/16z] {
+xPO73jim34MfnPNxtxUGskyQ4I8ADbR6pnvFt67yu_JJJsftQAj4pIxZd2WH9Rb6IoQgrbqe2dziczRIEJnh_qvCl4TR8yhYVkRx8zxT2BpPaS8iE15UBMKZ
+yFydCHwHbQ0aJ9JrbCA_ZmaGZbhn0uEpuv6IGmZfDS_THZa7xgfFnQcsu1-T6YdarEETIY_ZxPSyxlL8PKfpXHC7l14bTGS_bqdMlD9HRkPvjeWuulCfKvFx
+9UOh4bZAb3xdc2yeO4fFvLFVup4vQMgVJHx-LdjgtstUgceP6CPdoGjHiyU9pqSQCBvBtbgt1LwASRCZ3SqzuD4RWw_M7w7UpMuH3rkTpyxY9xwPPhOL3qar
+LxJ_mPipaKGyXFgTUTVgNFGotrKesHtUMlF6b_ak8wftU9SiInv6x0K_6bBs5j7COnAs5o7unIzui8Z1Jnjaxuy0-6c3HG807e7l2mvtVh71upGa2WAFqa11
+u64QglaDcVf7wgUV_W
+}
+
+AWSEntityColoring(Workspaces)
+!define Workspaces(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Workspaces, Workspaces)
+!define Workspaces(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Workspaces, Workspaces)
+!define WorkspacesParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Workspaces, Workspaces)
+!define WorkspacesParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Workspaces, Workspaces)
+

--- a/awslib/GameTech/GameLift.puml
+++ b/awslib/GameTech/GameLift.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $GameLift [64x64/16z] {
+xTM7hkmu283X7mpOuFT_tpqPMzfiT2QJxUr-Acd27LB_H3_yaBr7z97rMtGJ5cdngvjm0H3tnhhvLIrq0HDQ7lSGBaZKOmwMWTPX7ZVfqEgXXlHAOTHY-AoX
+Q3uCrvpbU6s9797sh047wLb2rZQDc3NQeobqn40K7RbQo0pK15I9-aJeS-ojbuMNrYiXwrvWknbhAeisPUs_OtLlJplH-jdi-3nzVg_JzjNgPEpNQrTk67rF
+8-eaHVOD-cJuvVGwK_9oSt5ftXXrriZJ0D_gs3okiv7pl836M1-2k8_lBqhqiyP-lb_0u3E_txxmBo6OdodxkNs8zzyr_q7xNUjV8kjgx_RVe-uqnkNyZTv7
+rHYdcZxoO_hrVHqDGFkSQntIW9jQch_Clmxgtg3P8eYvyIQDJmacX5SAiSlviWDJYVS367Eu0bgEpsfQiwFZYzDE5VLxWHeWw2WbSmWzr_hFrwv46xVRs40Y
+KoHBf1n0PsFiKv2WLNvpZFGrIYDAg6w2nUf_dIh5Ltru9nNDcVYh5a-bPY9hRZwhZfPkAtasYF8ZNdAEKRMp9ey6r_4awaQ0U2zPIz4Lv0NmaRtn8RxIm4l4
+MNIJ_MX4tKll9LB3MsjeRHrfpVefFpvdupJYKg2VnryFc-E_DZvMo9B8hua_fUJMNf7-A5uPi-pwAvISgyvy54YqQwevueRM4mRejIS7PDGZ8_gtBxF-8Nxu
+uIS
+}
+
+AWSEntityColoring(GameLift)
+!define GameLift(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, GameLift, GameLift)
+!define GameLift(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, GameLift, GameLift)
+!define GameLiftParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, GameLift, GameLift)
+!define GameLiftParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, GameLift, GameLift)

--- a/awslib/GameTech/GameTech.puml
+++ b/awslib/GameTech/GameTech.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $GameTech [64x64/16z] {
+xTP5ejmm44NHLwG2xN-_aPhP44x-7PXFeq7uNNr5vpb1sjOCuAjllRRLyzxNrlu2_-NpkxmJgEtt0N61x_P6rOjqZyyS4-Kn4TdZZRxFDsGlbjq-YOmHktsb
+4dljzfbrwkeprtfZW3Hgr4LwZK89O5lZaw7DZM1jH3Id1Z9l2iv5dqHHrQiKe5E0rYo8SiahylHTXRBcSYN91Uc2JrXLFvm_SJxt7J6dSsB8ppuGbIxaKPTp
+NsbEW3ZiNlJTCHgMpvx7X01RvNqAoXp4wderDEAiycMlys0vV-thQsQDTDd3Uysklte9PSswOzdpSINcQNHAmGVMmCi-52Gwzz4b0An2q5ZXAvHP6wmk6ThS
+5hNAptf3NdsU7l3hVR5KNHEkJVvwybvFuKrUgEuYsUJZ-OuQgtp2hs___05ywVehvZ6nvyUMmuvx5to0X67rb86544j-dZtYzI8NrlWQ_xpoNxv_dxVSMjpv
+7Vqu3vOzCU4SxGh_Gjy
+}
+
+AWSEntityColoring(GameTech)
+!define GameTech(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, GameTech, GameTech)
+!define GameTech(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, GameTech, GameTech)
+!define GameTechParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, GameTech, GameTech)
+!define GameTechParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, GameTech, GameTech)

--- a/awslib/GameTech/all.puml
+++ b/awslib/GameTech/all.puml
@@ -1,0 +1,33 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $GameLift [64x64/16z] {
+xTM7hkmu283X7mpOuFT_tpqPMzfiT2QJxUr-Acd27LB_H3_yaBr7z97rMtGJ5cdngvjm0H3tnhhvLIrq0HDQ7lSGBaZKOmwMWTPX7ZVfqEgXXlHAOTHY-AoX
+Q3uCrvpbU6s9797sh047wLb2rZQDc3NQeobqn40K7RbQo0pK15I9-aJeS-ojbuMNrYiXwrvWknbhAeisPUs_OtLlJplH-jdi-3nzVg_JzjNgPEpNQrTk67rF
+8-eaHVOD-cJuvVGwK_9oSt5ftXXrriZJ0D_gs3okiv7pl836M1-2k8_lBqhqiyP-lb_0u3E_txxmBo6OdodxkNs8zzyr_q7xNUjV8kjgx_RVe-uqnkNyZTv7
+rHYdcZxoO_hrVHqDGFkSQntIW9jQch_Clmxgtg3P8eYvyIQDJmacX5SAiSlviWDJYVS367Eu0bgEpsfQiwFZYzDE5VLxWHeWw2WbSmWzr_hFrwv46xVRs40Y
+KoHBf1n0PsFiKv2WLNvpZFGrIYDAg6w2nUf_dIh5Ltru9nNDcVYh5a-bPY9hRZwhZfPkAtasYF8ZNdAEKRMp9ey6r_4awaQ0U2zPIz4Lv0NmaRtn8RxIm4l4
+MNIJ_MX4tKll9LB3MsjeRHrfpVefFpvdupJYKg2VnryFc-E_DZvMo9B8hua_fUJMNf7-A5uPi-pwAvISgyvy54YqQwevueRM4mRejIS7PDGZ8_gtBxF-8Nxu
+uIS
+}
+
+AWSEntityColoring(GameLift)
+!define GameLift(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, GameLift, GameLift)
+!define GameLift(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, GameLift, GameLift)
+!define GameLiftParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, GameLift, GameLift)
+!define GameLiftParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, GameLift, GameLift)
+
+sprite $GameTech [64x64/16z] {
+xTP5ejmm44NHLwG2xN-_aPhP44x-7PXFeq7uNNr5vpb1sjOCuAjllRRLyzxNrlu2_-NpkxmJgEtt0N61x_P6rOjqZyyS4-Kn4TdZZRxFDsGlbjq-YOmHktsb
+4dljzfbrwkeprtfZW3Hgr4LwZK89O5lZaw7DZM1jH3Id1Z9l2iv5dqHHrQiKe5E0rYo8SiahylHTXRBcSYN91Uc2JrXLFvm_SJxt7J6dSsB8ppuGbIxaKPTp
+NsbEW3ZiNlJTCHgMpvx7X01RvNqAoXp4wderDEAiycMlys0vV-thQsQDTDd3Uysklte9PSswOzdpSINcQNHAmGVMmCi-52Gwzz4b0An2q5ZXAvHP6wmk6ThS
+5hNAptf3NdsU7l3hVR5KNHEkJVvwybvFuKrUgEuYsUJZ-OuQgtp2hs___05ywVehvZ6nvyUMmuvx5to0X67rb86544j-dZtYzI8NrlWQ_xpoNxv_dxVSMjpv
+7Vqu3vOzCU4SxGh_Gjy
+}
+
+AWSEntityColoring(GameTech)
+!define GameTech(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, GameTech, GameTech)
+!define GameTech(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, GameTech, GameTech)
+!define GameTechParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, GameTech, GameTech)
+!define GameTechParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, GameTech, GameTech)
+

--- a/awslib/General/Client.puml
+++ b/awslib/General/Client.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Client [64x64/16z] {
+xTT5WWKn24NHXyHX_yjjTuUsBpdpMruH702jAOeRD3nf4AvqJ-i0o7m99yXoevk-8gK-wTi8QizwyJ1vqQ-GrxqYG5_tWW3vcNxtkz_zxdU_-pa2vgi-wdbF
+OmKDGlsfzSSa9D2ywJ7SLuhxm1LUdhGOrwYEb4hu8SG9X3lSBQKpVkBv3VVPQbYR3-ldYPGP-dxrEKRi-s_-d76i7_w2_6tVxNkzzFVt3nqf_QR7T2kSKEu-
+7FKqnRLgdc8LjxZKXC8u09S
+}
+
+AWSEntityColoring(Client)
+!define Client(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, Client, Client)
+!define Client(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, Client, Client)
+!define ClientParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, Client, Client)
+!define ClientParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, Client, Client)

--- a/awslib/General/Disk.puml
+++ b/awslib/General/Disk.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Disk [64x64/16z] {
+j5HNWaCX27nI5XHo_-kkJr8jwPcV51bWQDilaHhUeW9hCM-meWmlaL7iqC44dsLpQGoth5AXsRpzKVWfjaKukjATIEBVXnvmZ-sAanVrFOVxAlwyiYKjkY7x
+wz-QdNADe72dALeDSbgzMbL8z_NHRWDBUddOPoZXO4hNxGder44A-hCEXXhae3_h8FUDgzgtfr5hSDj6z4LLbvrox1pIzWBeDbrUYr-Nu6eNQZhJx1DMfAc2
+AlWwl4nCf7ZRuo8JvtALG3bu6a9h8mTSntS_Lm0dwiagpPI9MDjNcbG0pwbWJw_1ovb2fQRGEy2pQ3lOX2wTsjx1cGPXs-q2nniYd4fiQQWW79zea2PNfv2F
+rZhC48Urfxwt9QxH4Jb5aw3lW4RtR4YCOYDTcCLZssYGQT51wvSn779SexWu7ERzojivZJwlcEdhMUrrnX_DNFh6SdJbjjBSZuai-NJo4eWEqITyNFC_p_-_
+zFeG00200HZcRns8p62_ZVfb_tP-TdvtVtP_ytxi_ThxcVTx_qV-h_sV-R-N7v9Vaf-Mtv8Var-JdvFVpn_UNzwVtj_U7zzVtvy_
+}
+
+AWSEntityColoring(Disk)
+!define Disk(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, Disk, Disk)
+!define Disk(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, Disk, Disk)
+!define DiskParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, Disk, Disk)
+!define DiskParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, Disk, Disk)

--- a/awslib/General/Forums.puml
+++ b/awslib/General/Forums.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Forums [64x64/16z] {
+pTT94W8X38NX920pzp-kiqiwL1uKVljVUmxGSJwO-MVEhPirNj97COc_Ff19K7kNnsIYlxK-v2PwNyT4wLNh-bPDsgVlW6TF8Pi5-WTiHY-vcMN2hp-tNf99
+MVZyYaBffIdakdTTuQvx3WhU-VucRvBMVF-hlQ_FdiIR2Ps67Zz-_V3v3Jm_c-UNX356v_TKFpOrlsLiqVkFVxyxWC7vXSxFuz3r2tpzyVNR-VLd8AcApVDR
+iaBsdJ--VpB3UtJ_Ujm3
+}
+
+AWSEntityColoring(Forums)
+!define Forums(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, Forums, Forums)
+!define Forums(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, Forums, Forums)
+!define ForumsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, Forums, Forums)
+!define ForumsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, Forums, Forums)

--- a/awslib/General/General.puml
+++ b/awslib/General/General.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $General [64x64/16z] {
+xTO5LaGn30NGbzJRzEz_jpW4w_b9SNamCyTktV1L-G_T_n9YBRxK0h3wUandv8alqvln0_o_bvpb3RuIG7NNzu0uHaJeEtuaS9jNQOmql5uAjE6LKCJb6oEh
+c9B1pUIru_D9T1XElIIjx6cJaXXy8zJ5R8BQkSzOUsI3ftNxoU0JhyUFayKlvy_e5-l7x7Nztinur_Lhyulzu_QwVtVz56QPVg-9SNwk__SqLdwGmJUY8gzv
+AKJDUtx5w3k_TE6hr_tlFxzZrFs_St_4gFj_u_uwOZpyzvSEGmeX8VGlkB_r_V3ztp__liutllzbEDEV-8sydmU7dR1MIrl1RyWb
+}
+
+AWSEntityColoring(General)
+!define General(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, General, General)
+!define General(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, General, General)
+!define GeneralParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, General, General)
+!define GeneralParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, General, General)

--- a/awslib/General/GenericDatabase.puml
+++ b/awslib/General/GenericDatabase.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $GenericDatabase [64x64/16z] {
+xPS72aCX341_rP-T-r-t8jrr5IdJnqPU1hXo_8_BWr_5a81Or6weC44ASs4Yi7eLPOW3EU3DDHKXmWAHYDej1eQEJNRByopssTAjBgDM1B2Ie5DZBEKPL1VH
+tJaT0nAxEzOMtEqy9ZZDlP96tE8nHJINumlznTTQ_ldww_ap78V9sJDQyyiU4UXj492oj-e-1VOId226BpK2QLdcG0t_VVyo8K86aVXz_xRzJ4Gnhs9IzkR0
+prpYYIIgPfOjCrKXFEFjI8pzv_qHCi_xOyAlynz_-zlV_lQtl_tjRvzdVQxvx9Rcz6JEg__tnVbXSNvPdf_MvxVr-N5zVbsVdzUv0W
+}
+
+AWSEntityColoring(GenericDatabase)
+!define GenericDatabase(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, GenericDatabase, GenericDatabase)
+!define GenericDatabase(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, GenericDatabase, GenericDatabase)
+!define GenericDatabaseParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, GenericDatabase, GenericDatabase)
+!define GenericDatabaseParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, GenericDatabase, GenericDatabase)

--- a/awslib/General/InternetAlt1.puml
+++ b/awslib/General/InternetAlt1.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $InternetAlt1 [64x64/16z] {
+xPK73gD034NjwIx__jVT4R8YM6K8iBqy5PhVZpBDz7kISiw97xfLp34nQUc-FJOtSBcPq7opUgsrYm7mVaSV0BHoF74H0CgNTG6yqfvYWAMB-dXJom8ONzBh
+-qe1v8hE3i_q1WNQ1N-iofB3cPkQQUEpdzVr7rF3XjULtu3bjqqs4SEwIE5yChBUc8ZRQeo8_MIKsRn44XPbwNIGcIaGUA8t5A3iqcX50Uf7VxZmUfhUVEDc
+kznnjciCi97fG3LCoavV1iJNmxdG0LZFXu9rG6vwN4WzPlUbcyBqREDd0L1tsouVz_2OxYeWfDT2OeD_fTE0qQS0GEC6VJ-BKzzyulDzEsB0vR3k-zJ39rQX
+DSanQ6B7RSiKVjolqQs87PqEXF-H0UTlyVltyiTpFuRXaHzY1yeJdnqIysXF_0RKA8RSzxF3E3O08EccNtRdJJB0H-QBVlJrtRGbmSHKDaRuNO8-xqSb6hAX
+vfXqsb4LBvn9VFhgyQn4vaBiknh9T2GtKTiGfgQ3Q5Wmfez1BBQXCcgYMsp-WP_l__V_-tpV7CelFrcxgpT0EVnaGBxfHnUU_gOFeWS1meeH-gC0DMZepm8c
+eJyB2FrnGEZF0q9_2cVwFVa2
+}
+
+AWSEntityColoring(InternetAlt1)
+!define InternetAlt1(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, InternetAlt1, InternetAlt1)
+!define InternetAlt1(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, InternetAlt1, InternetAlt1)
+!define InternetAlt1Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, InternetAlt1, InternetAlt1)
+!define InternetAlt1Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, InternetAlt1, InternetAlt1)

--- a/awslib/General/InternetAlt2.puml
+++ b/awslib/General/InternetAlt2.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $InternetAlt2 [64x64/16z] {
+xPNfjlCW24KXgAXmtlznly7BQbocTkNsTtRdojP3HhhmyF30p5-xKfgvktLDNonS32TMVXaZsT1QrTf-llugGm5WAl7hK0DGx-iAGEV4h0uqlh-wht75W7Qp
+Ty25LhZVR84DIBl_xwLNUeSuZ2XfQve-Bc-ytQorOz1bvsUWVEWCS3C0lelGuFoXDTI3wAZOLR6XqOx3KSvMtfTiuiUeKD0t0GJ8T8EygKlpJiwc7rgfx_Gs
+pPkn7WhQ2WK6xuMNy0q0qgcl4vWt2aQfAyyzEO1U9dsTmCxGdAi1C5dtxgcxmHtGrJ-diEb04eTdclLKqSK0lVe1A-2nP0SctU69Aema4gn-e42B7JUDoSWr
+V183ojQd1enDK3621DKpXK_YdVU-H3n3fmcXbqy7qzuFaNqT2Z_O-nNEmzVlVBtb7pBvYQ_-v_o7kRpyZCwB7vjXwnV09VmCGEOTQB4PPE-J0Yx37qVczO8b
+GDlwaI1rrD2lrzi6wDQF2NmyCytBmpckA83k_6W1M5O_-Yab1opprYTTzQFutBKO0EzL_rCr_59rK0lfq3KAcZc0nijj7e4pLJUYxl6x4vMUY1qdjbo4EJVp
+7un9hH4r3rgKl0fwJKnNE3X_1c_77nuU_W8
+}
+
+AWSEntityColoring(InternetAlt2)
+!define InternetAlt2(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, InternetAlt2, InternetAlt2)
+!define InternetAlt2(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, InternetAlt2, InternetAlt2)
+!define InternetAlt2Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, InternetAlt2, InternetAlt2)
+!define InternetAlt2Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, InternetAlt2, InternetAlt2)

--- a/awslib/General/InternetGateway.puml
+++ b/awslib/General/InternetGateway.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $InternetGateway [64x64/16z] {
+xPL7SiCm34K5TfH__-jc97Ci2Yf3PwstIMoZynDSJhoyl13HltrZOJKpbPh-aRWeThJyM4RIpOrRRVpvzwSQ2W2jiNyALG6qUVSAeDBOJJM0QJwx-NAZ0ZpP
+Es1nyP1Cja0AfBllvwglrtemwBAaobpJOtgbsx4smOR4E_yCb8VE05F5C60Fm-X95YqiIsYuio9zEAPWA7ihroQ7yZtXsxRS5920l4oGR-oIF-JxLjgLEv_Z
+KbZnbWeJVwiZ0yVybAge0J2LbaRppTGgZJqP02b3l6OOiHRtoBaf08tkT7qrfbnBAPMtCi1nA2xh8AHeiB7rkbMJzu0XRm4RZNi1i6uXXya5sPDHY85wGrxx
+5LrlwQ2eQ7tbKUO-FzvAYUAk9mDRl0OBHndJAdJpuwDsr7ViyHHoq4Vf8u19AxaqiNvUZkv8Nazz19BfEsq1eC7xDnXj_dxho3Q2Ba3ghy9vCzOx_sZh2AY8
+6SoaXBNvjDpwjyMnbbeC7TUyyn_cvqUWN5Vv0TUBaQ5z3F7gDckchrZvOM55NFsScNRBGa_xbfsmvY25KTyexj6S8GnoJjQxdVSkDdOTzIFNEaNxN2mczyp_
+XBfbkLtNEVQDwA0vkklBoyiV
+}
+
+AWSEntityColoring(InternetGateway)
+!define InternetGateway(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, InternetGateway, InternetGateway)
+!define InternetGateway(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, InternetGateway, InternetGateway)
+!define InternetGatewayParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, InternetGateway, InternetGateway)
+!define InternetGatewayParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, InternetGateway, InternetGateway)

--- a/awslib/General/Marketplace.puml
+++ b/awslib/General/Marketplace.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Marketplace [64x64/16z] {
+xPK7jYCX30HRGcGnzp_kVkJ0Ss17csCvoov2F-4Plnd_-Oz-cvquhH6QSFqYlH00BiFe4G2akUqMW3IjyE5e9d2PfQWkUuesMHCWLWQIsf90MHqwWMwRhGH0
+-YqIGCxz2Y3htG0ikkjosEFptF1rnOm0sut5uVEJHY2K07lNBKqBKSddsrfX6uzejX0BqUr_a937kFf3sLw-nCyeony1-WN-SVUFYFxiwvLz_ktkLqRKcwzv
+vf-83DuCe0B4VcIKemjWNMT-PL0UWy66wDXWFqme6U2gQJu7D1jsZExe0Sq40DT-xm8ZM98DqNc68BgE0QWCmt9na01AUZ_EwDUwe7r-vdQRHyWcjUFCT5kB
+lTkoli-mw48YSBNyZOwmTzVwR9yMdOMu_7eMdtdhLL1N_pdYimas_U-9ppPuzOz7VyNZ2J23wytN3EWQtHMW2Y3Tpf_ripE-bT3Ka0NbslZUxbjJQARL-Cxu
+7hUeSLt59deUtsF4HojwF8vzYg2q3HdftC_OupcyFSMt151CEbmSnxm_LiGwqaUJ8FMX41caNhrYaZQ5KvHGjD7g5MLaRMm51_OVUnJaLP1rPNFwu-jz9QgZ
+CzeguACGK8UF0Z0GdmiolDH0d5yAElpefl3RyP__V08
+}
+
+AWSEntityColoring(Marketplace)
+!define Marketplace(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, Marketplace, Marketplace)
+!define Marketplace(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, Marketplace, Marketplace)
+!define MarketplaceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, Marketplace, Marketplace)
+!define MarketplaceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, Marketplace, Marketplace)

--- a/awslib/General/MobileClient.puml
+++ b/awslib/General/MobileClient.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $MobileClient [64x64/16z] {
+xTT7TiKW44JH8eXOjV_bEWu_RTevSQSwJra2y1d24fnovrBFy6WoDUnLYRqiT4eLEv6Q2GzkhpTDCMAZI4-NMSaAXFGCJx9KzbVF022AL4JI4mOy2bJRznDM
+Z-dhhVFtzxVtpz-pcEZfN-BgQNBrCmP3TDu_qw_hJt_wqv_-zAS_VNXlptVs_-B-ipT3_vBv8wV9z_p2zpu_XlUyVqKg-sssI6dKib27n8YTJ9cOiHVRvD9i
+yNthvyzm3m
+}
+
+AWSEntityColoring(MobileClient)
+!define MobileClient(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, MobileClient, MobileClient)
+!define MobileClient(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, MobileClient, MobileClient)
+!define MobileClientParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, MobileClient, MobileClient)
+!define MobileClientParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, MobileClient, MobileClient)

--- a/awslib/General/Multimedia.puml
+++ b/awslib/General/Multimedia.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Multimedia [64x64/16z] {
+rPS7jYmX24H7p4BjVxl_TBK-vsTUUzBKHD2hGYTyVRv2UgX0F1aUojB5AnvBhzKRMdga1Wlao-kHoZiV2vNP8kLMO7gd8MpAjn5_uSDA8WSOeAnTHfjDWpWe
+ah_oPeOx5fr6lum-3UMQQVoHhoBH5jz5H77F3nMHldYB8lLFFBydJtBpwtinvK-yzjunUHgsUEkzw-91umyyjNXgnKzD_Y_vUpMbXh2NtagNaQR1aMKerJZM
+mVdp0Nn8jVLUippYOxULwv6-pOT6KbKvof3lyQ80UfQhFJK3BBdvYO-upGPOzlD1WHRQs4WnM7Jp3MYl0A3BScL0lNmq3Fe1AszZ5YVVW4Y_OQSXADJ71qvF
+Vr80BSpUI2u-0NdozscWpACOgeilW92dFuwLHyLmyOtkxIzsvx53NVpij_tHS2sfGOE3PxztFWq0pJz_XSdcTmQ7C_uCf2y-6s1rhgUvU37qoSlOPr06ieDd
+0atervbvIc71noUWqm-WoJuhglVwusCe0D3qTarPyFB2v_2m-aKaO_HEdjsRVD6X65VlvZc0rJYB4GLnFpyl6-ZeNMqcmizJMR6aDJnv_iJQX-geANp0y_EW
+VZYeNyxgf_FwxRn-FAzVp-ldy_hzYSYVxbyEzq-d-xVJ_UFdwmS
+}
+
+AWSEntityColoring(Multimedia)
+!define Multimedia(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, Multimedia, Multimedia)
+!define Multimedia(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, Multimedia, Multimedia)
+!define MultimediaParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, Multimedia, Multimedia)
+!define MultimediaParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, Multimedia, Multimedia)

--- a/awslib/General/OfficeBuilding.puml
+++ b/awslib/General/OfficeBuilding.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $OfficeBuilding [64x64/16z] {
+xPLL0hGm30Q_j3Ia9Bt_SNyXh4jWtUPXqC45zu4Em1BO3c0ieBO3AXOWpNW7QxAiL-oWb_Gf9zTblTlBN__hOtgPqB6lzh-tElOg4prEaTkQiIyz0zoNiT-G
+p_IwWh43wuhpVOU0xdoV4P2ZlXigWGS1t38mt5I7BkxPZ51jv_gxoOndzCte-FqdQr_GKqfmkLCYZ7Q5VS3TUzfyzDF1AFtk_tNlp_tVtu2NxxFqX28Ck5aA
+tDHBZdksTkhwjo_uVbrz_gaK89SEaxkICRcKz0RF7n5SxjMOA-wBAK5i0Do32ToaLcQ-_s8AkDK4xj__y_h-_l-lWA0N3f3pVSoPFgdDG1DEGRF0BVaB
+}
+
+AWSEntityColoring(OfficeBuilding)
+!define OfficeBuilding(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, OfficeBuilding, OfficeBuilding)
+!define OfficeBuilding(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, OfficeBuilding, OfficeBuilding)
+!define OfficeBuildingParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, OfficeBuilding, OfficeBuilding)
+!define OfficeBuildingParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, OfficeBuilding, OfficeBuilding)

--- a/awslib/General/SAMLToken.puml
+++ b/awslib/General/SAMLToken.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SAMLToken [64x64/16z] {
+lTG7ZYKn20HGS3Qcxd_TbSN4tbyI6qjXKh_2uVV8_uYI97bt4ijnq6YE-nmlik6QurrUPJmyvKqIFiEvp_DI2_4PNitXkpnydZjkJY6UyuW1QsnWFtoILs29
+o8QNXy_TUmDQ_AaopwV7_2aYYyxdF7BWiot0X7ZA8yrnuvLwpgFW0B0gn3EkSzivwtvRM-Zm6LvACG1uFFxmb8SzTe12FRztzSjDuzQ9PzF3s-Wgie16FEUg
+nJ55BiTHuXbNStTWIF0YnDEJH-pzoICpFEFXRKt2kr_FkAfUVzV-cZS7Ek5rchlRj7WapUCNkl0Hqr-UNWw0i-OwlysjnbFZrxbiOCbdVfKtO7zzz1Tv_6_z
+J7Mid--TSptOb_McyGl3oKsF5CSGtG1EdE6CzN2kttvHWIvn__6s3Q0m7h7F4ujFh3giJg1_cS-vwDS2TQpR8U-l_SPHpZyBL286huxJTpnP7Fi5vmKTcFDp
+_mleX9Cj7FYO3bY9qpDoxsm5rU6prgjr0bx9T58GSyxihIy7l37E2zh1Uqxbd1VeC0VWrZNBdv-3KkC8AEShU8PpNi1vVWlatXCh8DFp1OJd2mZF5n2UBc0y
+lmB2qmM4vmiwuTa249ukSCAJ1OIde_8_yWC
+}
+
+AWSEntityColoring(SAMLToken)
+!define SAMLToken(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, SAMLToken, SAMLToken)
+!define SAMLToken(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, SAMLToken, SAMLToken)
+!define SAMLTokenParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, SAMLToken, SAMLToken)
+!define SAMLTokenParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, SAMLToken, SAMLToken)

--- a/awslib/General/SDK.puml
+++ b/awslib/General/SDK.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SDK [64x64/16z] {
+xPU7hcCn24JTE___koiIInF9R2vaz_LdjRIJompOOFUzLmZ_GlkwLlKlutaI4Sty6Xq7m_mN8xuWl17HAjwNHKJDQ0Ce_9C1JuWQIf9QU8ThZqvsbGs-BI9a
+3PaaMkrQn4ru3uAX_MR3XV31mfFzIpnYbYV1JJ4uI8HmwszaY-COyJ8vPufHWwWzgJYmAd_cXLG8fdj-LZtvXUZn60G61KlaRmKI3famPclYtmdyIlTzSjgC
+TrjJIqlWlKltMFrEyr4O_gufEI_pEzRzexFsvjRqLtx7kjKT3cqLJtXsRWa5iYDRxE85xoOH121yNjEf-8vD_BXrkvh78V9uT1Xu513AnyPlS0ouQU1nYEFe
+Dl4m3ZRQUHU9eZFol_pm4k-7bgTPJhvCql1eK-3neO97cmAFngRYSM8oZtTQ7jil4QMpiSby5DeKUoOqjYZmj8gsV_4NLTK_qPEEngRgtvaeQ_htsRHGFzeP
+0scMUHI6Vdu2Zo_rynjuD073_0ZUC3_2Ol18ZdL-PXx5OP_VcRVFxvZw-VmttnzGqdkD-17t9_d-Phy_Vk_r1m
+}
+
+AWSEntityColoring(SDK)
+!define SDK(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, SDK, SDK)
+!define SDK(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, SDK, SDK)
+!define SDKParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, SDK, SDK)
+!define SDKParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, SDK, SDK)

--- a/awslib/General/SSLPadlock.puml
+++ b/awslib/General/SSLPadlock.puml
@@ -1,0 +1,18 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SSLPadlock [64x64/16z] {
+pPQ7Skqu34DLg0xy_-TkuMZZQuoSSRRZlJHT7dQNyCygnX_ODjEZj5RICwiFFWTHnECYbrWNS1pnHXBr5dsIvBnbK46o7V12WkIuh6sHOv3BBe-3RbQ2AeF8
+1X8znzzJjq5oXE0_p8zo1mbpqw2LadNx9-QS88dcTU7ZoFEhsXMFqlqNczp2s47o0BUc-KadX_PkVbLInvnprFJHo7tqbVKasxrtFkVNIeiizzwzuWHHPwgO
+pR9kcwOSlPY3KbyakNfwMBVfher4F4K0jt3ABeAq7V-qqPNah6PrqbT3DUZntS7185zX2yXySE-u5mf2Qvo4XIt3jHr7f91TFh-TTAh_VX_PL8DoIzbqm4ao
+Ch9gUP_xU_ZOP1X33F0TFtJaWqks0_4RVdauiN_FHx25ntfpAMKGjNofaTtCilgxrAvwCn-Lh_QtyDGGuwFigTrnSNviRasgd7FxM8d95PxcdwyuQfDb_h9_
+1pv6uMN_PF-5pmCOMNZTVwyUwS0RI19su1EuuaSrBHpuFvvVmhlQrR6uVIcVt6rpJ7dFUKDjrw9yzlDovFsyRKzSuS1xNfOzZl2knHLbzb9_ewj9_R83dKXd
+FdIGwE7C9z0_cfpXp7kH9Ppu2unWV-GpcH_vJaJdsv_Zsx_0p_azB_V2DzUltdFrNknhTr0HFe93PxHvh8CWl7Do-RowV-e5LENvt_g3sgtwQ-qdPOLUg9Fp
+ysri_EpzRUpNfyi1wdkymd5vKryrle5ZNVkjNbqIeyYnAfK17fDD3II9DMgEnxYvZWMtQUbeK2ReMjs2oFgY2xCybvcikGzlXfJiR3C9VSnpulBWjBDUrpkb
+jaYkudlklqh9RwUKys6oRps014W8_LgfasHFxmcLhMNXVwrV0G
+}
+
+AWSEntityColoring(SSLPadlock)
+!define SSLPadlock(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, SSLPadlock, SSLPadlock)
+!define SSLPadlock(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, SSLPadlock, SSLPadlock)
+!define SSLPadlockParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, SSLPadlock, SSLPadlock)
+!define SSLPadlockParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, SSLPadlock, SSLPadlock)

--- a/awslib/General/TapeStorage.puml
+++ b/awslib/General/TapeStorage.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $TapeStorage [64x64/16z] {
+xLNNekiW30Dijld_txsuj56uXRCVqPcDF0GUCN-0WuE30qi-XC1knplkj2UxPYdLDb0ZBUXuqMb5vtQ393VJBicTp_z729sM7CWvnx5e4hxJhBbBv4vJK5h2
+v1xxeuI3ivfuq5vJUfgqnjbTlAzbrkDlxXAuL8k0yWW0lfB9SqffGizqqgERCAMa2cixJ9sqQYVDJprbcDOc3hG6jPVwSFq5ahgDGCbqS6iPBFJqz7NyKmiP
+mCaGK5vvoroJ-XJWhvEesIoWnwEHliDQ0y0lDxa8pWMjGNeUrOaddMQ3Qyj3Hy6PEeGrbQAgGSQjiYWVNdHfTOH9EB6Kfa-BT73Ho0NXQsj5z3QYqY6gSFMF
+E16Rg7ghg8wUMfqopXCDwwcJqZ7i_KFiS5j_LfhKVwD_OAj_8Ad_ylu6TlU7yFMxzKkB-g5_SdOVzKz0Uy8F_Oi6N_UlpjUYVp4t_G7jvmVpZVcPvZUetNv-
+-VgC-PtsHn2n7-mFbaQB_O7zPHo33u8wggi4OwVjzBO0sxXyxCyQBZosBvd5_aG-DS7-Nc2xln4Ja3TCTAPFtb_s3TFxwxVlpz_ZuE3Wu1y
+}
+
+AWSEntityColoring(TapeStorage)
+!define TapeStorage(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, TapeStorage, TapeStorage)
+!define TapeStorage(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, TapeStorage, TapeStorage)
+!define TapeStorageParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, TapeStorage, TapeStorage)
+!define TapeStorageParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, TapeStorage, TapeStorage)

--- a/awslib/General/Toolkit.puml
+++ b/awslib/General/Toolkit.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Toolkit [64x64/16z] {
+tPU9RlOu203nRGVc_Hzt3xIHlA9_dNxHMNgtdWd4_GAMtnqvlw7JC1lfOxmfWBRFw781gi1LFYXy0jPJwWRC_3FwfdQJF8zwPxrNKXyNlW1juKwkyYZrQM0Z
+XPq4c-SYlF2L9KHUWFL3uHTmrUT_Z9VG_aro6fBRIuo5dzV4MzpRbsJENsrEtE8E8vQ-3DEHmp_77GEi9yU1cS9VFQxagNGBrnXOSJbWS6NPeeCjWwki_uem
+8f_SlK0LD6sb6rQdupRlt_o1bwJONB1jSuFMWBx0qe6NRDZ_-OabcU1HJhnK0rWxhqbSO4zugMgs2oPM_CjQM3xm7haeh2qVhwPNHUNCkq5XtlU3BYLBgWhj
+6Uy2pw18jo4DKyMLHtxF80rhKgJXOKEUyovGe4bIM6lrB0S-2d11sHuAptcPeCC5IHxn4S_INF0v7mGF-Um2BIwmzbE-Mjy5jETyxcijW-822u83tmsF8JK5
+mPaVWAhHfN45mP4lO2r9gj8CQYZXn2-i-OCutzrk5npvf5oJA_cQIppsNJZoXe4BBkTtWM7jp8EvG9tV1UFRvwV_HIwugi4eR6icMCuAC_IFqB-qB5XL_Lfx
+1ZU-zQ_OFzCg2-owbsm2cB5_nluz3OyPNerJOl-Eiq7gQbYSK-OypHZvTkUSdiylx-Udz_FR-_dn_VpwVdv-Fx-_Fp-yFx_4yzFByzlBy-FlZhy1
+}
+
+AWSEntityColoring(Toolkit)
+!define Toolkit(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, Toolkit, Toolkit)
+!define Toolkit(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, Toolkit, Toolkit)
+!define ToolkitParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, Toolkit, Toolkit)
+!define ToolkitParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, Toolkit, Toolkit)

--- a/awslib/General/TraditionalServer.puml
+++ b/awslib/General/TraditionalServer.puml
@@ -1,0 +1,12 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $TraditionalServer [64x64/16z] {
+xTUv3KHH24FHj-_qt-uqW0mIypFV_2JEdFvRDeEyFhEA_1IpYVoGDmTeFXc6pt0UsvS4AZwVrTo-FxNkzUE9qXjUNuPQSNhGfvxxSt_kp_r1zFJqzFJqz87_
+5FvlyVyO_w_n_npl1m
+}
+
+AWSEntityColoring(TraditionalServer)
+!define TraditionalServer(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, TraditionalServer, TraditionalServer)
+!define TraditionalServer(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, TraditionalServer, TraditionalServer)
+!define TraditionalServerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, TraditionalServer, TraditionalServer)
+!define TraditionalServerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, TraditionalServer, TraditionalServer)

--- a/awslib/General/User.puml
+++ b/awslib/General/User.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $User [64x64/16z] {
+jPO7elGW28GH4vKozp_kNxRmMehXxNvRKqR6g0YzbVAFj7OTQkwcOqsqmSCH-E2BiRi3S1rZYDx-zal15O0-RVDwEoppSWDieK-i1XXVaCktQ4K0ctIWmA0V
+220qGzk-iIYmqZd5uPj6sM5puHjjqgSC6ApiEbCwWu5EEupesJuhi2Ik1HtE1zuQdJ1WvM1eEfqWC3hGZpV4J_K___ppuoyJuq-Qc7-9-PzRV-MDwp-GNFu9
+oaR-OuqCdCo_ytAgWbl-Pxh1pG10wkIsftZW9cE8EMx4Zh97E8LhUxGIodOxjfKEOG7W_MQyDZ7_Xqcx7NDt0C97mHtmNYWepENRhkhx5dgqV-YlqoP5el4J
+Yr9sv5Rfb6hR3GYWF5iSo5RVhSpFx_upDHbVgI_MxslRAqrJ_LkMbQsaCvyZbZYSHO250Wqxix13FuVlT94U1Y9yra051brc03MiLBfCZKuRZAuHijZn4dI0
+OrTDi03hN5LrN8qeZ58OzFuZb49WOIF1hUDH52Nehz8tIj5UfTUUGkzw84yX8l4qGlyfQUZt_0K
+}
+
+AWSEntityColoring(User)
+!define User(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, User, User)
+!define User(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, User, User)
+!define UserParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, User, User)
+!define UserParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, User, User)

--- a/awslib/General/Users.puml
+++ b/awslib/General/Users.puml
@@ -1,0 +1,18 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Users [64x64/16z] {
+hPQ7SaGh28P1hC3__ezxozdAuCcOcNp9Dbsgm4f_33EVRcQugxlR5DeWqznT-xsAvdZWWnBZlTbeJmTWSqm5i8WY2u2ECGr0trj_gwu630fCmEeZH0SgPTZW
+h_LYS0cn0_QAkpfiR_xZLmLcCF-jRsmTM72cDmgBlYczAOv92ONIXn6q5G_v-6WBYokSXPSlUQ3lJTrvF9FzhQaeKMvTD5WuZ449mPVMZbWau_lp0eGowwEs
+EOn3SVYdE4QepX0aLcLYcO3Nt1fJYBWguBmJdmu0RjSBLb1G5VzZZqsV9JUF0xXsNwyjT5RSz4u1NW2qiWmrdOrbNWbWgLBu_z1y2hUffaEk4B3uMrm1Ysqj
+XPe-l5sLH68s350EgTT2aMfueqAHek6qBssH0S1dhwqlp_5U7lVFmNb9rGWV_DoVOUOaeGcqF0pio-VgGCrVcQ_Qqeto47Az2ZAYppfgsVn8Isdb8xTIFN9e
+j-1aN5hxQI90lsdlF34uJxCE26LlQrR9b_n8uITR99iilUIdV5EkZQryaM_UzYDA7KZsAr194RdaBSdNx2iDe2JvgoPAZKWuh311fKOAxPb0JUaVT8myoZKM
+DDCv8tPqiL1H1op0QXY-z1ju081s4Qd307ZdtqWx4ZvEDJG7OACjnuMlDWrNG0Vm1A3jKHbzZ5xv_zLcE4e2wsPQlYzEYm_4jT0M2LF_LdpnZxlq4nDOFwh_
+kOmhGjrcYW5ohpvS6syjq1tzeCacq6xD9-ypxBSEjACcoxVNV8FDx6-l-VVa0Dr7cQVcVPRbV3qZDtRcGVZnCXnPC3g13VCcBtI4OPtO_xsyZoFyplzJzlQ7
+7xClSpw6_ev_0G
+}
+
+AWSEntityColoring(Users)
+!define Users(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, Users, Users)
+!define Users(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, Users, Users)
+!define UsersParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, Users, Users)
+!define UsersParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, Users, Users)

--- a/awslib/General/all.puml
+++ b/awslib/General/all.puml
@@ -1,0 +1,281 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $Client [64x64/16z] {
+xTT5WWKn24NHXyHX_yjjTuUsBpdpMruH702jAOeRD3nf4AvqJ-i0o7m99yXoevk-8gK-wTi8QizwyJ1vqQ-GrxqYG5_tWW3vcNxtkz_zxdU_-pa2vgi-wdbF
+OmKDGlsfzSSa9D2ywJ7SLuhxm1LUdhGOrwYEb4hu8SG9X3lSBQKpVkBv3VVPQbYR3-ldYPGP-dxrEKRi-s_-d76i7_w2_6tVxNkzzFVt3nqf_QR7T2kSKEu-
+7FKqnRLgdc8LjxZKXC8u09S
+}
+
+AWSEntityColoring(Client)
+!define Client(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, Client, Client)
+!define Client(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, Client, Client)
+!define ClientParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, Client, Client)
+!define ClientParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, Client, Client)
+
+sprite $Disk [64x64/16z] {
+j5HNWaCX27nI5XHo_-kkJr8jwPcV51bWQDilaHhUeW9hCM-meWmlaL7iqC44dsLpQGoth5AXsRpzKVWfjaKukjATIEBVXnvmZ-sAanVrFOVxAlwyiYKjkY7x
+wz-QdNADe72dALeDSbgzMbL8z_NHRWDBUddOPoZXO4hNxGder44A-hCEXXhae3_h8FUDgzgtfr5hSDj6z4LLbvrox1pIzWBeDbrUYr-Nu6eNQZhJx1DMfAc2
+AlWwl4nCf7ZRuo8JvtALG3bu6a9h8mTSntS_Lm0dwiagpPI9MDjNcbG0pwbWJw_1ovb2fQRGEy2pQ3lOX2wTsjx1cGPXs-q2nniYd4fiQQWW79zea2PNfv2F
+rZhC48Urfxwt9QxH4Jb5aw3lW4RtR4YCOYDTcCLZssYGQT51wvSn779SexWu7ERzojivZJwlcEdhMUrrnX_DNFh6SdJbjjBSZuai-NJo4eWEqITyNFC_p_-_
+zFeG00200HZcRns8p62_ZVfb_tP-TdvtVtP_ytxi_ThxcVTx_qV-h_sV-R-N7v9Vaf-Mtv8Var-JdvFVpn_UNzwVtj_U7zzVtvy_
+}
+
+AWSEntityColoring(Disk)
+!define Disk(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, Disk, Disk)
+!define Disk(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, Disk, Disk)
+!define DiskParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, Disk, Disk)
+!define DiskParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, Disk, Disk)
+
+sprite $Forums [64x64/16z] {
+pTT94W8X38NX920pzp-kiqiwL1uKVljVUmxGSJwO-MVEhPirNj97COc_Ff19K7kNnsIYlxK-v2PwNyT4wLNh-bPDsgVlW6TF8Pi5-WTiHY-vcMN2hp-tNf99
+MVZyYaBffIdakdTTuQvx3WhU-VucRvBMVF-hlQ_FdiIR2Ps67Zz-_V3v3Jm_c-UNX356v_TKFpOrlsLiqVkFVxyxWC7vXSxFuz3r2tpzyVNR-VLd8AcApVDR
+iaBsdJ--VpB3UtJ_Ujm3
+}
+
+AWSEntityColoring(Forums)
+!define Forums(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, Forums, Forums)
+!define Forums(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, Forums, Forums)
+!define ForumsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, Forums, Forums)
+!define ForumsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, Forums, Forums)
+
+sprite $General [64x64/16z] {
+xTO5LaGn30NGbzJRzEz_jpW4w_b9SNamCyTktV1L-G_T_n9YBRxK0h3wUandv8alqvln0_o_bvpb3RuIG7NNzu0uHaJeEtuaS9jNQOmql5uAjE6LKCJb6oEh
+c9B1pUIru_D9T1XElIIjx6cJaXXy8zJ5R8BQkSzOUsI3ftNxoU0JhyUFayKlvy_e5-l7x7Nztinur_Lhyulzu_QwVtVz56QPVg-9SNwk__SqLdwGmJUY8gzv
+AKJDUtx5w3k_TE6hr_tlFxzZrFs_St_4gFj_u_uwOZpyzvSEGmeX8VGlkB_r_V3ztp__liutllzbEDEV-8sydmU7dR1MIrl1RyWb
+}
+
+AWSEntityColoring(General)
+!define General(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, General, General)
+!define General(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, General, General)
+!define GeneralParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, General, General)
+!define GeneralParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, General, General)
+
+sprite $GenericDatabase [64x64/16z] {
+xPS72aCX341_rP-T-r-t8jrr5IdJnqPU1hXo_8_BWr_5a81Or6weC44ASs4Yi7eLPOW3EU3DDHKXmWAHYDej1eQEJNRByopssTAjBgDM1B2Ie5DZBEKPL1VH
+tJaT0nAxEzOMtEqy9ZZDlP96tE8nHJINumlznTTQ_ldww_ap78V9sJDQyyiU4UXj492oj-e-1VOId226BpK2QLdcG0t_VVyo8K86aVXz_xRzJ4Gnhs9IzkR0
+prpYYIIgPfOjCrKXFEFjI8pzv_qHCi_xOyAlynz_-zlV_lQtl_tjRvzdVQxvx9Rcz6JEg__tnVbXSNvPdf_MvxVr-N5zVbsVdzUv0W
+}
+
+AWSEntityColoring(GenericDatabase)
+!define GenericDatabase(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, GenericDatabase, GenericDatabase)
+!define GenericDatabase(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, GenericDatabase, GenericDatabase)
+!define GenericDatabaseParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, GenericDatabase, GenericDatabase)
+!define GenericDatabaseParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, GenericDatabase, GenericDatabase)
+
+sprite $InternetAlt1 [64x64/16z] {
+xPK73gD034NjwIx__jVT4R8YM6K8iBqy5PhVZpBDz7kISiw97xfLp34nQUc-FJOtSBcPq7opUgsrYm7mVaSV0BHoF74H0CgNTG6yqfvYWAMB-dXJom8ONzBh
+-qe1v8hE3i_q1WNQ1N-iofB3cPkQQUEpdzVr7rF3XjULtu3bjqqs4SEwIE5yChBUc8ZRQeo8_MIKsRn44XPbwNIGcIaGUA8t5A3iqcX50Uf7VxZmUfhUVEDc
+kznnjciCi97fG3LCoavV1iJNmxdG0LZFXu9rG6vwN4WzPlUbcyBqREDd0L1tsouVz_2OxYeWfDT2OeD_fTE0qQS0GEC6VJ-BKzzyulDzEsB0vR3k-zJ39rQX
+DSanQ6B7RSiKVjolqQs87PqEXF-H0UTlyVltyiTpFuRXaHzY1yeJdnqIysXF_0RKA8RSzxF3E3O08EccNtRdJJB0H-QBVlJrtRGbmSHKDaRuNO8-xqSb6hAX
+vfXqsb4LBvn9VFhgyQn4vaBiknh9T2GtKTiGfgQ3Q5Wmfez1BBQXCcgYMsp-WP_l__V_-tpV7CelFrcxgpT0EVnaGBxfHnUU_gOFeWS1meeH-gC0DMZepm8c
+eJyB2FrnGEZF0q9_2cVwFVa2
+}
+
+AWSEntityColoring(InternetAlt1)
+!define InternetAlt1(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, InternetAlt1, InternetAlt1)
+!define InternetAlt1(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, InternetAlt1, InternetAlt1)
+!define InternetAlt1Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, InternetAlt1, InternetAlt1)
+!define InternetAlt1Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, InternetAlt1, InternetAlt1)
+
+sprite $InternetAlt2 [64x64/16z] {
+xPNfjlCW24KXgAXmtlznly7BQbocTkNsTtRdojP3HhhmyF30p5-xKfgvktLDNonS32TMVXaZsT1QrTf-llugGm5WAl7hK0DGx-iAGEV4h0uqlh-wht75W7Qp
+Ty25LhZVR84DIBl_xwLNUeSuZ2XfQve-Bc-ytQorOz1bvsUWVEWCS3C0lelGuFoXDTI3wAZOLR6XqOx3KSvMtfTiuiUeKD0t0GJ8T8EygKlpJiwc7rgfx_Gs
+pPkn7WhQ2WK6xuMNy0q0qgcl4vWt2aQfAyyzEO1U9dsTmCxGdAi1C5dtxgcxmHtGrJ-diEb04eTdclLKqSK0lVe1A-2nP0SctU69Aema4gn-e42B7JUDoSWr
+V183ojQd1enDK3621DKpXK_YdVU-H3n3fmcXbqy7qzuFaNqT2Z_O-nNEmzVlVBtb7pBvYQ_-v_o7kRpyZCwB7vjXwnV09VmCGEOTQB4PPE-J0Yx37qVczO8b
+GDlwaI1rrD2lrzi6wDQF2NmyCytBmpckA83k_6W1M5O_-Yab1opprYTTzQFutBKO0EzL_rCr_59rK0lfq3KAcZc0nijj7e4pLJUYxl6x4vMUY1qdjbo4EJVp
+7un9hH4r3rgKl0fwJKnNE3X_1c_77nuU_W8
+}
+
+AWSEntityColoring(InternetAlt2)
+!define InternetAlt2(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, InternetAlt2, InternetAlt2)
+!define InternetAlt2(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, InternetAlt2, InternetAlt2)
+!define InternetAlt2Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, InternetAlt2, InternetAlt2)
+!define InternetAlt2Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, InternetAlt2, InternetAlt2)
+
+sprite $InternetGateway [64x64/16z] {
+xPL7SiCm34K5TfH__-jc97Ci2Yf3PwstIMoZynDSJhoyl13HltrZOJKpbPh-aRWeThJyM4RIpOrRRVpvzwSQ2W2jiNyALG6qUVSAeDBOJJM0QJwx-NAZ0ZpP
+Es1nyP1Cja0AfBllvwglrtemwBAaobpJOtgbsx4smOR4E_yCb8VE05F5C60Fm-X95YqiIsYuio9zEAPWA7ihroQ7yZtXsxRS5920l4oGR-oIF-JxLjgLEv_Z
+KbZnbWeJVwiZ0yVybAge0J2LbaRppTGgZJqP02b3l6OOiHRtoBaf08tkT7qrfbnBAPMtCi1nA2xh8AHeiB7rkbMJzu0XRm4RZNi1i6uXXya5sPDHY85wGrxx
+5LrlwQ2eQ7tbKUO-FzvAYUAk9mDRl0OBHndJAdJpuwDsr7ViyHHoq4Vf8u19AxaqiNvUZkv8Nazz19BfEsq1eC7xDnXj_dxho3Q2Ba3ghy9vCzOx_sZh2AY8
+6SoaXBNvjDpwjyMnbbeC7TUyyn_cvqUWN5Vv0TUBaQ5z3F7gDckchrZvOM55NFsScNRBGa_xbfsmvY25KTyexj6S8GnoJjQxdVSkDdOTzIFNEaNxN2mczyp_
+XBfbkLtNEVQDwA0vkklBoyiV
+}
+
+AWSEntityColoring(InternetGateway)
+!define InternetGateway(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, InternetGateway, InternetGateway)
+!define InternetGateway(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, InternetGateway, InternetGateway)
+!define InternetGatewayParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, InternetGateway, InternetGateway)
+!define InternetGatewayParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, InternetGateway, InternetGateway)
+
+sprite $Marketplace [64x64/16z] {
+xPK7jYCX30HRGcGnzp_kVkJ0Ss17csCvoov2F-4Plnd_-Oz-cvquhH6QSFqYlH00BiFe4G2akUqMW3IjyE5e9d2PfQWkUuesMHCWLWQIsf90MHqwWMwRhGH0
+-YqIGCxz2Y3htG0ikkjosEFptF1rnOm0sut5uVEJHY2K07lNBKqBKSddsrfX6uzejX0BqUr_a937kFf3sLw-nCyeony1-WN-SVUFYFxiwvLz_ktkLqRKcwzv
+vf-83DuCe0B4VcIKemjWNMT-PL0UWy66wDXWFqme6U2gQJu7D1jsZExe0Sq40DT-xm8ZM98DqNc68BgE0QWCmt9na01AUZ_EwDUwe7r-vdQRHyWcjUFCT5kB
+lTkoli-mw48YSBNyZOwmTzVwR9yMdOMu_7eMdtdhLL1N_pdYimas_U-9ppPuzOz7VyNZ2J23wytN3EWQtHMW2Y3Tpf_ripE-bT3Ka0NbslZUxbjJQARL-Cxu
+7hUeSLt59deUtsF4HojwF8vzYg2q3HdftC_OupcyFSMt151CEbmSnxm_LiGwqaUJ8FMX41caNhrYaZQ5KvHGjD7g5MLaRMm51_OVUnJaLP1rPNFwu-jz9QgZ
+CzeguACGK8UF0Z0GdmiolDH0d5yAElpefl3RyP__V08
+}
+
+AWSEntityColoring(Marketplace)
+!define Marketplace(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, Marketplace, Marketplace)
+!define Marketplace(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, Marketplace, Marketplace)
+!define MarketplaceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, Marketplace, Marketplace)
+!define MarketplaceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, Marketplace, Marketplace)
+
+sprite $MobileClient [64x64/16z] {
+xTT7TiKW44JH8eXOjV_bEWu_RTevSQSwJra2y1d24fnovrBFy6WoDUnLYRqiT4eLEv6Q2GzkhpTDCMAZI4-NMSaAXFGCJx9KzbVF022AL4JI4mOy2bJRznDM
+Z-dhhVFtzxVtpz-pcEZfN-BgQNBrCmP3TDu_qw_hJt_wqv_-zAS_VNXlptVs_-B-ipT3_vBv8wV9z_p2zpu_XlUyVqKg-sssI6dKib27n8YTJ9cOiHVRvD9i
+yNthvyzm3m
+}
+
+AWSEntityColoring(MobileClient)
+!define MobileClient(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, MobileClient, MobileClient)
+!define MobileClient(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, MobileClient, MobileClient)
+!define MobileClientParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, MobileClient, MobileClient)
+!define MobileClientParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, MobileClient, MobileClient)
+
+sprite $Multimedia [64x64/16z] {
+rPS7jYmX24H7p4BjVxl_TBK-vsTUUzBKHD2hGYTyVRv2UgX0F1aUojB5AnvBhzKRMdga1Wlao-kHoZiV2vNP8kLMO7gd8MpAjn5_uSDA8WSOeAnTHfjDWpWe
+ah_oPeOx5fr6lum-3UMQQVoHhoBH5jz5H77F3nMHldYB8lLFFBydJtBpwtinvK-yzjunUHgsUEkzw-91umyyjNXgnKzD_Y_vUpMbXh2NtagNaQR1aMKerJZM
+mVdp0Nn8jVLUippYOxULwv6-pOT6KbKvof3lyQ80UfQhFJK3BBdvYO-upGPOzlD1WHRQs4WnM7Jp3MYl0A3BScL0lNmq3Fe1AszZ5YVVW4Y_OQSXADJ71qvF
+Vr80BSpUI2u-0NdozscWpACOgeilW92dFuwLHyLmyOtkxIzsvx53NVpij_tHS2sfGOE3PxztFWq0pJz_XSdcTmQ7C_uCf2y-6s1rhgUvU37qoSlOPr06ieDd
+0atervbvIc71noUWqm-WoJuhglVwusCe0D3qTarPyFB2v_2m-aKaO_HEdjsRVD6X65VlvZc0rJYB4GLnFpyl6-ZeNMqcmizJMR6aDJnv_iJQX-geANp0y_EW
+VZYeNyxgf_FwxRn-FAzVp-ldy_hzYSYVxbyEzq-d-xVJ_UFdwmS
+}
+
+AWSEntityColoring(Multimedia)
+!define Multimedia(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, Multimedia, Multimedia)
+!define Multimedia(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, Multimedia, Multimedia)
+!define MultimediaParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, Multimedia, Multimedia)
+!define MultimediaParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, Multimedia, Multimedia)
+
+sprite $OfficeBuilding [64x64/16z] {
+xPLL0hGm30Q_j3Ia9Bt_SNyXh4jWtUPXqC45zu4Em1BO3c0ieBO3AXOWpNW7QxAiL-oWb_Gf9zTblTlBN__hOtgPqB6lzh-tElOg4prEaTkQiIyz0zoNiT-G
+p_IwWh43wuhpVOU0xdoV4P2ZlXigWGS1t38mt5I7BkxPZ51jv_gxoOndzCte-FqdQr_GKqfmkLCYZ7Q5VS3TUzfyzDF1AFtk_tNlp_tVtu2NxxFqX28Ck5aA
+tDHBZdksTkhwjo_uVbrz_gaK89SEaxkICRcKz0RF7n5SxjMOA-wBAK5i0Do32ToaLcQ-_s8AkDK4xj__y_h-_l-lWA0N3f3pVSoPFgdDG1DEGRF0BVaB
+}
+
+AWSEntityColoring(OfficeBuilding)
+!define OfficeBuilding(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, OfficeBuilding, OfficeBuilding)
+!define OfficeBuilding(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, OfficeBuilding, OfficeBuilding)
+!define OfficeBuildingParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, OfficeBuilding, OfficeBuilding)
+!define OfficeBuildingParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, OfficeBuilding, OfficeBuilding)
+
+sprite $SAMLToken [64x64/16z] {
+lTG7ZYKn20HGS3Qcxd_TbSN4tbyI6qjXKh_2uVV8_uYI97bt4ijnq6YE-nmlik6QurrUPJmyvKqIFiEvp_DI2_4PNitXkpnydZjkJY6UyuW1QsnWFtoILs29
+o8QNXy_TUmDQ_AaopwV7_2aYYyxdF7BWiot0X7ZA8yrnuvLwpgFW0B0gn3EkSzivwtvRM-Zm6LvACG1uFFxmb8SzTe12FRztzSjDuzQ9PzF3s-Wgie16FEUg
+nJ55BiTHuXbNStTWIF0YnDEJH-pzoICpFEFXRKt2kr_FkAfUVzV-cZS7Ek5rchlRj7WapUCNkl0Hqr-UNWw0i-OwlysjnbFZrxbiOCbdVfKtO7zzz1Tv_6_z
+J7Mid--TSptOb_McyGl3oKsF5CSGtG1EdE6CzN2kttvHWIvn__6s3Q0m7h7F4ujFh3giJg1_cS-vwDS2TQpR8U-l_SPHpZyBL286huxJTpnP7Fi5vmKTcFDp
+_mleX9Cj7FYO3bY9qpDoxsm5rU6prgjr0bx9T58GSyxihIy7l37E2zh1Uqxbd1VeC0VWrZNBdv-3KkC8AEShU8PpNi1vVWlatXCh8DFp1OJd2mZF5n2UBc0y
+lmB2qmM4vmiwuTa249ukSCAJ1OIde_8_yWC
+}
+
+AWSEntityColoring(SAMLToken)
+!define SAMLToken(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, SAMLToken, SAMLToken)
+!define SAMLToken(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, SAMLToken, SAMLToken)
+!define SAMLTokenParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, SAMLToken, SAMLToken)
+!define SAMLTokenParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, SAMLToken, SAMLToken)
+
+sprite $SDK [64x64/16z] {
+xPU7hcCn24JTE___koiIInF9R2vaz_LdjRIJompOOFUzLmZ_GlkwLlKlutaI4Sty6Xq7m_mN8xuWl17HAjwNHKJDQ0Ce_9C1JuWQIf9QU8ThZqvsbGs-BI9a
+3PaaMkrQn4ru3uAX_MR3XV31mfFzIpnYbYV1JJ4uI8HmwszaY-COyJ8vPufHWwWzgJYmAd_cXLG8fdj-LZtvXUZn60G61KlaRmKI3famPclYtmdyIlTzSjgC
+TrjJIqlWlKltMFrEyr4O_gufEI_pEzRzexFsvjRqLtx7kjKT3cqLJtXsRWa5iYDRxE85xoOH121yNjEf-8vD_BXrkvh78V9uT1Xu513AnyPlS0ouQU1nYEFe
+Dl4m3ZRQUHU9eZFol_pm4k-7bgTPJhvCql1eK-3neO97cmAFngRYSM8oZtTQ7jil4QMpiSby5DeKUoOqjYZmj8gsV_4NLTK_qPEEngRgtvaeQ_htsRHGFzeP
+0scMUHI6Vdu2Zo_rynjuD073_0ZUC3_2Ol18ZdL-PXx5OP_VcRVFxvZw-VmttnzGqdkD-17t9_d-Phy_Vk_r1m
+}
+
+AWSEntityColoring(SDK)
+!define SDK(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, SDK, SDK)
+!define SDK(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, SDK, SDK)
+!define SDKParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, SDK, SDK)
+!define SDKParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, SDK, SDK)
+
+sprite $SSLPadlock [64x64/16z] {
+pPQ7Skqu34DLg0xy_-TkuMZZQuoSSRRZlJHT7dQNyCygnX_ODjEZj5RICwiFFWTHnECYbrWNS1pnHXBr5dsIvBnbK46o7V12WkIuh6sHOv3BBe-3RbQ2AeF8
+1X8znzzJjq5oXE0_p8zo1mbpqw2LadNx9-QS88dcTU7ZoFEhsXMFqlqNczp2s47o0BUc-KadX_PkVbLInvnprFJHo7tqbVKasxrtFkVNIeiizzwzuWHHPwgO
+pR9kcwOSlPY3KbyakNfwMBVfher4F4K0jt3ABeAq7V-qqPNah6PrqbT3DUZntS7185zX2yXySE-u5mf2Qvo4XIt3jHr7f91TFh-TTAh_VX_PL8DoIzbqm4ao
+Ch9gUP_xU_ZOP1X33F0TFtJaWqks0_4RVdauiN_FHx25ntfpAMKGjNofaTtCilgxrAvwCn-Lh_QtyDGGuwFigTrnSNviRasgd7FxM8d95PxcdwyuQfDb_h9_
+1pv6uMN_PF-5pmCOMNZTVwyUwS0RI19su1EuuaSrBHpuFvvVmhlQrR6uVIcVt6rpJ7dFUKDjrw9yzlDovFsyRKzSuS1xNfOzZl2knHLbzb9_ewj9_R83dKXd
+FdIGwE7C9z0_cfpXp7kH9Ppu2unWV-GpcH_vJaJdsv_Zsx_0p_azB_V2DzUltdFrNknhTr0HFe93PxHvh8CWl7Do-RowV-e5LENvt_g3sgtwQ-qdPOLUg9Fp
+ysri_EpzRUpNfyi1wdkymd5vKryrle5ZNVkjNbqIeyYnAfK17fDD3II9DMgEnxYvZWMtQUbeK2ReMjs2oFgY2xCybvcikGzlXfJiR3C9VSnpulBWjBDUrpkb
+jaYkudlklqh9RwUKys6oRps014W8_LgfasHFxmcLhMNXVwrV0G
+}
+
+AWSEntityColoring(SSLPadlock)
+!define SSLPadlock(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, SSLPadlock, SSLPadlock)
+!define SSLPadlock(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, SSLPadlock, SSLPadlock)
+!define SSLPadlockParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, SSLPadlock, SSLPadlock)
+!define SSLPadlockParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, SSLPadlock, SSLPadlock)
+
+sprite $TapeStorage [64x64/16z] {
+xLNNekiW30Dijld_txsuj56uXRCVqPcDF0GUCN-0WuE30qi-XC1knplkj2UxPYdLDb0ZBUXuqMb5vtQ393VJBicTp_z729sM7CWvnx5e4hxJhBbBv4vJK5h2
+v1xxeuI3ivfuq5vJUfgqnjbTlAzbrkDlxXAuL8k0yWW0lfB9SqffGizqqgERCAMa2cixJ9sqQYVDJprbcDOc3hG6jPVwSFq5ahgDGCbqS6iPBFJqz7NyKmiP
+mCaGK5vvoroJ-XJWhvEesIoWnwEHliDQ0y0lDxa8pWMjGNeUrOaddMQ3Qyj3Hy6PEeGrbQAgGSQjiYWVNdHfTOH9EB6Kfa-BT73Ho0NXQsj5z3QYqY6gSFMF
+E16Rg7ghg8wUMfqopXCDwwcJqZ7i_KFiS5j_LfhKVwD_OAj_8Ad_ylu6TlU7yFMxzKkB-g5_SdOVzKz0Uy8F_Oi6N_UlpjUYVp4t_G7jvmVpZVcPvZUetNv-
+-VgC-PtsHn2n7-mFbaQB_O7zPHo33u8wggi4OwVjzBO0sxXyxCyQBZosBvd5_aG-DS7-Nc2xln4Ja3TCTAPFtb_s3TFxwxVlpz_ZuE3Wu1y
+}
+
+AWSEntityColoring(TapeStorage)
+!define TapeStorage(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, TapeStorage, TapeStorage)
+!define TapeStorage(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, TapeStorage, TapeStorage)
+!define TapeStorageParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, TapeStorage, TapeStorage)
+!define TapeStorageParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, TapeStorage, TapeStorage)
+
+sprite $Toolkit [64x64/16z] {
+tPU9RlOu203nRGVc_Hzt3xIHlA9_dNxHMNgtdWd4_GAMtnqvlw7JC1lfOxmfWBRFw781gi1LFYXy0jPJwWRC_3FwfdQJF8zwPxrNKXyNlW1juKwkyYZrQM0Z
+XPq4c-SYlF2L9KHUWFL3uHTmrUT_Z9VG_aro6fBRIuo5dzV4MzpRbsJENsrEtE8E8vQ-3DEHmp_77GEi9yU1cS9VFQxagNGBrnXOSJbWS6NPeeCjWwki_uem
+8f_SlK0LD6sb6rQdupRlt_o1bwJONB1jSuFMWBx0qe6NRDZ_-OabcU1HJhnK0rWxhqbSO4zugMgs2oPM_CjQM3xm7haeh2qVhwPNHUNCkq5XtlU3BYLBgWhj
+6Uy2pw18jo4DKyMLHtxF80rhKgJXOKEUyovGe4bIM6lrB0S-2d11sHuAptcPeCC5IHxn4S_INF0v7mGF-Um2BIwmzbE-Mjy5jETyxcijW-822u83tmsF8JK5
+mPaVWAhHfN45mP4lO2r9gj8CQYZXn2-i-OCutzrk5npvf5oJA_cQIppsNJZoXe4BBkTtWM7jp8EvG9tV1UFRvwV_HIwugi4eR6icMCuAC_IFqB-qB5XL_Lfx
+1ZU-zQ_OFzCg2-owbsm2cB5_nluz3OyPNerJOl-Eiq7gQbYSK-OypHZvTkUSdiylx-Udz_FR-_dn_VpwVdv-Fx-_Fp-yFx_4yzFByzlBy-FlZhy1
+}
+
+AWSEntityColoring(Toolkit)
+!define Toolkit(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, Toolkit, Toolkit)
+!define Toolkit(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, Toolkit, Toolkit)
+!define ToolkitParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, Toolkit, Toolkit)
+!define ToolkitParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, Toolkit, Toolkit)
+
+sprite $TraditionalServer [64x64/16z] {
+xTUv3KHH24FHj-_qt-uqW0mIypFV_2JEdFvRDeEyFhEA_1IpYVoGDmTeFXc6pt0UsvS4AZwVrTo-FxNkzUE9qXjUNuPQSNhGfvxxSt_kp_r1zFJqzFJqz87_
+5FvlyVyO_w_n_npl1m
+}
+
+AWSEntityColoring(TraditionalServer)
+!define TraditionalServer(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, TraditionalServer, TraditionalServer)
+!define TraditionalServer(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, TraditionalServer, TraditionalServer)
+!define TraditionalServerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, TraditionalServer, TraditionalServer)
+!define TraditionalServerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, TraditionalServer, TraditionalServer)
+
+sprite $User [64x64/16z] {
+jPO7elGW28GH4vKozp_kNxRmMehXxNvRKqR6g0YzbVAFj7OTQkwcOqsqmSCH-E2BiRi3S1rZYDx-zal15O0-RVDwEoppSWDieK-i1XXVaCktQ4K0ctIWmA0V
+220qGzk-iIYmqZd5uPj6sM5puHjjqgSC6ApiEbCwWu5EEupesJuhi2Ik1HtE1zuQdJ1WvM1eEfqWC3hGZpV4J_K___ppuoyJuq-Qc7-9-PzRV-MDwp-GNFu9
+oaR-OuqCdCo_ytAgWbl-Pxh1pG10wkIsftZW9cE8EMx4Zh97E8LhUxGIodOxjfKEOG7W_MQyDZ7_Xqcx7NDt0C97mHtmNYWepENRhkhx5dgqV-YlqoP5el4J
+Yr9sv5Rfb6hR3GYWF5iSo5RVhSpFx_upDHbVgI_MxslRAqrJ_LkMbQsaCvyZbZYSHO250Wqxix13FuVlT94U1Y9yra051brc03MiLBfCZKuRZAuHijZn4dI0
+OrTDi03hN5LrN8qeZ58OzFuZb49WOIF1hUDH52Nehz8tIj5UfTUUGkzw84yX8l4qGlyfQUZt_0K
+}
+
+AWSEntityColoring(User)
+!define User(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, User, User)
+!define User(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, User, User)
+!define UserParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, User, User)
+!define UserParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, User, User)
+
+sprite $Users [64x64/16z] {
+hPQ7SaGh28P1hC3__ezxozdAuCcOcNp9Dbsgm4f_33EVRcQugxlR5DeWqznT-xsAvdZWWnBZlTbeJmTWSqm5i8WY2u2ECGr0trj_gwu630fCmEeZH0SgPTZW
+h_LYS0cn0_QAkpfiR_xZLmLcCF-jRsmTM72cDmgBlYczAOv92ONIXn6q5G_v-6WBYokSXPSlUQ3lJTrvF9FzhQaeKMvTD5WuZ449mPVMZbWau_lp0eGowwEs
+EOn3SVYdE4QepX0aLcLYcO3Nt1fJYBWguBmJdmu0RjSBLb1G5VzZZqsV9JUF0xXsNwyjT5RSz4u1NW2qiWmrdOrbNWbWgLBu_z1y2hUffaEk4B3uMrm1Ysqj
+XPe-l5sLH68s350EgTT2aMfueqAHek6qBssH0S1dhwqlp_5U7lVFmNb9rGWV_DoVOUOaeGcqF0pio-VgGCrVcQ_Qqeto47Az2ZAYppfgsVn8Isdb8xTIFN9e
+j-1aN5hxQI90lsdlF34uJxCE26LlQrR9b_n8uITR99iilUIdV5EkZQryaM_UzYDA7KZsAr194RdaBSdNx2iDe2JvgoPAZKWuh311fKOAxPb0JUaVT8myoZKM
+DDCv8tPqiL1H1op0QXY-z1ju081s4Qd307ZdtqWx4ZvEDJG7OACjnuMlDWrNG0Vm1A3jKHbzZ5xv_zLcE4e2wsPQlYzEYm_4jT0M2LF_LdpnZxlq4nDOFwh_
+kOmhGjrcYW5ohpvS6syjq1tzeCacq6xD9-ypxBSEjACcoxVNV8FDx6-l-VVa0Dr7cQVcVPRbV3qZDtRcGVZnCXnPC3g13VCcBtI4OPtO_xsyZoFyplzJzlQ7
+7xClSpw6_ev_0G
+}
+
+AWSEntityColoring(Users)
+!define Users(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, Users, Users)
+!define Users(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, Users, Users)
+!define UsersParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, Users, Users)
+!define UsersParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, Users, Users)
+

--- a/awslib/GroupIcons/AutoScalingGroup.puml
+++ b/awslib/GroupIcons/AutoScalingGroup.puml
@@ -1,0 +1,12 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $AutoScalingGroup [64x64/16z] {
+xPPLeiD030EbWBNtl_23ejima-SlC4wMbPe90hDfEccJT80sIPzGm0W275qW0qMAoCRvbYa1IPcbiGXGSXpA3pzySenlhoKZkLkzoIjhteXyo6-3zgLJ7Ox3
+5N2w75K_WuC0Q4u724TMzGbFnV-4xVylg_w_oPDQKLRjlqnJns_g_9amVo-tViCFt_9xViadvwUf-MrYVfoONoVcv-NoUn3y0W
+}
+
+AWSEntityColoring(AutoScalingGroup)
+!define AutoScalingGroup(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, AutoScalingGroup, AutoScalingGroup)
+!define AutoScalingGroup(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, AutoScalingGroup, AutoScalingGroup)
+!define AutoScalingGroupParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, AutoScalingGroup, AutoScalingGroup)
+!define AutoScalingGroupParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, AutoScalingGroup, AutoScalingGroup)

--- a/awslib/GroupIcons/Cloud.puml
+++ b/awslib/GroupIcons/Cloud.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Cloud [64x64/16z] {
+xPG7SiKW30KN93uo8hd_RTCxnVXFfhDJ_JmhkXx-iDbiDjLByNglVAG84DJkAN4844LYW7XSrZF4_3PtDu5qSGetoD-A1VHI0GFx-LqYUa7tW3L9NlSJgTbE
+WdjEQUKi7Bm95GcmT1QPr8O5K3E5SkOhHoyDzduoyMG9DUAzs3__dgqWX3fVtUDKBtE_46U7u8dv2Zr0kDNXu8Jay-CrXUWZlRLRYlGBL26jDGVjFeYZMVg8
+6dh7cB2Hi7H98sNLByGs3DHLlnB-tu_ugk-z-Ulw_Xsz0pHarLToz-dcrU63TsFoaXu6ApMGuwp158NRg7A485CY11jNDmdCaLpd4_IMyitNncqscyqp
+}
+
+AWSEntityColoring(Cloud)
+!define Cloud(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, Cloud, Cloud)
+!define Cloud(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, Cloud, Cloud)
+!define CloudParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, Cloud, Cloud)
+!define CloudParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, Cloud, Cloud)

--- a/awslib/GroupIcons/Cloudalt.puml
+++ b/awslib/GroupIcons/Cloudalt.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Cloudalt [64x64/16z] {
+xLI9OkmW21n44ONi_t_kAz5sBpVllZEzAClWPC1ilnydJfmuOIgbIFEtq7ltaNi8UeqIMx4p1bBRDW4aafu0tGC6sKSDwJDV8fy8Y485E98TG9v1ykY6n6by
+-03bsjszKHnj18J86kry1ELI0JPtjwhRIuoZUUZUzVPj_xzTyaWUmqBfVjwsEQ4GQWGXeqJo2EuUVFBnlF6xSHZGTwQ66yrV7Io9Y3W7VpS-R2GlqKY0DXy7
+L9OjEc4Y-C7GIqRUD1h5z4AVZ2AsP-an5UszoU2tK9mW5mFK2NcAr1mjaYzi7qaRV2Sa0reqbdPhl5Sivh1lNA3FHWKa88k01RXHV8dQ1Nz8tFqRWWXy3Uxv
+zP7VGfHxpy3msWY0346plcGrTrS2-ie_406Sfv8y6td2hETvHPPhP8n0SKjfhrQYP148KHuQ4tPGNIvVqweMWS-EDWAFO4HTHUBw_ytmhhLglvzU_rAsZIlm
+i462ycMcE5FYp3HcV4K5v8iwZ54OFQv0e-kxuHXUYtj2NRs_atG_9hT2WDbYWpSbH8kN--6cGGRtJS6h0i4EugBT_8xQQadNvMMqjJjnm4GOdOkKd3b5Th8z
+of1V-biJNe9rY1Bse_sILGlYsc-6U0WtbLlHAN_3fNFllRqXdFmJSUB4YKy
+}
+
+AWSEntityColoring(Cloudalt)
+!define Cloudalt(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, Cloudalt, Cloudalt)
+!define Cloudalt(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, Cloudalt, Cloudalt)
+!define CloudaltParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, Cloudalt, Cloudalt)
+!define CloudaltParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, Cloudalt, Cloudalt)

--- a/awslib/GroupIcons/CorporateDataCenter.puml
+++ b/awslib/GroupIcons/CorporateDataCenter.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CorporateDataCenter [64x64/16z] {
+xPG5WWGX30H9WZJ_V_39DgmRurQZIE6GH-3W8CWDeTKtTuEr-p6Za6Ctlx9YtpJryiNrytLkN_hvmBppboAc7JyeSRU-Ku9FVdALLFpRoC--WPo2GWF4llAl
+WzwkMzpiatOV2ILO12Iq-C5v1jMb6jtcsxslFUlNJlLBDpzPl9q_MEWxVttzlktlCNuzvc-TFY8pylnZnAJp3p38BtyQ_2Yr_q8ZYQrd_llN7oKmQ59yyUlP
+ltZ1T_uxFljGUOCY3yZ1mIy
+}
+
+AWSEntityColoring(CorporateDataCenter)
+!define CorporateDataCenter(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, CorporateDataCenter, CorporateDataCenter)
+!define CorporateDataCenter(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, CorporateDataCenter, CorporateDataCenter)
+!define CorporateDataCenterParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, CorporateDataCenter, CorporateDataCenter)
+!define CorporateDataCenterParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, CorporateDataCenter, CorporateDataCenter)

--- a/awslib/GroupIcons/ElasticBeanstalkContainer.puml
+++ b/awslib/GroupIcons/ElasticBeanstalkContainer.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ElasticBeanstalkContainer [64x64/16z] {
+xPM7Ra8n303F-_t_3pCI8gBNiBNQSbgLnJck1sn_ZozVCko4PxrbXt91_FKCfO1wXAk0v8jwolNL2e5uLTUQYh7N4fGEVU2Gp_kEx3jcvr16F9EbX5Z4J06q
+7lg1p6P6jY28AiZ318RFhGEiMW4dCnLzN7xEQt1vDAD77dQoeAPEPXkdJTNPyxxsJkOK2YJhZcr0pQds_zBTYqW1ZNqhIhWAQN9pZ0awjqUnnK9Lo7gC9Rl4
+2PRvS_rhFSQOqrRLETBmHPFZxkQK2wAvfO4j9kwhCGfvBR0Hvs0jEoNtV4EYoY2xNs5g-RHVa6FPX1hbM3tf9pe-rNn5F0pilc_OqW_aSiDvxPykroV77tFz
+Xa_dq93bDwAYDVgNLGxP_TZDrsyke8oDH_hY2ENOUF_E5_Bmr2EgR5oIKDa_xb1RHHZWz-uNSlImxu-1chGi0UF8rbIOQlF5pq2rfq7EHQIQ3_ikoQ3wGh_u
+Crfk3MYU4zjRIFVj0__49xwSuNt_GhxhPtNUzOVuFtstslukNxuS0G
+}
+
+AWSEntityColoring(ElasticBeanstalkContainer)
+!define ElasticBeanstalkContainer(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, ElasticBeanstalkContainer, ElasticBeanstalkContainer)
+!define ElasticBeanstalkContainer(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, ElasticBeanstalkContainer, ElasticBeanstalkContainer)
+!define ElasticBeanstalkContainerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, ElasticBeanstalkContainer, ElasticBeanstalkContainer)
+!define ElasticBeanstalkContainerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, ElasticBeanstalkContainer, ElasticBeanstalkContainer)

--- a/awslib/GroupIcons/Region.puml
+++ b/awslib/GroupIcons/Region.puml
@@ -1,0 +1,12 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Region [64x64/16z] {
+xTCtTiGm303HGM00xdzWTsmsI0BjofnMxuivVhFJQQZOhFC9O6MU3HimoxwZ3b5FWHORoHvFPUINRdZltxhsN_Dhh_Ofq5lhV_yb7PbtVBolmSYopmuze-od
+u15rhrXiU4DZnojMzclvTR-sltv-3KR5hmoPE-yt58sTz-lWD_pNshLNjm-vcrVVx-hQnx_rnnz_VCP6Ig_ImKfBNbOMVz_fz0C
+}
+
+AWSEntityColoring(Region)
+!define Region(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, Region, Region)
+!define Region(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, Region, Region)
+!define RegionParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, Region, Region)
+!define RegionParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, Region, Region)

--- a/awslib/GroupIcons/ServerContents.puml
+++ b/awslib/GroupIcons/ServerContents.puml
@@ -1,0 +1,9 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ServerContents [64x64/16z] xTQr0G0X44HHdDd-6xxyt8t_SfmLEnMG_AHaAtWtoQyRNqqZhAuTBnkbxunN6T2MyTKDr4thnm6zzVvuVzwVz-Vz6SzunZF-UFyuoT_HFwy7T
+
+AWSEntityColoring(ServerContents)
+!define ServerContents(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, ServerContents, ServerContents)
+!define ServerContents(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, ServerContents, ServerContents)
+!define ServerContentsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, ServerContents, ServerContents)
+!define ServerContentsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, ServerContents, ServerContents)

--- a/awslib/GroupIcons/SpotFleet.puml
+++ b/awslib/GroupIcons/SpotFleet.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SpotFleet [64x64/16z] {
+xPQ7bkqW24KFY1p__uTVYIunHVBgh7Rtz8mR6r7Q_-F31zM_a4a29FzChaK5Fn0jzTT2k7BAYXCwGr1zvokajwe2GCsT0DrD0KZjka1tFkK8G0N4kAuVJG3b
+R986S63O2pJ0Gyy3FCxGt_LyV2_wUnjzrSbh00R7_kRPf7APf4bWhJKNJVGA-6aAH70yTA1cSxTOW-4xEzwVMR86TMe2uV1dtlP7bFq051OZwJbGIZlxpJRv
+EpeRq9lR3sgr7tZuqUf6FKLsmKGy_AQx2HHO2mnI1W9RV4FPhRwVV8jVLzyXtFZy5PyxFvwJlFeCN_3aAu0nCnEWrDMl1K3NZj_qxilqANZqIvk-t7qwu1o-
+a-Vna-JQBacVCS6pVscNxD-hxn0c-HE-sa0lYLNI_1s-8uZ4olBN0ORVt8eT5FD6BjFt_FqT_lh-KeHp-9gV7wlF659aNytEh-4FXhy4iF4pFpyNE6Ddv-T0
+uJr59-LwDsfBe3TNRmnkToDVxo_zBzTV_FF_tD-XSrS_C0AyrY-Lf_ohc_ebgv-gz_hFQr8_vVMR09BKRnbksbM8cdzv_Hhry__ZmuVl
+}
+
+AWSEntityColoring(SpotFleet)
+!define SpotFleet(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, SpotFleet, SpotFleet)
+!define SpotFleet(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, SpotFleet, SpotFleet)
+!define SpotFleetParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, SpotFleet, SpotFleet)
+!define SpotFleetParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, SpotFleet, SpotFleet)

--- a/awslib/GroupIcons/StepFunction.puml
+++ b/awslib/GroupIcons/StepFunction.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $StepFunction [64x64/16z] {
+xTP5jiGm34JHKcmBAljVxsS8WtLwbZj_3Ob1V9N7muf8CVPIV57sSQ2wLy3PfQ7mGq5Zbmhb1qNjxHi_jDxU84wwmDYd0AK0XPsYuaCDTdF0cI72cvfC0JBL
+UAfWIWHJvKflZ4sq2_rOzf-O7_LktmOq-nQtUi6Itknhg__QnhQBgaSzfqPTznnvr0Ud_leeQssh7sRajpUi2LU6lUTdA3vdMttyAB3unj--SYxI_VNVVzwV
+FxzY2v2Bx-_y-P-ldwXhshL-EJAtVwhczc_s_CYVNzdpCtj-9-wFtFsLlp_pztT-ViZFB_dvAJ-_vUV7_FoQdv_p7ezt
+}
+
+AWSEntityColoring(StepFunction)
+!define StepFunction(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, StepFunction, StepFunction)
+!define StepFunction(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, StepFunction, StepFunction)
+!define StepFunctionParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, StepFunction, StepFunction)
+!define StepFunctionParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, StepFunction, StepFunction)

--- a/awslib/GroupIcons/VPCSubnetPrivate.puml
+++ b/awslib/GroupIcons/VPCSubnetPrivate.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $VPCSubnetPrivate [64x64/16z] {
+xTHLWeH038JX2cb9rVtlkpBkGuVrvNj1VvpcpxLQILmWUcizcDGT6zwPuG0czmc0Szm4bA34AC2KEBjrSKFTHgz03HRYZiBGn166UXAemZYYmtZ6q3cVAehE
+LXHK3VIETjut-63FCx-fNtx_l7L-pjBCS9TPU_xXRjXLYescfxqpxg3FwiKxDA_dNUEzjAZljVO5lGE0fti7IW4ysNUWIs7ecNupgxEX8zTxicTihhyZUVra
+0TpppuyiwVUtixluT4z3BEZNlZNc-utnNdVDwgtu7SNcz8yyxHdjeU0pUeW_oMhr2W
+}
+
+AWSEntityColoring(VPCSubnetPrivate)
+!define VPCSubnetPrivate(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, VPCSubnetPrivate, VPCSubnetPrivate)
+!define VPCSubnetPrivate(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, VPCSubnetPrivate, VPCSubnetPrivate)
+!define VPCSubnetPrivateParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, VPCSubnetPrivate, VPCSubnetPrivate)
+!define VPCSubnetPrivateParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, VPCSubnetPrivate, VPCSubnetPrivate)

--- a/awslib/GroupIcons/VPCSubnetPublic.puml
+++ b/awslib/GroupIcons/VPCSubnetPublic.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $VPCSubnetPublic [64x64/16z] {
+xTG50eD034JHoSPp_mFNNRTUu5UHXqCDjQcfT3FFHxKpOHwnFw9J03Jc1a2od_ESHSqB0JXxFOEYrWM1Excj-6u1riMp7G93onxle3nO7i5xl4Bg887sU87L
+GGQP_5tblEAvpxtcdbTJRkLj4K3j80AMltxB6wvcjpt7nVWkNnVxEn-gyRXFnZpEHpq38W0_w0E8vRS_u7T_1VeLlzxo0E8nNm8mFtxyAkNHytUu2u_x8kGp
+FaVkopt_xVb3SZ62lVlv7tQrg04rDJK3
+}
+
+AWSEntityColoring(VPCSubnetPublic)
+!define VPCSubnetPublic(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, VPCSubnetPublic, VPCSubnetPublic)
+!define VPCSubnetPublic(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, VPCSubnetPublic, VPCSubnetPublic)
+!define VPCSubnetPublicParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, VPCSubnetPublic, VPCSubnetPublic)
+!define VPCSubnetPublicParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, VPCSubnetPublic, VPCSubnetPublic)

--- a/awslib/GroupIcons/VirtualPrivateCloudVPC.puml
+++ b/awslib/GroupIcons/VirtualPrivateCloudVPC.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $VirtualPrivateCloudVPC [64x64/16z] {
+xPH7miGW24O_YWBU_xv_dQAacCpQjvdw24tRm6AnM8IfC4kn-CHs9JoWSZz29O2BkPaIm7PJBu3ugmu6wbszz9tGUm4Cg9k0rqi8XhQ4WgErY4kz0yLEpE92
+n1TcmNl56XwGJtG7nMvHK0zZKCpIbz6CnqRKt9nzDCsEMVtltQEGMGBQb--qgPdFH-b3-nHinf0XlgGZbLQjYny4pnsj0AZ6qSCXrf8VrFlXXG7P2n04jg5t
+0Fy0i4GwdhmJGCTl3HrZqvnsnkY0jy5dVx1fkW6U_G9foMyF9FjDKB8lg1C_hMc2uTTz1r_muvvloGS_mCOtyAn-HuVFwwyvf7UqUV-39jTidd-cpgxPl7yP
+1QONPDx_783KpC-muVmbAkC2TDodi29yZZxkdyLYiVW6
+}
+
+AWSEntityColoring(VirtualPrivateCloudVPC)
+!define VirtualPrivateCloudVPC(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, VirtualPrivateCloudVPC, VirtualPrivateCloudVPC)
+!define VirtualPrivateCloudVPC(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, VirtualPrivateCloudVPC, VirtualPrivateCloudVPC)
+!define VirtualPrivateCloudVPCParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, VirtualPrivateCloudVPC, VirtualPrivateCloudVPC)
+!define VirtualPrivateCloudVPCParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, VirtualPrivateCloudVPC, VirtualPrivateCloudVPC)

--- a/awslib/GroupIcons/all.puml
+++ b/awslib/GroupIcons/all.puml
@@ -1,0 +1,149 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $AutoScalingGroup [64x64/16z] {
+xPPLeiD030EbWBNtl_23ejima-SlC4wMbPe90hDfEccJT80sIPzGm0W275qW0qMAoCRvbYa1IPcbiGXGSXpA3pzySenlhoKZkLkzoIjhteXyo6-3zgLJ7Ox3
+5N2w75K_WuC0Q4u724TMzGbFnV-4xVylg_w_oPDQKLRjlqnJns_g_9amVo-tViCFt_9xViadvwUf-MrYVfoONoVcv-NoUn3y0W
+}
+
+AWSEntityColoring(AutoScalingGroup)
+!define AutoScalingGroup(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, AutoScalingGroup, AutoScalingGroup)
+!define AutoScalingGroup(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, AutoScalingGroup, AutoScalingGroup)
+!define AutoScalingGroupParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, AutoScalingGroup, AutoScalingGroup)
+!define AutoScalingGroupParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, AutoScalingGroup, AutoScalingGroup)
+
+sprite $Cloud [64x64/16z] {
+xPG7SiKW30KN93uo8hd_RTCxnVXFfhDJ_JmhkXx-iDbiDjLByNglVAG84DJkAN4844LYW7XSrZF4_3PtDu5qSGetoD-A1VHI0GFx-LqYUa7tW3L9NlSJgTbE
+WdjEQUKi7Bm95GcmT1QPr8O5K3E5SkOhHoyDzduoyMG9DUAzs3__dgqWX3fVtUDKBtE_46U7u8dv2Zr0kDNXu8Jay-CrXUWZlRLRYlGBL26jDGVjFeYZMVg8
+6dh7cB2Hi7H98sNLByGs3DHLlnB-tu_ugk-z-Ulw_Xsz0pHarLToz-dcrU63TsFoaXu6ApMGuwp158NRg7A485CY11jNDmdCaLpd4_IMyitNncqscyqp
+}
+
+AWSEntityColoring(Cloud)
+!define Cloud(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, Cloud, Cloud)
+!define Cloud(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, Cloud, Cloud)
+!define CloudParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, Cloud, Cloud)
+!define CloudParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, Cloud, Cloud)
+
+sprite $Cloudalt [64x64/16z] {
+xLI9OkmW21n44ONi_t_kAz5sBpVllZEzAClWPC1ilnydJfmuOIgbIFEtq7ltaNi8UeqIMx4p1bBRDW4aafu0tGC6sKSDwJDV8fy8Y485E98TG9v1ykY6n6by
+-03bsjszKHnj18J86kry1ELI0JPtjwhRIuoZUUZUzVPj_xzTyaWUmqBfVjwsEQ4GQWGXeqJo2EuUVFBnlF6xSHZGTwQ66yrV7Io9Y3W7VpS-R2GlqKY0DXy7
+L9OjEc4Y-C7GIqRUD1h5z4AVZ2AsP-an5UszoU2tK9mW5mFK2NcAr1mjaYzi7qaRV2Sa0reqbdPhl5Sivh1lNA3FHWKa88k01RXHV8dQ1Nz8tFqRWWXy3Uxv
+zP7VGfHxpy3msWY0346plcGrTrS2-ie_406Sfv8y6td2hETvHPPhP8n0SKjfhrQYP148KHuQ4tPGNIvVqweMWS-EDWAFO4HTHUBw_ytmhhLglvzU_rAsZIlm
+i462ycMcE5FYp3HcV4K5v8iwZ54OFQv0e-kxuHXUYtj2NRs_atG_9hT2WDbYWpSbH8kN--6cGGRtJS6h0i4EugBT_8xQQadNvMMqjJjnm4GOdOkKd3b5Th8z
+of1V-biJNe9rY1Bse_sILGlYsc-6U0WtbLlHAN_3fNFllRqXdFmJSUB4YKy
+}
+
+AWSEntityColoring(Cloudalt)
+!define Cloudalt(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, Cloudalt, Cloudalt)
+!define Cloudalt(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, Cloudalt, Cloudalt)
+!define CloudaltParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, Cloudalt, Cloudalt)
+!define CloudaltParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, Cloudalt, Cloudalt)
+
+sprite $CorporateDataCenter [64x64/16z] {
+xPG5WWGX30H9WZJ_V_39DgmRurQZIE6GH-3W8CWDeTKtTuEr-p6Za6Ctlx9YtpJryiNrytLkN_hvmBppboAc7JyeSRU-Ku9FVdALLFpRoC--WPo2GWF4llAl
+WzwkMzpiatOV2ILO12Iq-C5v1jMb6jtcsxslFUlNJlLBDpzPl9q_MEWxVttzlktlCNuzvc-TFY8pylnZnAJp3p38BtyQ_2Yr_q8ZYQrd_llN7oKmQ59yyUlP
+ltZ1T_uxFljGUOCY3yZ1mIy
+}
+
+AWSEntityColoring(CorporateDataCenter)
+!define CorporateDataCenter(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, CorporateDataCenter, CorporateDataCenter)
+!define CorporateDataCenter(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, CorporateDataCenter, CorporateDataCenter)
+!define CorporateDataCenterParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, CorporateDataCenter, CorporateDataCenter)
+!define CorporateDataCenterParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, CorporateDataCenter, CorporateDataCenter)
+
+sprite $ElasticBeanstalkContainer [64x64/16z] {
+xPM7Ra8n303F-_t_3pCI8gBNiBNQSbgLnJck1sn_ZozVCko4PxrbXt91_FKCfO1wXAk0v8jwolNL2e5uLTUQYh7N4fGEVU2Gp_kEx3jcvr16F9EbX5Z4J06q
+7lg1p6P6jY28AiZ318RFhGEiMW4dCnLzN7xEQt1vDAD77dQoeAPEPXkdJTNPyxxsJkOK2YJhZcr0pQds_zBTYqW1ZNqhIhWAQN9pZ0awjqUnnK9Lo7gC9Rl4
+2PRvS_rhFSQOqrRLETBmHPFZxkQK2wAvfO4j9kwhCGfvBR0Hvs0jEoNtV4EYoY2xNs5g-RHVa6FPX1hbM3tf9pe-rNn5F0pilc_OqW_aSiDvxPykroV77tFz
+Xa_dq93bDwAYDVgNLGxP_TZDrsyke8oDH_hY2ENOUF_E5_Bmr2EgR5oIKDa_xb1RHHZWz-uNSlImxu-1chGi0UF8rbIOQlF5pq2rfq7EHQIQ3_ikoQ3wGh_u
+Crfk3MYU4zjRIFVj0__49xwSuNt_GhxhPtNUzOVuFtstslukNxuS0G
+}
+
+AWSEntityColoring(ElasticBeanstalkContainer)
+!define ElasticBeanstalkContainer(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, ElasticBeanstalkContainer, ElasticBeanstalkContainer)
+!define ElasticBeanstalkContainer(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, ElasticBeanstalkContainer, ElasticBeanstalkContainer)
+!define ElasticBeanstalkContainerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, ElasticBeanstalkContainer, ElasticBeanstalkContainer)
+!define ElasticBeanstalkContainerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, ElasticBeanstalkContainer, ElasticBeanstalkContainer)
+
+sprite $Region [64x64/16z] {
+xTCtTiGm303HGM00xdzWTsmsI0BjofnMxuivVhFJQQZOhFC9O6MU3HimoxwZ3b5FWHORoHvFPUINRdZltxhsN_Dhh_Ofq5lhV_yb7PbtVBolmSYopmuze-od
+u15rhrXiU4DZnojMzclvTR-sltv-3KR5hmoPE-yt58sTz-lWD_pNshLNjm-vcrVVx-hQnx_rnnz_VCP6Ig_ImKfBNbOMVz_fz0C
+}
+
+AWSEntityColoring(Region)
+!define Region(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, Region, Region)
+!define Region(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, Region, Region)
+!define RegionParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, Region, Region)
+!define RegionParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, Region, Region)
+
+sprite $ServerContents [64x64/16z] xTQr0G0X44HHdDd-6xxyt8t_SfmLEnMG_AHaAtWtoQyRNqqZhAuTBnkbxunN6T2MyTKDr4thnm6zzVvuVzwVz-Vz6SzunZF-UFyuoT_HFwy7T
+
+AWSEntityColoring(ServerContents)
+!define ServerContents(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, ServerContents, ServerContents)
+!define ServerContents(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, ServerContents, ServerContents)
+!define ServerContentsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, ServerContents, ServerContents)
+!define ServerContentsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, ServerContents, ServerContents)
+
+sprite $SpotFleet [64x64/16z] {
+xPQ7bkqW24KFY1p__uTVYIunHVBgh7Rtz8mR6r7Q_-F31zM_a4a29FzChaK5Fn0jzTT2k7BAYXCwGr1zvokajwe2GCsT0DrD0KZjka1tFkK8G0N4kAuVJG3b
+R986S63O2pJ0Gyy3FCxGt_LyV2_wUnjzrSbh00R7_kRPf7APf4bWhJKNJVGA-6aAH70yTA1cSxTOW-4xEzwVMR86TMe2uV1dtlP7bFq051OZwJbGIZlxpJRv
+EpeRq9lR3sgr7tZuqUf6FKLsmKGy_AQx2HHO2mnI1W9RV4FPhRwVV8jVLzyXtFZy5PyxFvwJlFeCN_3aAu0nCnEWrDMl1K3NZj_qxilqANZqIvk-t7qwu1o-
+a-Vna-JQBacVCS6pVscNxD-hxn0c-HE-sa0lYLNI_1s-8uZ4olBN0ORVt8eT5FD6BjFt_FqT_lh-KeHp-9gV7wlF659aNytEh-4FXhy4iF4pFpyNE6Ddv-T0
+uJr59-LwDsfBe3TNRmnkToDVxo_zBzTV_FF_tD-XSrS_C0AyrY-Lf_ohc_ebgv-gz_hFQr8_vVMR09BKRnbksbM8cdzv_Hhry__ZmuVl
+}
+
+AWSEntityColoring(SpotFleet)
+!define SpotFleet(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, SpotFleet, SpotFleet)
+!define SpotFleet(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, SpotFleet, SpotFleet)
+!define SpotFleetParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, SpotFleet, SpotFleet)
+!define SpotFleetParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, SpotFleet, SpotFleet)
+
+sprite $StepFunction [64x64/16z] {
+xTP5jiGm34JHKcmBAljVxsS8WtLwbZj_3Ob1V9N7muf8CVPIV57sSQ2wLy3PfQ7mGq5Zbmhb1qNjxHi_jDxU84wwmDYd0AK0XPsYuaCDTdF0cI72cvfC0JBL
+UAfWIWHJvKflZ4sq2_rOzf-O7_LktmOq-nQtUi6Itknhg__QnhQBgaSzfqPTznnvr0Ud_leeQssh7sRajpUi2LU6lUTdA3vdMttyAB3unj--SYxI_VNVVzwV
+FxzY2v2Bx-_y-P-ldwXhshL-EJAtVwhczc_s_CYVNzdpCtj-9-wFtFsLlp_pztT-ViZFB_dvAJ-_vUV7_FoQdv_p7ezt
+}
+
+AWSEntityColoring(StepFunction)
+!define StepFunction(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, StepFunction, StepFunction)
+!define StepFunction(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, StepFunction, StepFunction)
+!define StepFunctionParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, StepFunction, StepFunction)
+!define StepFunctionParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, StepFunction, StepFunction)
+
+sprite $VPCSubnetPrivate [64x64/16z] {
+xTHLWeH038JX2cb9rVtlkpBkGuVrvNj1VvpcpxLQILmWUcizcDGT6zwPuG0czmc0Szm4bA34AC2KEBjrSKFTHgz03HRYZiBGn166UXAemZYYmtZ6q3cVAehE
+LXHK3VIETjut-63FCx-fNtx_l7L-pjBCS9TPU_xXRjXLYescfxqpxg3FwiKxDA_dNUEzjAZljVO5lGE0fti7IW4ysNUWIs7ecNupgxEX8zTxicTihhyZUVra
+0TpppuyiwVUtixluT4z3BEZNlZNc-utnNdVDwgtu7SNcz8yyxHdjeU0pUeW_oMhr2W
+}
+
+AWSEntityColoring(VPCSubnetPrivate)
+!define VPCSubnetPrivate(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, VPCSubnetPrivate, VPCSubnetPrivate)
+!define VPCSubnetPrivate(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, VPCSubnetPrivate, VPCSubnetPrivate)
+!define VPCSubnetPrivateParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, VPCSubnetPrivate, VPCSubnetPrivate)
+!define VPCSubnetPrivateParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, VPCSubnetPrivate, VPCSubnetPrivate)
+
+sprite $VPCSubnetPublic [64x64/16z] {
+xTG50eD034JHoSPp_mFNNRTUu5UHXqCDjQcfT3FFHxKpOHwnFw9J03Jc1a2od_ESHSqB0JXxFOEYrWM1Excj-6u1riMp7G93onxle3nO7i5xl4Bg887sU87L
+GGQP_5tblEAvpxtcdbTJRkLj4K3j80AMltxB6wvcjpt7nVWkNnVxEn-gyRXFnZpEHpq38W0_w0E8vRS_u7T_1VeLlzxo0E8nNm8mFtxyAkNHytUu2u_x8kGp
+FaVkopt_xVb3SZ62lVlv7tQrg04rDJK3
+}
+
+AWSEntityColoring(VPCSubnetPublic)
+!define VPCSubnetPublic(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, VPCSubnetPublic, VPCSubnetPublic)
+!define VPCSubnetPublic(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, VPCSubnetPublic, VPCSubnetPublic)
+!define VPCSubnetPublicParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, VPCSubnetPublic, VPCSubnetPublic)
+!define VPCSubnetPublicParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, VPCSubnetPublic, VPCSubnetPublic)
+
+sprite $VirtualPrivateCloudVPC [64x64/16z] {
+xPH7miGW24O_YWBU_xv_dQAacCpQjvdw24tRm6AnM8IfC4kn-CHs9JoWSZz29O2BkPaIm7PJBu3ugmu6wbszz9tGUm4Cg9k0rqi8XhQ4WgErY4kz0yLEpE92
+n1TcmNl56XwGJtG7nMvHK0zZKCpIbz6CnqRKt9nzDCsEMVtltQEGMGBQb--qgPdFH-b3-nHinf0XlgGZbLQjYny4pnsj0AZ6qSCXrf8VrFlXXG7P2n04jg5t
+0Fy0i4GwdhmJGCTl3HrZqvnsnkY0jy5dVx1fkW6U_G9foMyF9FjDKB8lg1C_hMc2uTTz1r_muvvloGS_mCOtyAn-HuVFwwyvf7UqUV-39jTidd-cpgxPl7yP
+1QONPDx_783KpC-muVmbAkC2TDodi29yZZxkdyLYiVW6
+}
+
+AWSEntityColoring(VirtualPrivateCloudVPC)
+!define VirtualPrivateCloudVPC(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #232F3E, VirtualPrivateCloudVPC, VirtualPrivateCloudVPC)
+!define VirtualPrivateCloudVPC(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #232F3E, VirtualPrivateCloudVPC, VirtualPrivateCloudVPC)
+!define VirtualPrivateCloudVPCParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #232F3E, VirtualPrivateCloudVPC, VirtualPrivateCloudVPC)
+!define VirtualPrivateCloudVPCParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #232F3E, VirtualPrivateCloudVPC, VirtualPrivateCloudVPC)
+

--- a/awslib/INFO
+++ b/awslib/INFO
@@ -1,0 +1,2 @@
+VERSION=3.0.0
+SOURCE=https://github.com/awslabs/aws-icons-for-plantuml

--- a/awslib/InternetOfThings/FreeRTOS.puml
+++ b/awslib/InternetOfThings/FreeRTOS.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $FreeRTOS [64x64/16z] {
+xPQ73kiW34NljR6n_VyV_1IrA4WDfM-ldEvn1DUiv9_2pSrDR7ch2xR8Ev_G3U3QhgJKJ8wd4s7MjTrL5P8R1AhQymA_I6SYTb4XNzKUylBdbw-MOr17_lcp
+Go84NhFFutzNX9bXzhkWLtL8dtsOMNoINm5ObG5ed-GFTp_z4D00LS08YTDtzzZd5sYM4w1NAcIVFoCwnlyQz7W9CXvPsl3H8tAJls9CKuvNH6toTssZdove
+DVlL83voDUtly-lP1ddsJPVv1m_V8Ds0EFq0h0liuIzmaZXyGLGraEo7tqcYLSNpHvB-cGyxVCF2t_M_3xzVz7zVlphzMjHlENuAhJpzh0QTnsytVvA8kVq0
+Svu_k_bR1ixj4rRp_DsldmOnM95bCA8jrizo_MO3q99ylbcjt_N-uSGJ-dh_MEzVvI1nFBpM-zTw_vpgjzW_D_ktZ_hvOl_Ud1zTF5NJfI_FZ-y_lzRdPnwF
+yR8zFpy_lt_czKF6blnJkBcv-G8
+}
+
+AWSEntityColoring(FreeRTOS)
+!define FreeRTOS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, FreeRTOS, FreeRTOS)
+!define FreeRTOS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, FreeRTOS, FreeRTOS)
+!define FreeRTOSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, FreeRTOS, FreeRTOS)
+!define FreeRTOSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, FreeRTOS, FreeRTOS)

--- a/awslib/InternetOfThings/InternetofThings.puml
+++ b/awslib/InternetOfThings/InternetofThings.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $InternetofThings [64x64/16z] {
+xTU54YGX30JGxWWJyl__UqQbzYXRmhdqkhmL89aPu7zu6PJ7LOfH06a74AAyv6mcvUKLCjiHw6_l__k8R_5301dNtg1ZAEpIF_3y5CTpvLEvxb3pnZliYqk3
+jtq-17Hv1VXapmz8E28_yO27O7Hy3jWdI8avGnWv3IFF_RFcB0WHCDPSFkUUzNYGezxFKv-Eo9f3hNi1poF_AE2rx5Mh41pGvy0RQ0h6xeDG8-oj7_2P6UJk
+oSYSZl7EY-RwjoDVFiSQaLHvuyjDeQelxwgKMXTnxiar_kJcZt-_bRVjzv-EtzT-6x-p-TjzpLzZ_Mo-razZ_Mw-rc-ZVdO_XQtwtNspVjDXkpTudlYAG-Bb
+G-3z_ad6PnzagtzMd03NsQ-s7qOtqfoMbpvJDVFMr_ZTUfVbnPk-4dNpj-y__VVPvLd-kno_NENbLQqTrVAWN8Mey2hu7V8H
+}
+
+AWSEntityColoring(InternetofThings)
+!define InternetofThings(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, InternetofThings, InternetofThings)
+!define InternetofThings(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, InternetofThings, InternetofThings)
+!define InternetofThingsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, InternetofThings, InternetofThings)
+!define InternetofThingsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, InternetofThings, InternetofThings)

--- a/awslib/InternetOfThings/IoT1Click.puml
+++ b/awslib/InternetOfThings/IoT1Click.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoT1Click [64x64/16z] {
+xTO5WY9130NG7y_F_U-xWepGGgthcy49IPVpz_7VVrNDhnS2m9gxobI3Pnmm5oZt13vJ7Yj8pz0Gmuq6agrm7fcu1lPUal7BXmqvZdSKFnFXbbq_LFHo_ks7
+SvQV3QdJw-zI18y5O2O7AHAV6S-a092t-OStan2rv1DTR44E6IOGZUQDeeOhfe0k0KG5GDpBDowQW01U93i0kwVdCiEzs6c5pqp2k4wHmviMP9WifjzUwoGk
+WiiS-RuQxrmlWFCmoBikLTXmJGcQ6uBenUeXtBB5Dd18DdTqhFn0GNgE1kP28zh9C9-43yy9UAoXV4Bas-8L_Itn4_0vNo7FjI0ukz5CeFbC0Hgv8mn8FjUA
+8pbSeB1u0SHD6fnFp2MzSUuQDdUKPmLav2NyeCNhlFrAjbk4eTulh0e9xXDu6kHiE2eWW1-jUZFpBc4vT1vsIBQWzWTNpkt-nXxNpKJSlx9LKCxRVIAW6O9y
+6-_7yLIelsrzGSyKx64JFnp5RUzFNv3Db4jy5ckdFqND1EpX46V5DGcu0SMl5G0a-VMwYh-n__xx2
+}
+
+AWSEntityColoring(IoT1Click)
+!define IoT1Click(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoT1Click, IoT1Click)
+!define IoT1Click(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoT1Click, IoT1Click)
+!define IoT1ClickParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoT1Click, IoT1Click)
+!define IoT1ClickParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoT1Click, IoT1Click)

--- a/awslib/InternetOfThings/IoTAction.puml
+++ b/awslib/InternetOfThings/IoTAction.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTAction [64x64/16z] {
+n9G7TiD024IpTDt_mY4oRhnbqXFSZUPJnkkNNusLyJKbYNh4aH7XAlGviSRH8lJ32F6Ik6c6US5SFgIEIpb-67pnfQ5ubq1UlGupEPv2J_MmydKI5BXbcRVr
+rGjMueFnVFnspHv0cV9CuLYU01ggsqSCike0ovVpfm3UgYSE0RmRrx-ItFJejNSRwMof0s82h6XmttIhnTm5FxShDJm4z1N8qx8MNdIFbQd7yZekUeqdHHwc
+N-EYVMZWdg6XF0PeML3lXbY-MMsh6W-h-FYnA5c1C43H009-wIT_070vOBLz291DOpMOe_6hqXOGXp-yOC1knYeSsSQN07Rg5rW__ZlGN5pJGq3yanxt_rfw
+VGW00C003FEt3aHciDzM_RP_Epyxlxi_kxzvF_P-xVtC-xt_8__N_i_ytyiFoI_9JyjloO_9hydFoU_d3-ylxq_lR--Fxw_lpny
+}
+
+AWSEntityColoring(IoTAction)
+!define IoTAction(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTAction, IoTAction)
+!define IoTAction(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTAction, IoTAction)
+!define IoTActionParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTAction, IoTAction)
+!define IoTActionParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTAction, IoTAction)

--- a/awslib/InternetOfThings/IoTActuator.puml
+++ b/awslib/InternetOfThings/IoTActuator.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTActuator [64x64/16z] {
+jPQ9Zkim24ND3l__mq-kquULu6pgtDapEa3DXRhzaG0HuItBwj7bWYzmyKWPFQInqsx2n68zWZx2gTCCts3QIu07sJDXbkEt0u17oEwHHTXTNXDFMJwyhjxg
+eg2ngj9rUgpFr3P3d4Q0rIkr0VTlPm4uWfPDPMWW4G6dvSDg6aPWFhMJNJVACiKhdYFmnFbsfyDSLj2jVit36EjZ1AhQYsgcs6RnnmcE1QxxXn9TXu7W7W4F
+PN4hSBCCa9BzJ6g1moWJk_kB07fbN8gW_5dwe3Pkve0jk5J1kJ1kPHMCuAgFEbVZwsLWfUKyxCgusfqYFcTQ89hvTvilSl_M-VEe2lNaBWiVQtcQgRftDU7X
+i1WtlBC7E4AVyEc_ZATmmTV-pntl37TueDuNAfjbfaEyvqatbVFVnHuftVCQamJAdfAQR-fD5nsyVlxmhvIJhfKzwVtFtV3y8h9zuaCqUzBbh-zXdlZB08c_
+4fWb_aPm1oT_9ShryqewyVfOCVFU7ikFFB3mpcggRHOErJpvuTrsgd8-AAvudFuvNmfehdb8AzuY6CZ3r_xrC6RscXyFPDfOFI97sExCx8pdv2L2yqgTl2_h
+fpxqFhruGlpyoFeHSS7JTiNb-R26_CxvDOxiNyrR3Cd2FwA2qphzB_W-uey8zhornxAPTwQ7OW_zrVpAEpud1L-f_KB_
+}
+
+AWSEntityColoring(IoTActuator)
+!define IoTActuator(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTActuator, IoTActuator)
+!define IoTActuator(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTActuator, IoTActuator)
+!define IoTActuatorParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTActuator, IoTActuator)
+!define IoTActuatorParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTActuator, IoTActuator)

--- a/awslib/InternetOfThings/IoTAlexaEnabledDevice.puml
+++ b/awslib/InternetOfThings/IoTAlexaEnabledDevice.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTAlexaEnabledDevice [64x64/16z] {
+vPU7hkmW34Gn67lc_t_uCMHx2rcjshj79VLWqqNvDMOVBti4KvTEwDz6LdcawoqOUtuIcyy_vvj8eevBa6rSdFHnQMGVbmgcYLUsWykWFUiyn5C18Bilqaay
+w3RqiaoGzkJxkj__9pzI7FLJn1PP7FKtv2V4KHyYBs_gt-s_BkAe7xBy5_s7xtrSbgrsrAyc_eV-QyAF-jx4mVwpmLF_BVhc2GwGRhT-gM8l_ngy8RrkhBRV
+38ZexdrcWSlFAxwbOhPBW-inRDatR3jUzSWC7s83cKMiZDyaqqhDI-thp2YAs6__JkQv1GQwzbceB_cLX9KW6LM_jtaxAsL5kEZlV9bDqI5xqg0C6XaBxMTa
+ddAuK45MrS3sVLVurFytpDXDogwVXCB7KvUOaR6_Vu1PNE7lQ5jMK6HCtlYcfWhY_MlZvBtl2lISLfnNaH3vlJ-ndVnjfrfshFtgbbQkzP-HyRm1BFNVPVoq
+XwmmlznLwFFuhVU5Ui5Tgu2C_WgSvyzDi1d-FcBZ6_n-_WfLn-Rh6nhuakhNzQEUPtGOI7zpVj0bjXtMvPpMhnYNqsAQDSbOFR_8G9jnjsC6EbJMgb-K3RC5
+wSa1gEZh_lFf15xMVM616xjRUKSWTN5W-e1yOHwGcz7i-xErr9_o3m
+}
+
+AWSEntityColoring(IoTAlexaEnabledDevice)
+!define IoTAlexaEnabledDevice(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTAlexaEnabledDevice, IoTAlexaEnabledDevice)
+!define IoTAlexaEnabledDevice(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTAlexaEnabledDevice, IoTAlexaEnabledDevice)
+!define IoTAlexaEnabledDeviceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTAlexaEnabledDevice, IoTAlexaEnabledDevice)
+!define IoTAlexaEnabledDeviceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTAlexaEnabledDevice, IoTAlexaEnabledDevice)

--- a/awslib/InternetOfThings/IoTAlexaSkill.puml
+++ b/awslib/InternetOfThings/IoTAlexaSkill.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTAlexaSkill [64x64/16z] {
+hPU9MWKX28KJ6PRtV-2xU6WilwnXYDOh_hWVyUE_hALiWKdCKsP2Nt3n6oOdhkwk1oVi6CXiNUaZQQIVFQ0NtcxCjxeJciVVh55qm32GlAdRkn_knpt-S6-3
+vtiy_y4twlooJkq6trZDmqovvNWINqpeEjyERF5trz-3mE4usaM-lwjh_rQaxu3z4i-JNYFm1PvzRWZgBwEvtCv_yC0xMlpK19Cec06sV0UE_axJFfs_ySsY
+XWoAEr7d4KaYWBNVU8cnwxbUvtfgp85iUKX1u4RVzfDD3-rvGUy5YhAgXM04ik77lxgESfqPVK4xdgFAZu94Pt3UyUg66iT6BZhaQiCtZ4sYXzCsxfKd_6Uk
+Mxq3HJ_pVNIGTde44hLMVlKljiRVyctKegtWTzIlykN-r-SlltvOUKJ9xvypiBYrM_kNK8uesVE3Vc7ud3-_qwa3Iki7VA4VUVqQe2vZs-jdWtukyaFGpwlw
+lPPpp4pY_k0lk8Jp-lrbRbEzvThzXMlocFizGWeSdBc_upoDkOpnPFA7mOz4nZZoXrp-ycBCnt-R_AMKFzNpjth-MCzVg_bpCN-llX-gxvVY-wduVYk-7yll
+r_hxkMvF
+}
+
+AWSEntityColoring(IoTAlexaSkill)
+!define IoTAlexaSkill(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTAlexaSkill, IoTAlexaSkill)
+!define IoTAlexaSkill(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTAlexaSkill, IoTAlexaSkill)
+!define IoTAlexaSkillParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTAlexaSkill, IoTAlexaSkill)
+!define IoTAlexaSkillParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTAlexaSkill, IoTAlexaSkill)

--- a/awslib/InternetOfThings/IoTAlexaVoiceService.puml
+++ b/awslib/InternetOfThings/IoTAlexaVoiceService.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTAlexaVoiceService [64x64/16z] {
+h9Q9sfmm24KBXEMy_mDtSVZoBpQZiRspJpnoao3uutz9jlGDrYYsLA6VyE21Ok89f8yD-O7CwAJkBfScxK0XvS5w9sY7x-XxqZPGFP5j9VN71_Wpta4EVZpZ
+nmKlDlx8P8y_PsI5RV8Z-QeQ6xmLGBgfYAXv0fJTvHqeryyhuGN4BLuISFc-bWwaNFDIK1rRrCoq8KqekU8bwJ0orp3RJK391HyGxVUpN7emt_EZZz02AeQg
+cjTS_GH_nqixj2PQbi3enT4tVC1et4zRQg-HMFC2sL76UQ-Fo0cwvFqL9C_uN1c5MF95JOydzToIaWMluA_mSgBdv0ROWX-Wn-zOb9iUzWKVr0nmqhHNv8BF
+OoJ-Rd-IIItu8kRuMVFy5_ood3Vf8F_AF_LVA__xwxU_VpBtxrd-65XdmNx-ziJQtjNra-lyJ-hHzTk32h5NFrfAXqSVrAy3jAuDk_MptKVNpzlrExySMjBr
+-tx_AFbQFGFoVl-A3jRLk_lNHlyiSZPaw_wvqx_puCVhXDs_T-uVafG_D6d7HspUlnIj-bLw7Gi000002FEt3g1pKRJ_Y_-J_vl_e_-h_ZF-k_f1_O9-Gh-X
+7zclxcSl
+}
+
+AWSEntityColoring(IoTAlexaVoiceService)
+!define IoTAlexaVoiceService(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTAlexaVoiceService, IoTAlexaVoiceService)
+!define IoTAlexaVoiceService(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTAlexaVoiceService, IoTAlexaVoiceService)
+!define IoTAlexaVoiceServiceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTAlexaVoiceService, IoTAlexaVoiceService)
+!define IoTAlexaVoiceServiceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTAlexaVoiceService, IoTAlexaVoiceService)

--- a/awslib/InternetOfThings/IoTAnalytics.puml
+++ b/awslib/InternetOfThings/IoTAnalytics.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTAnalytics [64x64/16z] {
+xPI7ZlH828G_Ea7n_kzxORmMQjswPxGAb_vIci17WS7e7wjV-YNtqC-r36ZnOnpwQ5WbYD3d2iCpDUXtCmriV8hdOgGa6LyuM8Fs6IqDrejlN5KRIuhEoFTu
+p0RS_Yv9N-K4zfRs3bWtbb83wAwSMpad3R0PoWMj6pODnkqlE_kd6xQKad80z4WjmvPPPEQa7_45GtaFyDg_gmk3CJiMRtPctgac8rLVC0EQdt27TJC1PQK6
+jdovZZBcZUTWPE7qYIdF-BshPL_uA-4P3onKzZDLU6tIiteXbQlmNFGysskpt_6hW8TNkEPLkGgl2A3xO_drJzaNhZ2i6pmaCDjQARmCXbBpuGJ45Zcpy3rf
+LfsRd95xv8sNGLvFONs_-ZDt-nrFfvN_YNVi6_SEpCnqJ6U-i_B6YyOcz3bWwRd_iYyyOu1DfHjWwsdzMjaNNlIhzLczFypVQULUz1sIqdd_6YjlVAVbz0Us
+BhpJRlUC2Soeay9AFSk8LCClF3KDHkGMSC1pq4UZHQDlzFQ27XIyP7Hjz7RH3fhOYcKqhHVzS9xE_MSO1lqlLeEce_ph_Hf5xyN5U_vnIWDplJ_V-UsKCjeH
+hmvTtgW7NolSGk_L0MW6tKFAJ2dyMk6Fj7fhwne-hOynUWEiwlbCgJMCIzQNKZzGk2_tq3zNl_HBlmC
+}
+
+AWSEntityColoring(IoTAnalytics)
+!define IoTAnalytics(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTAnalytics, IoTAnalytics)
+!define IoTAnalytics(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTAnalytics, IoTAnalytics)
+!define IoTAnalyticsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTAnalytics, IoTAnalytics)
+!define IoTAnalyticsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTAnalytics, IoTAnalytics)

--- a/awslib/InternetOfThings/IoTAnalyticsChannel.puml
+++ b/awslib/InternetOfThings/IoTAnalyticsChannel.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTAnalyticsChannel [64x64/16z] {
+xPU7qjmm28IDGC3t_Y-Sk2M_oqqiCpSrUxsmta7KwGjetRstr-QT1RrWdWdOE_6GEasQ82ylt-PNVIaWoFLDubNxglwA_m2fdHywP2VQhQq4EtGuwgBjyIi6
+-Jo8dHKfVna721HIfJd4KT93We2soMXZ1CTWQM3JE85miH_pGMvHQv0cumHz5Q3CoDv62IGXFO18WD11WfOii4aiLX5o8b2FpEZtNBDPfhULp9dX-eD0amtn
+m1zY2NzywRjbHFAqCkecekq4NLPjZqkhzDMN9WSVwkUWKWy_SElgIqWv94lSNY-0yscrVgqb3deV0omFEVaIuXBkzp4ea_JBZmBzMgGlI6Bx4LCpwpFSFU8Y
+ru_snzHJhj2BL7bcdpCk1-x_qA_jDsJ6lRkI6F3V52Uv2ZPoVdcYJ931-C4EuTC_nw_UnAydTDa80s8mVwO0icjhwa3ASFx-XCju_SXcmOBGL_Lh_ekQgRoh
+dyNwNUmVnVvLx9_5_bsS7uhpIt5-AirljEByM9nV_-yVDVrL_nNtn-h-Mj-VluzV
+}
+
+AWSEntityColoring(IoTAnalyticsChannel)
+!define IoTAnalyticsChannel(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTAnalyticsChannel, IoTAnalyticsChannel)
+!define IoTAnalyticsChannel(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTAnalyticsChannel, IoTAnalyticsChannel)
+!define IoTAnalyticsChannelParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTAnalyticsChannel, IoTAnalyticsChannel)
+!define IoTAnalyticsChannelParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTAnalyticsChannel, IoTAnalyticsChannel)

--- a/awslib/InternetOfThings/IoTAnalyticsDataSet.puml
+++ b/awslib/InternetOfThings/IoTAnalyticsDataSet.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTAnalyticsDataSet [64x64/16z] {
+xTI35KD1443HCVflE2VMOcBU62_u2xWFzHg5DiiQx_S-D-e3vk8TUh4bkRhtNFAhUuk8J6lrsBP-PTilHRltR6AGJB--bsKVXLwqYO1KfT0F_VlAyKT0NKBG
+Or8RVmBA9OGy5fK-0e4YStaRSPHxeOVjN5_Uuh7_-C_xentZo8NxXmBb2R-ivxnY_h1i4A2SuF_uFxnNwzFo-BT5eRVei__uFRn7QW00Mhfo_0E0wlj7mxAl
+xXyjs-V_u__GFdLkr9VSt5kdnwfsNpViaHblwJcJNzo7LsIlhshtv6KAzx4
+}
+
+AWSEntityColoring(IoTAnalyticsDataSet)
+!define IoTAnalyticsDataSet(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTAnalyticsDataSet, IoTAnalyticsDataSet)
+!define IoTAnalyticsDataSet(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTAnalyticsDataSet, IoTAnalyticsDataSet)
+!define IoTAnalyticsDataSetParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTAnalyticsDataSet, IoTAnalyticsDataSet)
+!define IoTAnalyticsDataSetParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTAnalyticsDataSet, IoTAnalyticsDataSet)

--- a/awslib/InternetOfThings/IoTAnalyticsDataStore.puml
+++ b/awslib/InternetOfThings/IoTAnalyticsDataStore.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTAnalyticsDataStore [64x64/16z] {
+xPS5iiCm30NpnBh_XVyuPR3SdpBiO663tXbhUab0B6g-nbIOSAbBOf5d21CQoj3O2U4piVULejGr6-4gXBr_0YJgaGtjsuWcQ-zMGJh_0Jq_Cfsd4lRCcCuZ
+cJODiKpftZp6FZArwnk6kbL-Xg2q9RBm6s6CZipMxChNM1z3UMy10CIwTaChVuButlgBS8_OMtykc2eVgylqCm64hsuCjR_VdzbSd-trD_GBtiCNTuOtQ97V
+-a0sU96ly_aZmkdzdf-D_K6_NDjyttxNV_3TWj_buEl3txrVCSypkCb_-_MPB-lNZ66DQ_jTvci48nfFw_VNhma3UoPOx99-0V5g_-S2bFvu_pdqV_qIh84h
+--MlwFVw_VlryyFryylryzFryzlrysCzlxuaVm
+}
+
+AWSEntityColoring(IoTAnalyticsDataStore)
+!define IoTAnalyticsDataStore(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTAnalyticsDataStore, IoTAnalyticsDataStore)
+!define IoTAnalyticsDataStore(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTAnalyticsDataStore, IoTAnalyticsDataStore)
+!define IoTAnalyticsDataStoreParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTAnalyticsDataStore, IoTAnalyticsDataStore)
+!define IoTAnalyticsDataStoreParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTAnalyticsDataStore, IoTAnalyticsDataStore)

--- a/awslib/InternetOfThings/IoTAnalyticsNotebook.puml
+++ b/awslib/InternetOfThings/IoTAnalyticsNotebook.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTAnalyticsNotebook [64x64/16z] {
+xPS55iGm20KBVD9o_mElAxNmwZ8hrUX4Y_L08GeFAWjGmOTN2w4DuHMQ1RGvF6LNrGJXCI0ytL0pkHrwL3Q7XttW-tMoDhWnl0uCpm1ACmL0zsj16pIW_bRi
+ZvcJcTmEyV3UNpTP_b2sGHd-ulvz_MbPjS2xy-VhVudmB2B93BV3vxgPZFeB-_V-XhSVuZPsvY-U_rd6JtLTrX5hFn9llqW_qEblpVEVdp-Mg7ySrT_fpw-V
+b_EtSFZX-wSGEdp_E7p_kZnN
+}
+
+AWSEntityColoring(IoTAnalyticsNotebook)
+!define IoTAnalyticsNotebook(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTAnalyticsNotebook, IoTAnalyticsNotebook)
+!define IoTAnalyticsNotebook(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTAnalyticsNotebook, IoTAnalyticsNotebook)
+!define IoTAnalyticsNotebookParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTAnalyticsNotebook, IoTAnalyticsNotebook)
+!define IoTAnalyticsNotebookParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTAnalyticsNotebook, IoTAnalyticsNotebook)

--- a/awslib/InternetOfThings/IoTAnalyticsPipeline.puml
+++ b/awslib/InternetOfThings/IoTAnalyticsPipeline.puml
@@ -1,0 +1,12 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTAnalyticsPipeline [64x64/16z] {
+xTR50GCn34JHCMlwBpZCP0wjtbb_6OnVffIoxiGsJ4TU2CW8l10165v11g-ONH_TGQGWGowd3xt7GIZf0mxyWvu-Wva-PtPlCoxxtkkNxrsIdUGGaYHVstiU
+U2IIiNx_UxlzfwBzP_nnhxtsj1dV_ltp6KE_V_t_hzx_P-V_ktVzyCkKKci
+}
+
+AWSEntityColoring(IoTAnalyticsPipeline)
+!define IoTAnalyticsPipeline(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTAnalyticsPipeline, IoTAnalyticsPipeline)
+!define IoTAnalyticsPipeline(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTAnalyticsPipeline, IoTAnalyticsPipeline)
+!define IoTAnalyticsPipelineParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTAnalyticsPipeline, IoTAnalyticsPipeline)
+!define IoTAnalyticsPipelineParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTAnalyticsPipeline, IoTAnalyticsPipeline)

--- a/awslib/InternetOfThings/IoTBank.puml
+++ b/awslib/InternetOfThings/IoTBank.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTBank [64x64/16z] {
+xTS7hkCw38LXKOKyP_yRVY8D2FQZevioVUP7IVrSnDJoYwKml-Y0p8iAr7aXG2ypWtxfYV1aU38y6Hxyaxruq_l5c71UDBBDYqeEcKqltfrkngUpbZbVAct0
+I1rFfgILQp9vUJeb9Vdnl1-_YPTkrkKBhv7xX1bPb-mrAZD6uJC6yYR27yNauPszD3smjbAQWfusEVj0TdF-4Y2mv7lswvVtbezewosTRLeHstZ9E6z2_kUx
+DmwVfbWbJUxm8zXrVkwrNeZPUV-rgllh_73s7Xvvq3jvh8-jwlxqZAEcn6XhzyjCNuDTrkzyX94oqkAjizlE__ZaNTSCCA9uwrFuQU_Ih4ZR--gr6m-QUo_x
+5kmolxn_TjC7_cZh6sTeExyz_bADCskRuz-idzV0MNjl_JspHjedtiUuzUBL6p-w55D1sl_rzOl7yuC2k3__2DlvzVN0TdxT6yaxw4gCMkxy2FRC-ddFhx-C
+dH-oz_x8vJ4vN-TixBsHX9JR12GjUOEtF7ej3weTomUoDB_fTTFqQNuQBRzlUOtI-NV3DklX_x3VJv__VepVh_t99hTFVpz_-llzy_yF__v_VVx_zUVt7m
+}
+
+AWSEntityColoring(IoTBank)
+!define IoTBank(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTBank, IoTBank)
+!define IoTBank(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTBank, IoTBank)
+!define IoTBankParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTBank, IoTBank)
+!define IoTBankParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTBank, IoTBank)

--- a/awslib/InternetOfThings/IoTBicycle.puml
+++ b/awslib/InternetOfThings/IoTBicycle.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTBicycle [64x64/16z] {
+xPTNOYen302HR9Mv_uKV5elVOdhuIfa4jewBN3dyD4Jauh3SUqeGurMmuq51ZmS3cO_kyEUh-P64SO1qzu1OxxdfJRtpClrMxa2-15Mf5ODsU8bMiLbnyl0Y
+YVyaNsB0EpwboEPJlEKNSZT_iIFwDF-b_aiEzkNuoKKlrTQQl1V_94JsYTaZNmQnz-lYWH-b7Ex6tq2dxs1o9_vtV8NyJxtvmBT1Blu5gv-bt6-_1X1U1D3V
+xF-z_1aByatVoG2VjQKzydKGJ5yrYSEMW88deKUcJvHoi_t4iYww95WLNumYJPwsNqisOfoswYp1HhR5NyklbRKpY0uOUEdMUW9wKVurVbkP7TJ1EuE4BHO6
+AO_YRs3dXIf0EqK5Kqu9s2F_r0cbSjFnxGnqplb9xlob_-vMpNukXKKIGvm5aBN_2aNv9QgddajqpgsdopYS_1Ft_8qu-p4EzVBYh_D7lLlin7LYsSyVQ_mS
+T3U6-kvOAFYZ-6irS35F9IlHUNhVhs-o7JKnPhOTi76l9VYJzSk1ZClvtvWt_UdwPJc7ogITxzaBwvTqZ_2JFMdZNfTb_VhRVtosV_jy__Zv_dNTFmFk7kl-
+EUOZD_rq__xdV_3xyMVn3m
+}
+
+AWSEntityColoring(IoTBicycle)
+!define IoTBicycle(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTBicycle, IoTBicycle)
+!define IoTBicycle(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTBicycle, IoTBicycle)
+!define IoTBicycleParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTBicycle, IoTBicycle)
+!define IoTBicycleParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTBicycle, IoTBicycle)

--- a/awslib/InternetOfThings/IoTButton.puml
+++ b/awslib/InternetOfThings/IoTButton.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTButton [64x64/16z] {
+xTPLOeGn20JW0I8CzxzltKjIeRhxVwzn1Vu9XuEFUrpOLeYEUyxKnBsPjsz9zya43IDlF-86L-9MNxRdUvnz-rOUVpBZN7j_nRd5lMc2BR79jGQ8jRxKJ836
+1LV886E7Gw3EbC8ONF6k8ZQ21brCthWs00W0TLgwX0dXMWUwqwT2d8APtgf8t-njvvXnFyiOQA-h2fo9tYP9U-nSuKocwb0c382J8azkRmzzFTQ4CG408npw
+j68OvZlRAm3Vjj_Ftyq6i_cd-vTBzoy_lqn-ViNxKxo_nVTJVR-r_wF-VvN_p-h_NOqVfVRjYF_L_AcQlzNpnth--liEXqi
+}
+
+AWSEntityColoring(IoTButton)
+!define IoTButton(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTButton, IoTButton)
+!define IoTButton(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTButton, IoTButton)
+!define IoTButtonParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTButton, IoTButton)
+!define IoTButtonParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTButton, IoTButton)

--- a/awslib/InternetOfThings/IoTCamera.puml
+++ b/awslib/InternetOfThings/IoTCamera.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTCamera [64x64/16z] {
+xPU7Rkim301DIXpt_p_y8Y424RtODH2iZciJpzEWPewVXeYy7BPxNnB4U1NiSL3Gny50rgCp_dmrVv0m3f3k7X3xFJTzgtTkqz_b3kGjc9NQCMZ7BTgCpOwJ
+nqqI_qc-n83__HuBstnY84-VoVAxkvlC5YbyyoVoBl--qX8WOfAWP_dlzG_8-RvMFrFeD-EdINO7QmvQHhI9NliIK5H0wtR8_xuCWbplLT2qcrlN6biGmu-f
+77ly1Q8LFPRJLTiaG2h-kwylOyZdpKoezkllV1laydMq_xFEfYggzgnt-JcLhVsUlYKmSmzjdfdUD23AFud_I_uDGXmcBW7zfhzQFAVkDhyboLDV1_7YArXx
+rbe2ca4hFwPodCVVG8EKOo1309l-lVPpKi6h9JNn4x_Al_kzMbs3E2d_CZPVQfgrolzE_Al-rHXL_rj-WzvN09nvqKxywhzR-mUaDKi86TTx_xqQF_tPwoOX
+3dRSRRz9W4jF86teSPpuQ_xOV4d8heEMa59-pH_d_N_DPH7pa7hS7N-59KnorlsMtrzQfdb4U9TA4kHy_H8WBe6yMhywNz8lrw_cSOctRVtwstzyl7_xVF_u
+-Vwrzi-0kyU-VmvVZzpqq_txd__1xyUVnJy
+}
+
+AWSEntityColoring(IoTCamera)
+!define IoTCamera(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTCamera, IoTCamera)
+!define IoTCamera(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTCamera, IoTCamera)
+!define IoTCameraParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTCamera, IoTCamera)
+!define IoTCameraParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTCamera, IoTCamera)

--- a/awslib/InternetOfThings/IoTCar.puml
+++ b/awslib/InternetOfThings/IoTCar.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTCar [64x64/16z] {
+xPS73kGW301ZYktv_uTliL2AnUQokbv69NKK1BXa-ziGaSiXtVigXerNeRyE1Shhq47cexVyzqlN5mxZ0Awg1fRlQIzBlV6Ojlewu8y05YFeKBT7r9YRZEBR
+Gnpzcton0P_uX2BJ9_Z83-HRl_-3vw_KC_AfhtdNl_DbODclPChkMoZRxVmhr1CDDC__hUzOIYp8sky3Jtw5zYRi70_bTlqK90y8UJh_KcFuEK6rHxuqMsOf
+nvii_3AmwPUG0LrcI2yniw4iraz2nZMsMqOTaBlrCqBUtY0TzEJdyGjOcMKtCUyPo3x-F7-px3G7JxFN7Qp67DIR-H--BkRFc25KRtnHXLx1U_TBEUXn3v1o
+zjF-BG3c4MXb63kEI-nWq-7FHtd-Ypi3sqTyq8_0gJVhrnpm_Tq3dI_czSlvGqIXIooqxDYOEb5e8Zb_vFqlJk2IYZDWJ-AdE7EZ7zIuP_8m_bJR_lNzNg__
+wzVVr7zyU__sxVtZj_UlkNy6LDLo_spx8-tbM_lt__ut_3_-NNm1
+}
+
+AWSEntityColoring(IoTCar)
+!define IoTCar(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTCar, IoTCar)
+!define IoTCar(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTCar, IoTCar)
+!define IoTCarParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTCar, IoTCar)
+!define IoTCarParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTCar, IoTCar)

--- a/awslib/InternetOfThings/IoTCart.puml
+++ b/awslib/InternetOfThings/IoTCart.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTCart [64x64/16z] {
+xPU73kGW30LZcZt__yENe9Mr-vG8JjVBg6pB9F2mC7lyRPZPnujyjyJnwrBevqk1ShvqiFpfWVz-wUCau7g166Cuk7utUhdL6zkqkwS3iGLpKag7UcnHPpRA
+88vDWl6x-drK-rhV_8Bf1yGeIv-fsCldOlhc0B7s9wRFFx7cK3QVVvjVWVPD-GTU7oWxlgygNtsxyFI3P-8rmAaScdy-lzu3BldV-UrX0J9PzVj5f6ymRltn
+KeAOYZtKVqOX1BxE_ta21Vg6dnSg7SgjNoxU1nqo0VasyAde-icJReU_M3-vL8SllenVaXRoWXo_vYShdMXLhFU_2atR2zGTFxCUdsJwuclzvWIKbAH-DV-9
+UI0DpUVbo_LBxlT1zNN_o3avZC_UNjB7f_ASNma0bzxUj_Dt2A2zztQWRFe5nc6H-G5jjkrb_yhogR8FszHM_Ijh5I-Lh267KJhqHV_IygcoOhReNuav6L-k
+H-pKVngjsV56RTL-p_FBjv_Vllty-Etdrpm_0xDYvFpi-TFevLlFx__zR_Z_-7Vn1G
+}
+
+AWSEntityColoring(IoTCart)
+!define IoTCart(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTCart, IoTCart)
+!define IoTCart(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTCart, IoTCart)
+!define IoTCartParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTCart, IoTCart)
+!define IoTCartParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTCart, IoTCart)

--- a/awslib/InternetOfThings/IoTCertificateManager.puml
+++ b/awslib/InternetOfThings/IoTCertificateManager.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTCertificateManager [64x64/16z] {
+vPQ7TkOw28Gl8Cht_W-ycvXp_ogvf9osawumb04Z__UB4BKFg7o5goCB6fL3hx57ye8S5zW5KE6c7p2F_lka1qsWN9_El83KCy6tKFAcvIZWE0K7Oggu1E07
+zDWBCe0uYbww8qtjPp2QlkzWhO42Q_gnIO8TwMkGw-pZkB-nga2AaYNjs6mi79-rA-h_KSkgIb_fLDHSMRzDO2DaDIIwF9K4AYAArJ3eT8YIwX-KjLdIIids
+jznzrQI50j5Pf3oqAZV1SviyVpYNIL9Z-ruV37aOA4aWj02NMmTqCbVQ8cX2TWd2CwgYOxtFQViiKjdG0G8WExW1aDAvJkINptZk40xH2NY4Rpy-Y_CeADtC
+bloakXbJ9EIKFw3vGQdUEgJFw0KYCERw5M5iQ0Fd3J7Nhyy2nDjgGyte7Ui5NPDz6gYxtZV2U8BTj7f5bvoFfHap6HVgzb0gTsq7NUTyr2S2Zlv1kQcEN5q5
+0soz5kokMOtJ-wDLiVjD1-Mosi0-EvUxMch3bbk-OB6N5exFMac17j6LzPQtoVycCMmljvHTUkxN6FiE98-kk8JIlTix3_HPJbtFSvxf3saJSPDJ_Uq1pl4a
+WuoaBvOJw0r2kgbiBy6UqEl_9CIBHXMideOrFDoYkA72FFmyluX-YZp2-r4AwYh_Zd-MBn7o3VuegF5LlWGRGhx4jmB6wBc_pWyWjL_3YAlyAi3lJtJLDNu7
+RtGAL_d-UE3N-4dPsrB9ytmnUJlhen_7Nm
+}
+
+AWSEntityColoring(IoTCertificateManager)
+!define IoTCertificateManager(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTCertificateManager, IoTCertificateManager)
+!define IoTCertificateManager(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTCertificateManager, IoTCertificateManager)
+!define IoTCertificateManagerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTCertificateManager, IoTCertificateManager)
+!define IoTCertificateManagerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTCertificateManager, IoTCertificateManager)

--- a/awslib/InternetOfThings/IoTCoffeePot.puml
+++ b/awslib/InternetOfThings/IoTCoffeePot.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTCoffeePot [64x64/16z] {
+xPU7qkig30Oj4EZRzt_X6yBVBEABvsJQAPiUs54iqNByQPZPwILzjoM8qHNQuwL0URmqiDdqpx-cjFv0C5v0Z-U0oD_rLbxgpctyLNH0jm3AwZUenotgp4sY
+e-Ccej_pNRAtV2Y_wbiB2QJmZMynuEmNyKLOzec1VVWCphu9r0SXYEnFx3f-X_Rz7h-8VtNz1lWd3U9-_keOteKpkkbR4yJgO__dso3GoDhiNC7B5ntAsGyR
+73d_1dfcoqyHAzIB_AVwYNW-siale72xzDj0Q2PXkEV1Q0patxxQOAsVGodWQQKI26ZR_0_t4DBP3y8Sy9rlq8yEqCzjp2pOIxyC0itIpEAtTHux-FI9CiZr
+cv7i4BDdAg11tzHlHkgaWXVmcORavzy_UzQymXgqwUVVd-UFFNCZi3nZvlDs_WMQxzTDpS5t_XovrkhIQ7MjNnw_NwdED11Gy_XTrxy2RVKh0z_Cl-kBAw0H
+Blbv_VXAOCQWNQmVUVrhK2wsd7lh9tIxE9Li_K60mbwsLacnsx-AM6iu5xGEiDs_hAyfSFWu1xNz_kMhNvbelt_D5FgP02J0_SR-BrP6j02uuHUzr0y7jFK7
+bld-EldldD_UFp--VtxDvsVWyHpv_1nVJRsLTy_l__mt_Z_-MVm7
+}
+
+AWSEntityColoring(IoTCoffeePot)
+!define IoTCoffeePot(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTCoffeePot, IoTCoffeePot)
+!define IoTCoffeePot(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTCoffeePot, IoTCoffeePot)
+!define IoTCoffeePotParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTCoffeePot, IoTCoffeePot)
+!define IoTCoffeePotParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTCoffeePot, IoTCoffeePot)

--- a/awslib/InternetOfThings/IoTCore.puml
+++ b/awslib/InternetOfThings/IoTCore.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTCore [64x64/16z] {
+xPI7akCW44Hx0fF-_tytGEsXjMKjqkKxlwBIu9xaHlb7ykH9LULrmbjh5XVLBXYmNQaj06apKmROJnUdTr7L-t41x6HrWkQa0USwOBJAIHaeQbbT3N8JKKXZ
+8bcRWn3t8O08q0MvGMkdfUXhNKWWUzlgeOhUsZ75Y8FLjFgoVJem1iZYA-F9eJD0xU2UzzrQyr7fKG7UktDXZPag-6420-ST3G0eSaAmH-Nlcm-GXK9gTk3W
+_Udtujh_Ce9_gXEBpZC2j2e9aDYy1zlNjxej3W6Q2vX1FcsqfbUGbm40zrn-h7V8hHMZkgTqg6ZkUUNb4loZN8snntvyt-Bp1uC6hTdk9Z_3we6zvuqne9_7
+TG9qZhc30vgZHu09ij7N276cnz6NczIYzvZ1iF0nVtW8MgR0yeXG0599r0i3u5wV0Bo7kiSE2LFhgweIi83oNGy8mQk6dO-fldpITstIq8FBHYXo2GN0iT6F
+bqoUYqHtmrOVg-hflzhgPSw-X85ywal1UOu6s3VzNDsf1A1eC1_RF8qpFj2y1841Od1Tqy_z_oOzlazlBRr5DilhL3z_84-Ul08
+}
+
+AWSEntityColoring(IoTCore)
+!define IoTCore(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTCore, IoTCore)
+!define IoTCore(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTCore, IoTCore)
+!define IoTCoreParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTCore, IoTCore)
+!define IoTCoreParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTCore, IoTCore)

--- a/awslib/InternetOfThings/IoTDesiredState.puml
+++ b/awslib/InternetOfThings/IoTDesiredState.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTDesiredState [64x64/16z] {
+rPU7hkmW34J71Upv_nz-Y8lI55ORTbyxAeu6JdepleP8OrBHECTdJ81amo1aGs5i9E1i153PA43yJ8DWfxBS-zpzxXscPTtqw1ioRqWJVghq2gWtR0mhuAKX
+A6HiMsSe7g91rhuaoS02GMfV45Sie5a4Ny1Dy052-arQBznimp9avZjFpEQyylF0YY_Oa5T-X7tW3rPyCSEolrEAlkNx1K04xvy_umLxTlwT5_onhxAX2_ua
+gTK-yXjhFaJmaVz3XAtvOeQFprzVaiWJ8SzyvmL_xDS3ZtouJ_VsTMAP8rdpqVZSbqnRyxMKoTY3vB_tORPw_Ml55ww_wgB__6Z51pBs_pnRLENYgnxzu23k
+pdz9Cil9Lr8FVhxodHq_-a76QVjL6lNE5pBTavHzpDdmau_6oOVqJOkItWtTnYJPI9duMWewCx-IPcIT-4Csa_lzLpBDajJT3ssqSdFz2pi-lLhNys-Pa-it
+yoi7TRTUt3ywc2IFdr_SFlyHvcJnZKBwcudC_bRVIVR_DqsUI7qd6RAKLCWPxC4iWOxsmRZQlwHyt3zrWdJ8wDFK6xhtQvDsBezxNLEsVhEoKKU_w5ixgRqA
+V4mhhDYHlSyiR9JDHzxxeZWnxvSdzKly0W
+}
+
+AWSEntityColoring(IoTDesiredState)
+!define IoTDesiredState(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTDesiredState, IoTDesiredState)
+!define IoTDesiredState(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTDesiredState, IoTDesiredState)
+!define IoTDesiredStateParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTDesiredState, IoTDesiredState)
+!define IoTDesiredStateParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTDesiredState, IoTDesiredState)

--- a/awslib/InternetOfThings/IoTDeviceDefender.puml
+++ b/awslib/InternetOfThings/IoTDeviceDefender.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTDeviceDefender [64x64/16z] {
+xTI7Zkiw38JX8IMAd7d_1xvm2xQPmHhbjlDlJUHF9Ot_tFxqfqpoUIf3wIbcXG4MHVrIYgmC1n01m2Dhl_TzLPahvZ3WNBhsUM1ZnigiQhdZoiSgIgB4MkF3
+GESDOr-dYlkXSwtayM_j-nf0TTuelGvQ0m361RJbx_o771xXS7xe5pumA74W7ldhqe8_zTnxwWTIf1BZcL_maignddaEO6m_VEXvl7_usAlCIh_mS4gwcr1w
+vsVLYgYVVKMigjbv1RRY9tyEYKqBY1M6q5UlWCKAO7NUaA8AgAtBrnPGeXBMyCGGIKrSUpMxpeIv3mravwVElRexnk47tFqyasRdhxUQ8wN2owUKhw7YVOv9
+ClPhF_fzA4XE33QLmOR1yhjF74FLUTMuFl6-Ufv3wdo9LKN-vBaFAJjlaritVcks1u2zyuREstjlR1f8TLu9xtp2IlTUT2nsJTYwzsaOx9k0hvzzEdh-kihN
+5t_TdxtzECD7NpUwdI4kFn4tkfy1W-VwdUvFORQyr_qCGA_xqY_zj4p-S_lJd_u2
+}
+
+AWSEntityColoring(IoTDeviceDefender)
+!define IoTDeviceDefender(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTDeviceDefender, IoTDeviceDefender)
+!define IoTDeviceDefender(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTDeviceDefender, IoTDeviceDefender)
+!define IoTDeviceDefenderParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTDeviceDefender, IoTDeviceDefender)
+!define IoTDeviceDefenderParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTDeviceDefender, IoTDeviceDefender)

--- a/awslib/InternetOfThings/IoTDeviceGateway.puml
+++ b/awslib/InternetOfThings/IoTDeviceGateway.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTDeviceGateway [64x64/16z] {
+xTTPigmm20PWfa3O_uQlj9tY35mDdjV-dx3WArFEmjTyGWoNORfkkryEa3jVy-pt1zYp_M22FRkjaUpflLUFcPeptNjw3TOyZgyolxhCHQ67FqTB7Zv20EWH
+_5KuhU62R_arNl3mWuXU9HN52B_0Rmuxno_9Bxxf4sNLzSaiJST7RQStQFk4bQSosvwz3E_wKVlHyC97X3FIymWWDerX1RjUFI9F_L5DZOD6PwJfnxhJCrsF
+V_4Swv_kylJugqV6u-CFOquJUEeJoX1yxcdw4UxvdCA3Hx3fvugxehXBqsS27BRfJS-OkzBexnzpA3BngKSBJj3tAopSF__JvZiMEJORNhoCx7fKAwAuwIzo
+wpzUhhoKtfNInwqRcpE20FYryFIeVdh9v-JczrTavDk9BFRARs-gYZ6WNueHNbNjxJbMOcifkRbt_7A7aLpEsF9hTYKFXq-zznfhLIfwqRZtQ-b5nfuVyB-W
+tly_ALuE1D_lV_8F
+}
+
+AWSEntityColoring(IoTDeviceGateway)
+!define IoTDeviceGateway(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTDeviceGateway, IoTDeviceGateway)
+!define IoTDeviceGateway(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTDeviceGateway, IoTDeviceGateway)
+!define IoTDeviceGatewayParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTDeviceGateway, IoTDeviceGateway)
+!define IoTDeviceGatewayParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTDeviceGateway, IoTDeviceGateway)

--- a/awslib/InternetOfThings/IoTDeviceManagement.puml
+++ b/awslib/InternetOfThings/IoTDeviceManagement.puml
@@ -1,0 +1,18 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTDeviceManagement [64x64/16z] {
+fTQ7Wgqm20JG8I70yFyV_Du5tQPkqTbowqaXiV1BuhVn3Xysm4Dk-0SZuCC6U9OR_ku8-B01Vjy0UTENOwmLlESPf0aWTjFJ1p0dC9mtV2WmZBG1QF2lVWca
+viweft_pMwVTwpQKttkVmFGFAz6bE2t3-SJ5-gcRUP31C07qDzu4ihPX25wPrcK0PFtaVPiu6HEGgJe5c56Jc5M6QrzcU3yT4Ek6J31g0RSoN7ghYNS6Pdne
+TaIboh0kV4uejoWcFsH2tzToNljW9o3HJxO7WRE1_yOlhFoq4HRqtVD7Fs2cgW8HYAgQOPpxFFM2ZfAAZWHFVHvycQ7c0quwXfkEsWIdFWz-0a8o5rQLeWlO
+cu17dr-yOaWzqpv_Q2_8W5xu_EGTGeMzda3grqd3387ntET7Fs3f6EI4qVr5wqqQnfNFTnyOlNq5MBtqa5bl2fmNFdUVXfKrTWnK_Ue9lEgnBdtkVi6I9CIh
+4jMfTpqDUkspVAR2g_-Pv81N9JZXF_fit_q7X1coRpn1_DRt_3anL33-1wBIHxF2VlO1sJSXj1MsSuaWVlJCsGLap1f9hatNHcZFxxn3efOpqFtX_HooUrxw
+wd1q0miI8LWxLtBtFFTyUKw8CVzd0O3MR4pQCRR7Kx-OoNAYPck-_5osL01jffldqPj0h1g8YOge2YhJkGq3nix1PntnKItGrp9dPlXQo-FzZYAuv-0pOm3w
+uX-Fw_nmH-7yaAFlIIpc-Hs5yNDEVDOHwvcdTnHVS-AhUbs6FTixF4cUnhiCh2ItYV_U9wrcc-J-b7_okNNwFfI_-gqCNGhoXg--Uobk-gHL3Uxw2XzvyfdF
+fpwV-dpgywdFfpwV-ki6_W4
+}
+
+AWSEntityColoring(IoTDeviceManagement)
+!define IoTDeviceManagement(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTDeviceManagement, IoTDeviceManagement)
+!define IoTDeviceManagement(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTDeviceManagement, IoTDeviceManagement)
+!define IoTDeviceManagementParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTDeviceManagement, IoTDeviceManagement)
+!define IoTDeviceManagementParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTDeviceManagement, IoTDeviceManagement)

--- a/awslib/InternetOfThings/IoTDoorLock.puml
+++ b/awslib/InternetOfThings/IoTDoorLock.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTDoorLock [64x64/16z] {
+xPS5igr030L9XaZlVyF_fcgUCRnS-6vTWWoDd21X-ziGaG-JTLrF4BKfs6EYe8-9WSoXJ_dlg_c3X9f0kdj07DUvwQc-SvdzH5SWBm7ewXkCxHAZibbmSdj3
+5hOt4kzz2HP2hll92NdP7n3xWO3nYIzHyERl9m4hx6y-KSZqASvzaNEVGfuSNpqXNVlZJtpnToRxzBlyLh_qC0lAlEyBC_41IEjB4GVVNeKTxE2755kNVv3l
+jZ_Fl_7VdwIJhMz5BdviarZyjAAhNqbpN9Aud_yEFaTAlL__17zCrAcHpjSYZhuca0ca7ltGegjVhO-tDyVz-XLgystT-kVd_u7k_2VU-lVpdvf-Ywy9gOtV
+tByra00fgvzMTFdFgLbvNra_0n6mpY-aYDKVa0bZzKEAf_a5G7n3_HpyM-gle8tVV3ywl_z-zVxrxrSXxj8S_mSzFmDSFp8SnbLVaXDIBlc51WkXsy5l-ZSP
+2xBqRz_UFtvx_xhspu2xnx5_ZjSXD_tM_ls__mt_ZtyNNm
+}
+
+AWSEntityColoring(IoTDoorLock)
+!define IoTDoorLock(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTDoorLock, IoTDoorLock)
+!define IoTDoorLock(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTDoorLock, IoTDoorLock)
+!define IoTDoorLockParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTDoorLock, IoTDoorLock)
+!define IoTDoorLockParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTDoorLock, IoTDoorLock)

--- a/awslib/InternetOfThings/IoTEcho.puml
+++ b/awslib/InternetOfThings/IoTEcho.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTEcho [64x64/16z] {
+xPS5aeH034NZoR__XPVgoYfCaNNZZQ2lNUbJuOqtYMAHLOMDgWnJVeqSXHrfFBCviAYCy8t8B2ny57cjoEJvJOrrcy_z0b98zZdM0l9KDo28740nFOSJq3C_
+05abcBPxfe0F_3gEXArcFb2XJ0S5EFMx-jnjmoEw0Wk8Sx_44WUaSOtyxP_LEz9kmBuoDFKRRcWnztVy7l_oBv_f1ZpoaKA7I6BYxuRlnHeKfduFFwOBwx5W
+w9T6uO0AdPO_gqSzTzS0DF9Xj60MqGqHPbhOCF-fJ3jOSrv-bQuFqJABUXOmz0DDDMW2i_9ZYzgNll5hsZ-hUKHaHhYRya_lVvT_-PT_pPy6bDpUsJXD1l2G
+0tize7EyPs2c1xXdNwS9cZs7vFFzMyexDf0LyleDxEF-LRvs_ppd3W
+}
+
+AWSEntityColoring(IoTEcho)
+!define IoTEcho(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTEcho, IoTEcho)
+!define IoTEcho(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTEcho, IoTEcho)
+!define IoTEchoParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTEcho, IoTEcho)
+!define IoTEchoParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTEcho, IoTEcho)

--- a/awslib/InternetOfThings/IoTEvents.puml
+++ b/awslib/InternetOfThings/IoTEvents.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTEvents [64x64/16z] {
+xTO5ZkH038NXtwuoFD__lWkzKNe4MIKQuQW_GR2Oh9_au-EZt3o_aHmCGc-Z9vnKGKk7Yj1zZKcpgEDn6z2wp-YH7qassChI0u5jnoMf7GlDFEk4pLyvQcDf
+bClDV9Vkwkg4bB6bDC0CyD9ja-3iqO9LaZeNnCCCf8NNg39BaqOycmSJk1G6O35jfEvgN8sr75R4WgN2rBPrQKQdxjd4EAjdHktiMQGmNQc8qXU64dy_LR76
+wSkP0soTsjOuzUxHhUhPrEN2YpHIfrPZEbM_Nbuado1c2lmBO-cVzbDUfSzN-ZSpyBDsPiVBc8lwMvKJqg4pscWTAb-taVzTE4jlHWTxz3AB6acOhkHQgRS9
+jev9EzhuCGgZMx9aPC7AxdIi9SaftLAO2hATb_LAdYpTis1DmkxQQvtRHxHksRYnfmnMP8-UsLYtiQHm8EReaJkwEh3MiN-gAtj6jV3R-wVrUR-Ygd8RUDtU
+lvVUvyV1y_dv8OqgzjwH_VpyEinVZy_FRvxVtuqVVhoFZu_V
+}
+
+AWSEntityColoring(IoTEvents)
+!define IoTEvents(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTEvents, IoTEvents)
+!define IoTEvents(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTEvents, IoTEvents)
+!define IoTEventsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTEvents, IoTEvents)
+!define IoTEventsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTEvents, IoTEvents)

--- a/awslib/InternetOfThings/IoTFactory.puml
+++ b/awslib/InternetOfThings/IoTFactory.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTFactory [64x64/16z] {
+xPU9kgCW38K949Bp_YyySB5yFHDBcNtzxs9SVfM4Qfh-DaI45d7R7eEDGm7jYmpalb10vgx__ckojeu3Om5u_s-0yRQEvbkzufYQ8Xc07m4WHr-1aeueWAP0
+WwT37ErtzPlTLIURkvkyyCK66BwWu-4KobLpm0Po-HWiVvs2V2D_8dVNj-hX50elTzSFuv_JFgjZO5N8t-IF_4Id-2gVJ_76bu6HFodjoiNdliaWSVxPdyZZ
+5EnFPEFJAG3FW1MvztNWv3DIPCwiLgRlEdXHFsaVo0gkN61Wx_Elw50maMe0vCHtfs3HRlqyi6TVE5ZevLiUXFejFsSAsD_NBuv_xyVxh_YWhc1__t7-bzef
+QGN1t-S_y6FzE7-hTceAmV9v_Wec8Nyw0zvoNhyOH9-V7t7-n43u-N4__oLVGKeFV-qw_Von3npwdAsKGlusxo-kt_9Z_M23_VDl-RlFJxo-wyAdprja__uY
+fa_iyvVCyOJRpPQjduI8Mtv0__8j_Tktzu_Vthzo_mnWDixSFzlQrJH_Q__-t_-6xuz_5vy
+}
+
+AWSEntityColoring(IoTFactory)
+!define IoTFactory(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTFactory, IoTFactory)
+!define IoTFactory(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTFactory, IoTFactory)
+!define IoTFactoryParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTFactory, IoTFactory)
+!define IoTFactoryParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTFactory, IoTFactory)

--- a/awslib/InternetOfThings/IoTFireTV.puml
+++ b/awslib/InternetOfThings/IoTFireTV.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTFireTV [64x64/16z] {
+xTPLOiDG34HHuKYp_mtNK3QLyPsVu5LYjdolOT0tM_BYczMKAzz1bxuYto3ghWzvatXrF_hHcxlRJkygrpIRCspxwBoU4CY8RDQs5-TsmZudDlr4YuIVfngD
+AOoTVf8a6ww7SP5jKjJzNWoSTELcXdaM9wbJWUFjPyLL5p9Zba0r5x2bqyD-OjdSTRTwuLVxZsCpej9UjV-f9wfdLGZJpzh_Hp_wnflqNVzsKo_e4sIVW5nm
+qkKTZBHVsLla941YVVRACS5dudMzynb_vqsj_433S0C
+}
+
+AWSEntityColoring(IoTFireTV)
+!define IoTFireTV(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTFireTV, IoTFireTV)
+!define IoTFireTV(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTFireTV, IoTFireTV)
+!define IoTFireTVParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTFireTV, IoTFireTV)
+!define IoTFireTVParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTFireTV, IoTFireTV)

--- a/awslib/InternetOfThings/IoTFireTVStick.puml
+++ b/awslib/InternetOfThings/IoTFireTVStick.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTFireTVStick [64x64/16z] {
+xPK50WGn20Ct50Bv_uFFtLqxwpBrbk5jT3gT3kngjlpIrN1O0zr0RFcqgsYbtF9zk0vAdE6t-QabkDMlARVxDRtu0tsSDk1PLSGn7nauvJCPbEnu_gd0sMx3
+YVg7n7Qy_CKXwsJxMKf5nvvhaH81nPdszzA4OdWpJB7cp9AKRVeLP_klfVPOreljalutpzAQZHhXql43yo0poMXsx_Zx0lyDytS9xb-_xby_Ro3kZ1_tng_t
+q-bqEcC
+}
+
+AWSEntityColoring(IoTFireTVStick)
+!define IoTFireTVStick(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTFireTVStick, IoTFireTVStick)
+!define IoTFireTVStick(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTFireTVStick, IoTFireTVStick)
+!define IoTFireTVStickParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTFireTVStick, IoTFireTVStick)
+!define IoTFireTVStickParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTFireTVStick, IoTFireTVStick)

--- a/awslib/InternetOfThings/IoTGeneric.puml
+++ b/awslib/InternetOfThings/IoTGeneric.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTGeneric [64x64/16z] {
+xPS7ZiGm24MD9mR_-rzuOvafHA0bcbwUIkfB0TpAfq54PhCvzoy26RS2RTrKeAwR1f1U2ldvjV5A1yO6wCmiW6pFSQkklY3DuhqTG4y1mFc21XnAYiECpGP6
+Bqaw-9DyaW7s-901gO-9-iGXf3ucvBwV4SBk-rMxyAEwuKpy69sA0_MqF--lL0oXJmEnFZ40he4lD2Wc_iQdFa-HxqyezXdWHG39-6tGBtq2UAP2pk3izpQW
+C7uLM9mk9Hr_cbykzlqxyYVU_qT-7SYU-4iTsFnv-ISjfDtvKyqyoF73xrVCZqJVhvhl2o0B0pAqPFnjqZIHbFSjMaWry6tz1aNBvlscVatyu__dHFxoyLS_
+xZ_EL2__GeD4_apzFQZ_pFVVruqVruzVruwVl_d7jVEtw-UFryzVxVmP03FBTluifqlSwhNpzvz_nVhni_W3
+}
+
+AWSEntityColoring(IoTGeneric)
+!define IoTGeneric(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTGeneric, IoTGeneric)
+!define IoTGeneric(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTGeneric, IoTGeneric)
+!define IoTGenericParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTGeneric, IoTGeneric)
+!define IoTGenericParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTGeneric, IoTGeneric)

--- a/awslib/InternetOfThings/IoTGreengrass.puml
+++ b/awslib/InternetOfThings/IoTGreengrass.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTGreengrass [64x64/16z] {
+xPO5Ufmn34H7O5cZ-z-ty7yEnr6zvNPVO76U6VWNSETEHYHlPm20VqTSV0W6RqGmgrAGxCctNqeeoJ9CTeG24c_oGfAAREE0Al1QOF1CXsJVqAWA25-IWejE
+i1hwjg8v1DxN8A6RXfOXYmxbXoY232ZVovEqPXBDg__UoNDehfdmiK0lmwwQDQ7ivyzUG4EmvwrWMAuMAey5g__M9_DSy9IlmAXJmSe_pP5pGVZAKv2t28eB
+m-Inu8bo1Cy5Bhdo0y5ZGHas-LRGvdl1ok_RtmlcQFg_hG6RyMy4oMx-XOfuRWIENDstc_y34BmlLrYx_XAOfC7hqjUB1mFGhF-0rsKn6-Gmio3Tp2RfJ_dj
+_hFMjU1gWm6mkbwDoiUpesBRUmd9gW7BJ3BpyO7hrJg89ZSun1N8uePk_tTy9VRvxlp9cV6He3-1MO5D5IkjZvCr1VfU7uH0a-n90pnVIZdjuFuL0bWaMLyX
+SoYWazzASLpJo7oCuNOz3vvGdAx0GaVoc6BE-C9CilWdSkVEPm
+}
+
+AWSEntityColoring(IoTGreengrass)
+!define IoTGreengrass(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTGreengrass, IoTGreengrass)
+!define IoTGreengrass(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTGreengrass, IoTGreengrass)
+!define IoTGreengrassParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTGreengrass, IoTGreengrass)
+!define IoTGreengrassParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTGreengrass, IoTGreengrass)

--- a/awslib/InternetOfThings/IoTGreengrassConnector.puml
+++ b/awslib/InternetOfThings/IoTGreengrassConnector.puml
@@ -1,0 +1,12 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTGreengrassConnector [64x64/16z] {
+xTH50i0m20H0eh3_Vt2zr9KhSwiiyL37EUTSo9LdXLJXMSs1BiMAjQ1LiLOZdSle2Gy4Y5ft_RQJwKm1m2beiNLU8o4nW78UbqJga5T9pWeaG2AzoLCK8D6E
+ZlS-h_DnQ7xNfppFMJpcgHmwK86moq_EyW6e--uplM-VM0SG1zhzv_7h0E80i_mbdw6CUMl_3VDdMp_h_Z7kN-lvCPvVu_rXlB-CzwVz_dREETS2
+}
+
+AWSEntityColoring(IoTGreengrassConnector)
+!define IoTGreengrassConnector(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTGreengrassConnector, IoTGreengrassConnector)
+!define IoTGreengrassConnector(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTGreengrassConnector, IoTGreengrassConnector)
+!define IoTGreengrassConnectorParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTGreengrassConnector, IoTGreengrassConnector)
+!define IoTGreengrassConnectorParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTGreengrassConnector, IoTGreengrassConnector)

--- a/awslib/InternetOfThings/IoTHTTP2Protocol.puml
+++ b/awslib/InternetOfThings/IoTHTTP2Protocol.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTHTTP2Protocol [64x64/16z] {
+xTU5haGX30JGjWnjv_z_-0N9MnV8nfcho5cNM_bHT36t6f5SIWOkse8R2PF9aqolM4ZrPcpu85rbCUfaI0j8buquYN7tgJjUap4EBblnViTArZrVoU6nvt7y
+ySSVV_noZZzUpMJwtTnxBEREAnUZF_TLlqvzy6kl9VPynNllhUdGw37lXzAQhdrE4IH3N_bqaRO3CW4j209gh8WKaKBLGA5_yY8UqeB6Z2h6yj_f-TBNLrwR
+dxCZNla8e3xreBM7FsRYfS-8uAFFPEsFUpxyrSUFOY9ZL0hjojSlNxz-iFde_ttIFtXUVCtvuaq_wuUlxp-ydpCpTNgGVkrLHIwxTZ1fQ4me_Rnbtl-idox-
+NGeVlZ-N-isQ3xoB1ow9xY_res_zVbpgrogQMtxMpx9VHU_d3m
+}
+
+AWSEntityColoring(IoTHTTP2Protocol)
+!define IoTHTTP2Protocol(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTHTTP2Protocol, IoTHTTP2Protocol)
+!define IoTHTTP2Protocol(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTHTTP2Protocol, IoTHTTP2Protocol)
+!define IoTHTTP2ProtocolParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTHTTP2Protocol, IoTHTTP2Protocol)
+!define IoTHTTP2ProtocolParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTHTTP2Protocol, IoTHTTP2Protocol)

--- a/awslib/InternetOfThings/IoTHTTPProtocol.puml
+++ b/awslib/InternetOfThings/IoTHTTPProtocol.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTHTTPProtocol [64x64/16z] {
+xTTLeiKW30JG16Ap_mq_IdbUWSeVyp6vTgvRwA7mO7vhyS1GmkLR9yU5UFha0OIf34HjCUqA732cmR01NWz9uNGX1iXwyy5NF0Ty7KQNOlM66T1hNe7LopKl
+qqy__VJJ3sVwwJabQlvwjdsMlknvGr_uDHzy6Ztq5rw_fprxhfMyfWtEfRJBGsgn25no6H4Yf109w_AvNGc5hgTxAOt5SgUdJP_xl8defhUW7X_k_jyZ0ldE
+uvVCzCFhgF_r-WVikc_xmtLVXsrxIhMu59UgezPFt_QdY-__pVsjUZcD5x-vFmvyVspjhp7WD_Vd_dMQRkS3
+}
+
+AWSEntityColoring(IoTHTTPProtocol)
+!define IoTHTTPProtocol(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTHTTPProtocol, IoTHTTPProtocol)
+!define IoTHTTPProtocol(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTHTTPProtocol, IoTHTTPProtocol)
+!define IoTHTTPProtocolParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTHTTPProtocol, IoTHTTPProtocol)
+!define IoTHTTPProtocolParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTHTTPProtocol, IoTHTTPProtocol)

--- a/awslib/InternetOfThings/IoTHardwareBoard.puml
+++ b/awslib/InternetOfThings/IoTHardwareBoard.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTHardwareBoard [64x64/16z] {
+pPS50jmm30Iz8Zl__t0TAMd3fD8S-p9h2hdyKT3vBBEreTEClzZYSj3ahGqRlMggLeUEuPtUkgEJ0nsRW9Tw7GKG-KTz5z0tj_uXrJinTjxwvsETVMDqEwZm
+I7vHFRmFpKIiUTlneW5GYJuWfi9LKPGNY0z1q0Eal24Sb0b4rZk85mDAvVz5x3FYWvC0xhSDGnJT4lvcShr47tNy__8XoWa_JZdXdvyiI6QmyIqc9BwU1dHd
+WZP-dKeF0rWLDxvwAPTzGFpNQF890E_zE5qrEWY0HxVQ-ZEwI1lVOT5rW6hye679iHyi0txr1zDrhDEE_Nt0B4NBuYGS_MSYafs_3t1_A0w4x-Pl6O2V4rgV
+pZzPLSm1tW1gKrEMW6RAqe_Ujdcqmm8pdkx_6gEzy8Edlhal1pwq6jtwx3xsVWmZuG1T-3xiNFO-FpX_IaotbGDVaZvyEvK3wXE_S3ixdSaZlu1G4dxmH_tD
+HIk-F63o4o1x_VvlsTy_vU_VilUFsVlN_Frp_luzltx8hr_owwVy-Ys_ViolN_Fhvpm_
+}
+
+AWSEntityColoring(IoTHardwareBoard)
+!define IoTHardwareBoard(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTHardwareBoard, IoTHardwareBoard)
+!define IoTHardwareBoard(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTHardwareBoard, IoTHardwareBoard)
+!define IoTHardwareBoardParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTHardwareBoard, IoTHardwareBoard)
+!define IoTHardwareBoardParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTHardwareBoard, IoTHardwareBoard)

--- a/awslib/InternetOfThings/IoTHouse.puml
+++ b/awslib/InternetOfThings/IoTHouse.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTHouse [64x64/16z] {
+xPS5bkGm34GZsPPKzx_mZgNcQdipRnd-W-0FbFdusn2HfmsVs-FmUIimFZOAwCTc05AN_ljhTDW70SmD46RcWB-Uiw5lzOxJz8DH074A0Ch-0DfnYZQp8Gnn
+d2HWFydN2Fq6lm6K2llY4x3VaNJsaOfSV2JaZ-bs08FyGhRlj_hs1i0Mxz_ylpWGMXa2Bf_ChwINHvttMm1sUwSO46tjoyGHJy7RQnRzmVTKZaN-WpAlKvG_
+-Vmo_YJsnoGGd1OdMdwaygxy9EuwFo1acpyNDbU9hS-LZQia-pfnH2OPRUstoDG2dWgLN-tPxlNb5q9-Nl6LxtaN-VVlFqGrTdweod7_Viw_1XdncFHvEWgh
+IrJ_t_eDYTUeKEZdVBVqfSQiMFXKVs--rjrIJQ7VVQw_WkB97pqsVh7nanC-zH-LVzqnbhwdiipla2fVya_cV-Ed-E8JdFRtuvS3TiTllfk1yd_x_XVAB_ph
+urUFP_8kyKZwJvX__2J_s-Tltpv__FRvAy-VaVN7N-VFVhjaGxzr_lxV_uRruz_55m
+}
+
+AWSEntityColoring(IoTHouse)
+!define IoTHouse(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTHouse, IoTHouse)
+!define IoTHouse(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTHouse, IoTHouse)
+!define IoTHouseParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTHouse, IoTHouse)
+!define IoTHouseParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTHouse, IoTHouse)

--- a/awslib/InternetOfThings/IoTLambdaFunction.puml
+++ b/awslib/InternetOfThings/IoTLambdaFunction.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTLambdaFunction [64x64/16z] {
+jPUBakmW24I3HY3__yFNc5XdGf5zMRVt7MowXM57j_yAwVWRi-pDt8yETsjx-Hsv-H7WxSSfThiffgr3xKvc-u_OVibLuPdKov1_cw4ONhCz6P4CRR0b3yh8
+qDxPeZskyjS5ubsyRfkv0tkkhkUQF47feNDrEHxG868zGKdLnzh1Dvte3wEQuY2X3tx5RrAmD84DElm933mIM6mSZvxy7GF0uiCoBS77WAURBI7XpO6FWNsB
+gBTTrkYd5zrFJ2qC02LhB58DdM_u0NAGbHfDmHiobresAHYmq2CvGLBD3T2mVAXyjgIy6IZybl0fl8O5gDBXt00TISFlzgLWW0Ab6zYJyiWPe_CrawXtUdsP
+43gFWQ2XLyoJK3T0Zt83VXW_ujP6yhlpD1CWx1GNURDkWCwdKwI3Bz7QjUyo3PIioNEPH3uJDmqeER_du_McMZv5xtoi3chD3S2FzQDKzTq0zOlzerKOO8nB
+x1y_a9-4GNsECKOHvlNB_p9s7AQe9AzVvWTHsaZdgINp4-UNUY7SFWtCTsJc5m4qU3nyOc2W42SHyeKwniutrNi1jlcD6jD6Ei-AWYfxHZxKaSx39obMaISd
+78jygahF4K8U0_0fAWOKdIYFB_YAFE_VEjzvzpO9nDiLkQnKb3xE3mV0C9qd8awSyulO-x7DYBWCEzdvIS0MG2GzFmrBvCpn_G7mptJEhoc-FxzoVdu5v-V5
+y_lQ_M7z_h9-Vrg_lwtV7zVlh-ltvtNy0m
+}
+
+AWSEntityColoring(IoTLambdaFunction)
+!define IoTLambdaFunction(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTLambdaFunction, IoTLambdaFunction)
+!define IoTLambdaFunction(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTLambdaFunction, IoTLambdaFunction)
+!define IoTLambdaFunctionParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTLambdaFunction, IoTLambdaFunction)
+!define IoTLambdaFunctionParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTLambdaFunction, IoTLambdaFunction)

--- a/awslib/InternetOfThings/IoTLightbulb.puml
+++ b/awslib/InternetOfThings/IoTLightbulb.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTLightbulb [64x64/16z] {
+xPS7qjmW34QHGEMx_u6tOCqobaEMjTFplockpu0GnULVWuXsXtJlBGPxlWh8uy00Fmu2K3oQykMpw0C7dWV0LTK0o_TK-9jwmpAj7640lWG0Fle2rB94xR79
+ABmiuj1VubTHCvLwpc-EmDjtVR8dsFlitJJRZhptqHKA7vsTNtkntU9UaRhtEpGjdm48bO0404_BFxQV76WfDvtMuoSfG-BEgayOvyC1pNnwOiDfAPNZNXk-
+TQLCugzmoZuvT1R_x3ki733up9Sd3b-DZyExCka_clcqyFrBptDJgJsW4PI9pqzi-8B8refNvZCWmxUkpFgF0Ss-0hpQVyN26bbJ0IiJFzU_Ly0vJhQZnqcg
+_sp-4S3hyAi3yj7y9G2KDfyKeQ_wyG7RV4jwydF-1kp3Z-alv-ya_e4DtqhoDzxvNXlGga_zD7za_qNoq_mnMJzq-7fg_U8QS3dbL_EErVBv-ZN26WzMrg_i
+Uso8Q1B_T-LhchZMrg_XMtjW09s97o4uwHT182VtBnIKYNzv_tPz_tXz_vhtpm1KrVB-sLwFLFZg_ltBl_3_-6zn1m
+}
+
+AWSEntityColoring(IoTLightbulb)
+!define IoTLightbulb(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTLightbulb, IoTLightbulb)
+!define IoTLightbulb(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTLightbulb, IoTLightbulb)
+!define IoTLightbulbParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTLightbulb, IoTLightbulb)
+!define IoTLightbulbParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTLightbulb, IoTLightbulb)

--- a/awslib/InternetOfThings/IoTMQTTProtocol.puml
+++ b/awslib/InternetOfThings/IoTMQTTProtocol.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTMQTTProtocol [64x64/16z] {
+xTS7ijim38JX1OYszxzm1cAwwCXKdgVgTxVvkJVWYvBD_jIMnQqgxPVMv8rIV_0YAzmsycYZqoSPWiqao4HdPE16GTgy-P8xNeev3mAtYkE6XVHxtidfxPwt
+np_-yOz__7QFVxoeukHtM_jXx_NA1zzBFkPBBlD_Ubncd_KHnw8KG9FbW6VdbbrS-UG0q6k4EOo1OKutLJE6ZMiVmEWrKG2C2cZljMbovRC46IMec6RFbwT9
+ZHBC1UMRtaP5A4LkUaTHbOBv1vallR_ovcYVYQPZxOlnoWE77qspiFBd-U7i-sILhdqVnCgBe3k0Elt7gKxbXr_FJ-t_R6IDnVj_ERyT_ZIoLTgVvVJd-N7h
+--CylzQUFy_Fxu_J-E--0G
+}
+
+AWSEntityColoring(IoTMQTTProtocol)
+!define IoTMQTTProtocol(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTMQTTProtocol, IoTMQTTProtocol)
+!define IoTMQTTProtocol(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTMQTTProtocol, IoTMQTTProtocol)
+!define IoTMQTTProtocolParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTMQTTProtocol, IoTMQTTProtocol)
+!define IoTMQTTProtocolParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTMQTTProtocol, IoTMQTTProtocol)

--- a/awslib/InternetOfThings/IoTMedicalEmergency.puml
+++ b/awslib/InternetOfThings/IoTMedicalEmergency.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTMedicalEmergency [64x64/16z] {
+xTS5RaGn30JGXZttlt1ZM_fCqPIx8_Zu5i9v-s6fqlIGHK8_H97O3q4awzqczTP3p0Fc0VE0US5Vza7JlHvAX_sGWDGF4IYXf_kWETAfuN5QsdCCPVS13QZb
+OIhGDZnqFj38WB3pvRalVybNowXtfHUmp3vVPFOUxzIQoMTS94_UK9l__wZVbz_iOpXCVEh3IVySzR5QuhNFcdBaAopro1TZS_sTU94JFzUVN7ZfZo-yJCDM
+7FNHs5n-Ltwy_BtanRruBOpu2ejxJptpKPDsNdfQxjTDUdO-6JkfF_ldgyZMUrZF_dwk_FZwOziFstxP_iFsNtRyOCOlVlpanszs_c3dBtR-PEVlr_g7Np_E
+wzVyC9qtTltChj_v_SDh_yNlNxy_xm
+}
+
+AWSEntityColoring(IoTMedicalEmergency)
+!define IoTMedicalEmergency(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTMedicalEmergency, IoTMedicalEmergency)
+!define IoTMedicalEmergency(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTMedicalEmergency, IoTMedicalEmergency)
+!define IoTMedicalEmergencyParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTMedicalEmergency, IoTMedicalEmergency)
+!define IoTMedicalEmergencyParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTMedicalEmergency, IoTMedicalEmergency)

--- a/awslib/InternetOfThings/IoTOverTheAirUpdate.puml
+++ b/awslib/InternetOfThings/IoTOverTheAirUpdate.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTOverTheAirUpdate [64x64/16z] {
+xPK7ikGm24G_84BV_yBhDAkI3HvvS_XTOU9p0IrQ7pzQd_eKYTgYnjz4DyTBOVoOZfrSX5L6Zt0342OhHBnL4Z9FamFHg7_13a2dUGUSJlqyU801VlbI0cXJ
+k02HJ8i1pDX0KVnFZhA8Rdaj6pL0I6DpfkO3KLK610xPJVTwKnhWgWR0wlzGnHCE3xWsmn4tpiP1KTbbmARs0v2YH9tX2R2Idv6dXqnibhVa6903itp3AkVJ
+Yi1czvoROL7hE81dGKM6_W2gpqGjwKjPJ8xLOf4rsiQhoRA_ZFFa-Ov3MsyA9ETTZdcsD4OHRkQ1HQg892xy-2ibCGhZVZA0Czz1Xv_n6FsLIFcsJp0kl0r7
+NDnoNW39zax6WIfsfNnMVum3QHwhFEDvgpRcSYmna9D0IFou3ImUsatcMOW1-vhktvGZuEH-eibbqbvsGw-WlALQE8ruZp5z6m2ZJTG2W9moAKoLRzhrZLJL
+_JmEVsN39daJsunTeNI92u-8pkVRJXliRQJ7qP7kEWeShorQzFQ6kVPYjQirdvWzpHlJaDP1ptYuTBExMvFyxh0raRQzTPf3-mOeka8_deWYsbgsOrDXzeI8
+5tNu3zIdlW
+}
+
+AWSEntityColoring(IoTOverTheAirUpdate)
+!define IoTOverTheAirUpdate(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTOverTheAirUpdate, IoTOverTheAirUpdate)
+!define IoTOverTheAirUpdate(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTOverTheAirUpdate, IoTOverTheAirUpdate)
+!define IoTOverTheAirUpdateParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTOverTheAirUpdate, IoTOverTheAirUpdate)
+!define IoTOverTheAirUpdateParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTOverTheAirUpdate, IoTOverTheAirUpdate)

--- a/awslib/InternetOfThings/IoTPoliceEmergency.puml
+++ b/awslib/InternetOfThings/IoTPoliceEmergency.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTPoliceEmergency [64x64/16z] {
+xPU5iXWn24KB9C3z_n_kvbQPPQtwx8oiJ4w4-ASNXcUinyYKxQ6PkZqaSwo_aNxf8-a3z07w0Ft4M_PbuSZrc81k3mDiUoWmPIFXikXi2zmcRA_Z4RiC0l1v
+4mUYo8oGFnXaWEpyUT-VRybtyjIdn923FFL1sFEvgFwGRoc__PLHVKfnq7v3oDSN65yaOBVZ9mcaSXO2d7cQGCfTFx38I9INkEaxu1CWOm1aEk2jFnRpXpzP
+aix8c5iguOjkjIf99hMc_umjRP04hEc_BBxmhOEM53zfBFJdyj6NZv_BLsfT_0pmpdVgD-8VoCvFnBt-6u2qrH-jhmkhlkvzhRvHQ-UVz-NNyGFI-SBnioS0
+QVnI_nhdYW6-g_y-VihYEmBGw_WxeBslW5_xxEQUG3P-7R_zGborEduJvA5Fikc_X9-TBOgFPls8i_X5ituGAUk7jde2TXr_LivrPpkRUEr_RLtwqE_ky0Jr
+AxyUXS9sNutVxLywWoMcMV8PKxlzg_HVrsBYUh9_dkpVmdHJplVlis6d4Vh6pp-_Vtua0VYuYGFns-Vdtp-___xzuUF-zVp--iBu3
+}
+
+AWSEntityColoring(IoTPoliceEmergency)
+!define IoTPoliceEmergency(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTPoliceEmergency, IoTPoliceEmergency)
+!define IoTPoliceEmergency(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTPoliceEmergency, IoTPoliceEmergency)
+!define IoTPoliceEmergencyParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTPoliceEmergency, IoTPoliceEmergency)
+!define IoTPoliceEmergencyParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTPoliceEmergency, IoTPoliceEmergency)

--- a/awslib/InternetOfThings/IoTPolicy.puml
+++ b/awslib/InternetOfThings/IoTPolicy.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTPolicy [64x64/16z] {
+xPQ7SiGW34HHr_x_3sTiCHVkyDYarqskysHf1HgthzQ_B4yLUeuxhdGQW83qCm5vmPydw9_3SqLHUXtFkRyOabx5w-wp0U3Ny1KW2dyDNm6G_7h_0u2zld-6
+JVegll2q2l1A_vDt3-HLF2Lu3-Elp9_AUVcQ_J_hzVb_YNyAuBn_nAAcmY_TFnQ-rUM9KZglxzykIOmANZm_9V8DScKY5WlKkjNpspWtW9u_Eu2WjVbHUD31
+LslpYn9pJoc0M9kVFkFTB5sPttAxq9mMBUp_c1qfAU3NFDSgzSmmUenCX_oup01k72ZfGm9onFleO2Ah_-6v1o2JHiO5-W7les44s9QeKra9JS0IKDaAo9bt
+86aiNxe55U1PiTL6ZxmLFlBRCewW2ev8mFS0Fl9k7KzkzxmZM_GJmyADc1f901Xutv-ry9ctladzfhpd6O3gjFkflfMcKjqOvAD_vSqyl19EPKclxYQdH0p-
+ouoNOpkcJ1AJjpRsJsPyTqIReolvFZIFV2CwF6RPccPLJFVMnENzepIhB4LDfkDJwVhvdMlEPNKlu_h-MSjNddqfBnTKat6-EcGDhyL-jwjZmYypW7V_IA9t
+Sbrz08LxJ9rSamIwgfYNYzGZCwFg-2RwrnC
+}
+
+AWSEntityColoring(IoTPolicy)
+!define IoTPolicy(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTPolicy, IoTPolicy)
+!define IoTPolicy(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTPolicy, IoTPolicy)
+!define IoTPolicyParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTPolicy, IoTPolicy)
+!define IoTPolicyParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTPolicy, IoTPolicy)

--- a/awslib/InternetOfThings/IoTReportedState.puml
+++ b/awslib/InternetOfThings/IoTReportedState.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTReportedState [64x64/16z] {
+xTVLOiCm34PXIP4jdVT_u46vzY1snikvAtnbo2yVbGxLOAl9K5djXbScgXSUG1GVg1p8zTx3P32ByoCm29NXDC1ETsyoaPqUG18oLP0Yeb3cV04zU9SkhKqg
+NVw6TvfysETDCrxbadwQt_tkTw-HTuMEUQV9XtszQS8tr_v_VlUxLpDjlDbwNnAot7a3M-kTGtxh0sAbLqZt1Brw1_1rti0Fvzd5QmAapleAom9ryl4RvB8a
+s1elfNtzWbCnyVurVkhpOwU-ulDR_5BfptdR5wV9-tDUEtwM92ovAwq_f_T1NlP3Dy-qwVNzO10olL-sxwVv_RPnFsxUhzlty_OU0G
+}
+
+AWSEntityColoring(IoTReportedState)
+!define IoTReportedState(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTReportedState, IoTReportedState)
+!define IoTReportedState(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTReportedState, IoTReportedState)
+!define IoTReportedStateParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTReportedState, IoTReportedState)
+!define IoTReportedStateParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTReportedState, IoTReportedState)

--- a/awslib/InternetOfThings/IoTRule.puml
+++ b/awslib/InternetOfThings/IoTRule.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTRule [64x64/16z] {
+xTS5SWD134HHmKZgll-5KwkAfnBZ68ClOFpBA8-bEqS_aqkAExaV1qY4oZdA2VA9WGrseQ-ngRrUU-Gz2Ng-7xB9lJx8c8ytz23canjwdQCDKb_Gtpxzo0rk
+NdvJcKnMN5f_aWKqyiEOWXDCbcZs9CoHfytjTv5ZoxG719_xppgDhGJ9KBc9rLoGjvZhwtP6sa_knUosB0-ON25v8A_kKMY5s_fIQLetz9Zxge84hkbLagN5
+tbiDx1SfkhhieKdqJD2TFUbWAfRMmTYgxYNOGhftaaCkyTxZkkzXTTDzxuqk5sG7xxqui1NTz-1oeIyJDTlVZbMirdgomcIFHP6BVQkCCRn_8xjTx6417e4m
+BFKYOYCBd50vJ4IM-wPgvcwcAcsvF-47z3-y_-__-_zUx-c3B9UZlCXOkWL4-lxvnnCaIouBDbHbjAm2MyWA7SKZQgYiKeyiW0se3DURxwRbcTu
+}
+
+AWSEntityColoring(IoTRule)
+!define IoTRule(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTRule, IoTRule)
+!define IoTRule(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTRule, IoTRule)
+!define IoTRuleParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTRule, IoTRule)
+!define IoTRuleParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTRule, IoTRule)

--- a/awslib/InternetOfThings/IoTSensor.puml
+++ b/awslib/InternetOfThings/IoTSensor.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTSensor [64x64/16z] {
+xTL74kiu301H90Be-rzuogNlIBD4US9gtbPiHTYKVucggSgFF9kR6YRNHVDK9jTO7LSEZ-CknhMyeKFbO0cKNiY1V5tlVUK4sjFzQa79feIKJmMnVVVr_QPK
+VEJmyykRp1ogkMaJMTFLazOH0xYiEVZg04D51xJAKiBYQ1Do4v2oLBGiw7E9oafJSYB0PC4sUeDobIyquRnNW1uoyGOwv4pKrpbme5nsQFHq0cq8sJRDGKxv
+wGd6DBXNrDkenNAktTUZlZ6uiNekXN4-k04GvxDQr3AVJp0dHQzpYBFh3z2l-O3nzGGAAG_-ROarPc0sJUjKQDCoCPDRBsPdtry6fCoEVZR_3nMaxlRp_8iU
+szvMxyKyhre0bQ_yw2rVLGFjCXdDXpZwu5EgVA6HrQ_yJzzlAbGs7VtiF-h_xnrSJaKlGI-5_97y95_wlEojRxcicNiFLtcJkT_Rl8Kdv6vl77pQF_RwX641
+_JezDxRND_Mn5HH4GFtO3yZZjhRwWb1lMWuEX7i0VkNznMF1G-_q4jmC-RKNZJ5CxjGUzAmlkQnU-mw_A9hyftw_mMNlWsq_aN_2Nm
+}
+
+AWSEntityColoring(IoTSensor)
+!define IoTSensor(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTSensor, IoTSensor)
+!define IoTSensor(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTSensor, IoTSensor)
+!define IoTSensorParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTSensor, IoTSensor)
+!define IoTSensorParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTSensor, IoTSensor)

--- a/awslib/InternetOfThings/IoTServo.puml
+++ b/awslib/InternetOfThings/IoTServo.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTServo [64x64/16z] {
+xTO56jj030LXlGL9S_yBDohv2--w37yOnapsI_ttt_1tuev_CinCV0DLJqO-HyahK4tabtxO2m6uNV7gPMEfd_U_opTwGKJ83hrtcBROMm24VJKeMkuxLmEO
+5BVbtkPi2SsQ9EiLGrlkYvAK0mn1c6HR_G22aWuqixrUJl6WfFRwqYQaTI26RBSl6ksIr9DjzjT-vxv7nfGT5A7rVbAoN-sfljmF809ILvj-N-sJR5Vxkn8W
+jTOBPhqcVapz6E0d-mvX5j1FJRyIcbc3r9dbvv1-aU0drf_We1FRZqT-5lwjs-yVqxSnwacdUlK0kYNCjjyhAU4KrsxVgafA06Elbon00y2LfBRw1WvqazIi
+GROvDtgdV2s2qfTxKSRTMNkrdz1xjuCY0hJOAy5r__jSxXzV9SLIdn7Ly-x2xLer-lRhHnlFhrBV6VPB_VVV1m
+}
+
+AWSEntityColoring(IoTServo)
+!define IoTServo(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTServo, IoTServo)
+!define IoTServo(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTServo, IoTServo)
+!define IoTServoParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTServo, IoTServo)
+!define IoTServoParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTServo, IoTServo)

--- a/awslib/InternetOfThings/IoTShadow.puml
+++ b/awslib/InternetOfThings/IoTShadow.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTShadow [64x64/16z] {
+jPO7pYGh30PjRB3h_WT-RtVG08i6YVv3ANKgmWTOBR-4gifNAJKIoAWcp_5aaYxFi7nfhNfj0P0c3t0WQv6EUW9Lhgb0LPbe1TgJtcqFCwyRA5DVqBoTGe3B
+P6sWNEX-6gX1YAYvcygP90-l6tZj2rlbX9sdgKn2vTY9olaTwQgU4CVXXvmexsWqm4zZh7B4wroCF7NXbrlK3l6PN50Eu_HBNv8qbGqBm2zzoAhx-a2gt62n
+5nODe1MvHJrOKmY88gN57Kr5F6S3tZTbunRlPG4REq9x1faP4JbPR-95PlUbGFRkwG_QwxvOaGMLWRuG1PTr8mNey1lh2TD8M-iOK8UlqEQvwNxF86Qmi_9K
+NkJm9SZrt3IYG5g0BKhgkAarYUbNq7zz0viJT8W6CRuMQGT_zX_bdOi1rHBQYAl4Hx-D-GTpoCaRc_CV_YnOGGvV0yWY7tpV_25MA7FzpKqwMjx82_C_cCg-
+VWMY-qH4QstiypVhRSI-VwJr9uqxzlqhsXzPv1rHblCpLahb2GxK_Qz1vOxYEVNrSEGTitvDF7b0Llqmgjhkg2O_Ytw99VulCH9iV8as_VJ7vEg7F2PMFtkC
+NbrbHIDqlRLEBm-xRpbJcSaqcGIT-ial8zQ1R_T9ftto6xZQEDMpnRBuKOhbPp-9KLH7TpOR7Cwjtw2-7hJDlnk_0_w79O8ap2nfD_cnSCxll7x98C_hTzu_
+MWQwFP8__Ep-hO_9rVyIxRlru_lrw_ly3m
+}
+
+AWSEntityColoring(IoTShadow)
+!define IoTShadow(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTShadow, IoTShadow)
+!define IoTShadow(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTShadow, IoTShadow)
+!define IoTShadowParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTShadow, IoTShadow)
+!define IoTShadowParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTShadow, IoTShadow)

--- a/awslib/InternetOfThings/IoTSimulator.puml
+++ b/awslib/InternetOfThings/IoTSimulator.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTSimulator [64x64/16z] {
+pPO7bgim34NLBEdjVyEVmSw9YVWCddvFfLorA01z4yp2_55PFV56DFc0ROad8OksHCziQhsAjgOdaCRK4GSGlA03yFb-pPK0dALU3Y3k-WvuEHc0tgu-gC0n
+zARlfvUBve3KAvqVwLah--NhJknnEL1fHDm0y6Nv_MgYuYE3_zyF90q_L5KsT933Ywi24a4x_MusOneyVBkOi1nzmuQz-0A4yfdD3im-OyVq3Hj-Fvkjwfe0
+qfw-0cQ7-UrOO2FbLGVGrspoMol-1bkM09ozrSddx8awsVr10v9dtxi--oIvwwOypXm3U5dSexyXGWr0wj6lUs207ltGdJw0hBu2LXPtyfze0wJu37XPt5FV
+lFgznDcFrukoetWZwE1NfUPtwjXuV5xdRm1NloD26zVzAs1r_XqHtRYUFoVow5Vgxt-wJnVFhmahyOudj21qjV_4XzVUDHedps4ER8I_H_F4-NkW9UxYJ2Um
+UTuWZEblq-8CkwipJia5F-ELDT-8I9jDI-UhVc33FkmxTlI3FWCXEWqYrtm1xFWS-41-c_BZP_lVX8_FltioFb-OF-Pt982G3_k27LdqmmO9k0Envizuh_t3
+VX35ijzuu40cu1-T7oSsaZ_g4xU8nhJekpunqur0_jJpZm9dEDr6pg1luHy
+}
+
+AWSEntityColoring(IoTSimulator)
+!define IoTSimulator(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTSimulator, IoTSimulator)
+!define IoTSimulator(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTSimulator, IoTSimulator)
+!define IoTSimulatorParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTSimulator, IoTSimulator)
+!define IoTSimulatorParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTSimulator, IoTSimulator)

--- a/awslib/InternetOfThings/IoTSiteWise.puml
+++ b/awslib/InternetOfThings/IoTSiteWise.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTSiteWise [64x64/16z] {
+xPG5ikj030HdnAlxt_U30ezXdSAKEs1iaM4zAISd9vLPn-rK0A0Vr1sWcW1IntJ6wbuba2Ej0zbhKEotq0RlUoYkRGGlNIjosoTVQd74GxuX7gfVa0VcPtrT
+JSYsdWIYPxK4h4qz00NilnO4mUnDFJe8Y12mPNi175Dx6G5gpXxyAa2PQDnFxaLMpve34IfMt-f9_EUbMFAbfU7xIGgiabFyMtygO9P1lwiUCYVwPxvDMF97
+Fmxx0VXAGkjZ_wMGMWR4byCJtB7tlXCt93_t2NYPI1HlMHpmMsNC4B5oW5_cdygTj_mowMRL0CQyah_CFxSwzByz_RT3gXGs6sK0_zknlgHNtEr9Nzq5UPdW
+Y_rrXB5dNL6z2jBt3cDjF4L1Q9LEtzlCD0dCd-IHzp-qNCHBCIFSPERjS-FGQktJ4-7bUXoBCFPnQkodvEJav2y
+}
+
+AWSEntityColoring(IoTSiteWise)
+!define IoTSiteWise(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTSiteWise, IoTSiteWise)
+!define IoTSiteWise(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTSiteWise, IoTSiteWise)
+!define IoTSiteWiseParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTSiteWise, IoTSiteWise)
+!define IoTSiteWiseParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTSiteWise, IoTSiteWise)

--- a/awslib/InternetOfThings/IoTThermostat.puml
+++ b/awslib/InternetOfThings/IoTThermostat.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTThermostat [64x64/16z] {
+xPU7VkuW2CKBYiBxl_1LpZSakRHspzFXByH_1alpyCNKjC-Xgj8OM9N7GAfrMhks9tbJvysSDtFUp7crdypJrE3d80CSGp4hOs0pcTR1qzJ_wAAsBIrdt9wb
+SkJLhCcccfaUS3AJXss96Ptuki_NBPwBj24f_0AUPOc72Z-FvtO1XypLEEERA_0LSF59LF0eyJoeUM3G_JpDctTTOjJn2BJm48fwwivJzmIhzoJXmHOrwtJd
+7UgdzmVUoItjVdk-s9_stvo69ActssaBPnxZAoOTXDaTar8Uez9Y5bcF55pawvHS-BQM5jTcnh58suKNnuxnev0fWmQ_1fAEyTE5bn1eqSXJLJDPU7Nh58DN
+qmupWBBoeiw0PySE_kDv-TBkcShWbwnnG-R_4XjJQNtbgHNCI7c1FVSV-bJaUQeuts9VgrqZZoN0-U9OY1_u84vvwBNyQv__jVxRZn-Kn2_apwFlBuVyEUVl
+SRe4WyRyFTLFU07gDjGfF7widtFzzb2jgh3azPlt3nue4LoOzu-yVy7N-9_thxn_ijyDBIphdtd_XcVxqaws-lUwJZ0Q3WTxvFFr2nr3jM5cidxbwsS9QTkp
+zJDVlrKsrk_NxHzUltzv_VxfzVktr-yVaMjIDpLmVUt--RNxzzT_F_nzVxt--_NpzGy
+}
+
+AWSEntityColoring(IoTThermostat)
+!define IoTThermostat(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTThermostat, IoTThermostat)
+!define IoTThermostat(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTThermostat, IoTThermostat)
+!define IoTThermostatParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTThermostat, IoTThermostat)
+!define IoTThermostatParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTThermostat, IoTThermostat)

--- a/awslib/InternetOfThings/IoTThingsGraph.puml
+++ b/awslib/InternetOfThings/IoTThingsGraph.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTThingsGraph [64x64/16z] {
+xTG5iWDN30NH5Zn9L_jVSARy7OufJCSCFQWQ_Rlyxt_J5-tzpKYhZpYNF67SMDJe4qO61kQH6Mv0p4UzcgoHzY9r6kH7VM6PkjjL6TRxoVelVTmzPi8zCg7s
+tNwA3DgurE5YghSNO5nEqcPpgEACcRQWzOxqImU9RU5EoKpQmaPFzUNhPHI0gu1xhqr2J-pX4kkt9abyYvFKcjtth9_rYGU-JlXz_qzGXpZS-YrYd_OZN8QQ
+xuz_SJ6fukXaF-rxk9XkJKzTfBgC1kW3vrNlc1hpqFTM4jpaFkzz7HLdzKDXZX-FUBR-m0oNOSQFLrE0kU41ZwUWx78sxT8_wXioC8Tmg0TzH-jkCdpqdItS
+RBQ8mFhX_jT-Fqe_seN4yTt1i7ayVwNl5sKcRNlg4d2CcYGUp-3zg5TBwoZ9EO1BIi2vM3hCWxu9wK1qOcekLiP84m77RpMkH-wJS-kaAO_f-z_NSIpnUZB2
+GJUcZgET6QqKj6uC38XTFR95RXAhdG2y96E-WcEkWjGJOuoSsWOBXxD5z4YNqKwqdjaaDsWPHrBRxItOFGjgzSna5wOYL_VhnPnqplsZwOKqoFt-e9bs9xaj
+RepMSutbw4VzE5ZfugHUzjwZFPpLPV0zU8squuHU6GDCW_NkoZdhp4hRHkYrgUFa7iWwHcWmQISXzPQLCNkCIsgLf1Aiz2vdTbMdPkUCd0EfjnMndQrT7ODC
+ecVrDgSFOBK9QM2p-e1Zs0byWrvLj3uJnEmwuwPVfU_3ZklN6yEEVeCP_Stzxt_V
+}
+
+AWSEntityColoring(IoTThingsGraph)
+!define IoTThingsGraph(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTThingsGraph, IoTThingsGraph)
+!define IoTThingsGraph(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTThingsGraph, IoTThingsGraph)
+!define IoTThingsGraphParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTThingsGraph, IoTThingsGraph)
+!define IoTThingsGraphParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTThingsGraph, IoTThingsGraph)

--- a/awslib/InternetOfThings/IoTTopic.puml
+++ b/awslib/InternetOfThings/IoTTopic.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTTopic [64x64/16z] {
+xTS5ajjG48JX7fw-_uKJQMVPeZ3ehtBX-ypGniz87dQQ5nzM9xbm8xdWEzxLLpqTUCrvpHV9m4j1igvuroOJKvAjVibZhk25uvoNq2SFxNd5QkLFNcF_EhoP
+uo5DbiZ21UEJxJiyIHR6Ow6rN0GONoHpZxTZ_5p1yF7mthu2dRFZbt9EZvz7fO-zauRt7kvuxs6aR_fMZF_KUEqzJuO0Pe9FYHaWGUvxCaS_k8OazxqtbofS
+vHrLZ-9I-vu7h3XrrzJDgGpOzlCAUJOVrEdpwkxvr_kRwoslzo9V7y-Ht-cVzBU__UrlV_lRtzwElMrwdVstcsxlJyJil-raFGBiN467OYED7hwLzImj5RnB
+T5PP6_PwtNzTbHbVowpgr_sttz7-EvbQP7Ntwhehm_HR_qZZf_O5
+}
+
+AWSEntityColoring(IoTTopic)
+!define IoTTopic(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTTopic, IoTTopic)
+!define IoTTopic(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTTopic, IoTTopic)
+!define IoTTopicParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTTopic, IoTTopic)
+!define IoTTopicParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTTopic, IoTTopic)

--- a/awslib/InternetOfThings/IoTTravel.puml
+++ b/awslib/InternetOfThings/IoTTravel.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTTravel [64x64/16z] {
+xPU7rg0g38G5qkRzN_Xgpg0db_LVtTxc51iVXXJAzel9me-BHBJzqYFwVcaHiktoiC_oYEI1v87aWUG3VpBV3XdYk2ZGzyi0ndxfWBPT0Sj6dwA7ux5yh3XU
+QUd00TE7Ci2tgWROYoG3siBhSrw_b6_j5T_DzMee7WXzmNViYlaGIEd_UKkjVE81Z3E-OHg8v95GkXmK-MPkqecB03BnOoX6dih8nw79DmUGlphm7i3PLpQU
+V49UnqyyCANijlFADBdn7t5lRQW7A9EM-4oSyH5lQMUgYmLEsOoxVnW_gTLr64ASVu-sy798QM6tz9xmC_lG4-yRUKriZT_iGTjQeHElyOkJfvf6sjpB03sD
+htoSqrOdpyQoz921sIw-9tQV_yEhAntHNjKl7T4ByfWlyM81Z6seh7m_DB3oSlwUcMl83fCVYTNuLGrEizcgXab1tVCiEHhEr8uHyCBVsjyYyHo4SpJHcAR5
+_kA_OLHS1N5E0QeS_wt_1ouP3TMyfGEYR_Tyukvno2S-DaUsTkA5B_dRQ-dDWgDlb7Z9tnAOZfHBl_0hTpiWI_tK-7LrVh0TY0EZwvLpN-Mnp1zR6nRiBMET
+2iISUzVvOyt_hWbSl02IL7jIFtGGUIPJC1EVyFGLUGA3RHxnoPBdPpywzOKlwrVTOJYRyrdOfgnVT_Kdm21_BULh_6xNxmP4sINvXPVr-sx-SjHTsY3-TFxJ
+WcUQROzvHl2hzb-zRm_vhzy_Slyg3sM0V-t--IltxrztVlXt_lgAy-klfVy
+}
+
+AWSEntityColoring(IoTTravel)
+!define IoTTravel(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTTravel, IoTTravel)
+!define IoTTravel(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTTravel, IoTTravel)
+!define IoTTravelParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTTravel, IoTTravel)
+!define IoTTravelParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTTravel, IoTTravel)

--- a/awslib/InternetOfThings/IoTUtility.puml
+++ b/awslib/InternetOfThings/IoTUtility.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTUtility [64x64/16z] {
+xPTNmjmW30ON0K9p_ml7i8rOBk1DppylhhD57_NsXw5MwY6PXUKWPh8SWbcgTulfgOyr7veFpOVc6_-o7ogArKC6MGuHud8Go671q53PicDXc1AzpXJk0mfe
+7aIXhFG0Ej7883W_Z_lvp0-EALzPOpBZ6uwqwsjZvPVKaxslZNf1m_izthzpxzILsTzlbJ9Ll_dyCiX4Vexatli9_ZEXwalw3eMSxiJG-y_xg_m21wXivsU3
+FgIrRwzQozFFOHE9fVk0Lowh-hLnSey4YAkVztU9K2PyZu9uNohnwQjiSTS4qjEFKXdEJvjdgC-lzuqzufxV__vRY9jaxqUf38w_udrV_sDVqy9r_udp-_Qx
+GrTNIwxzzlrdd_1We__W_6rIYQx_hiQF8mJCZHyJywS2UMxyyn64otu1XNpLbnfzWU1yDt_jT_q8oSrVO_bP7Nh2Pl_JngolZU7_hw2nG9gfd-y1TZt_0fI9
+_1qYrN7-vVMZRrzf48NoyVhvy_Nxv_k7h_tN_Fxr3-CR
+}
+
+AWSEntityColoring(IoTUtility)
+!define IoTUtility(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTUtility, IoTUtility)
+!define IoTUtility(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTUtility, IoTUtility)
+!define IoTUtilityParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTUtility, IoTUtility)
+!define IoTUtilityParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTUtility, IoTUtility)

--- a/awslib/InternetOfThings/IoTWindfarm.puml
+++ b/awslib/InternetOfThings/IoTWindfarm.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IoTWindfarm [64x64/16z] {
+xPS7ZWGX30INQFV_FtmqdEH9BA2B6qfXOfbimUsVaLLuYQgkNBogBnUd6lbMD0zzQFM1wWFL1wglU6RVaUBpaefOBW48vUA1v0h5T-JA3e9f99nrB74A841E
+asH03heh-i8a0zp9J_UT6Eq-hVkiu1TyAl4BlbDef_wvGdzSl3qrYm_u94qNJx_H5ZMXFoxU7fN8LFkj-FN-i-A_u5lngxuLt_SZIVJ7nPkVgZOUFok-Dtvw
+r_SfmuhV--sz8xxZfylGDRkHKVy55W8cqSd-Jtc7GZrpSPhr1GV4qdR7zoHy-bbq2w3kvd7X1qz6unS1bSlsDuRZdq7KtV6j_bT4QQtertyy_xC5M5y_8NWB
+iEwtmSk0k8vlyxVlMmtEyrT11hu5EAqVZ7qBiFTX-MFWMu1T_fZilts0zVwtlP7_Yd_BrB_WavClIbPz9J8_VltrbokhVhE-slu7yBrt0_-B-qVRlyP9YYvV
+tJz_SV_-jVF3-_prXVFh_-83
+}
+
+AWSEntityColoring(IoTWindfarm)
+!define IoTWindfarm(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTWindfarm, IoTWindfarm)
+!define IoTWindfarm(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTWindfarm, IoTWindfarm)
+!define IoTWindfarmParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTWindfarm, IoTWindfarm)
+!define IoTWindfarmParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTWindfarm, IoTWindfarm)

--- a/awslib/InternetOfThings/all.puml
+++ b/awslib/InternetOfThings/all.puml
@@ -1,0 +1,837 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $FreeRTOS [64x64/16z] {
+xPQ73kiW34NljR6n_VyV_1IrA4WDfM-ldEvn1DUiv9_2pSrDR7ch2xR8Ev_G3U3QhgJKJ8wd4s7MjTrL5P8R1AhQymA_I6SYTb4XNzKUylBdbw-MOr17_lcp
+Go84NhFFutzNX9bXzhkWLtL8dtsOMNoINm5ObG5ed-GFTp_z4D00LS08YTDtzzZd5sYM4w1NAcIVFoCwnlyQz7W9CXvPsl3H8tAJls9CKuvNH6toTssZdove
+DVlL83voDUtly-lP1ddsJPVv1m_V8Ds0EFq0h0liuIzmaZXyGLGraEo7tqcYLSNpHvB-cGyxVCF2t_M_3xzVz7zVlphzMjHlENuAhJpzh0QTnsytVvA8kVq0
+Svu_k_bR1ixj4rRp_DsldmOnM95bCA8jrizo_MO3q99ylbcjt_N-uSGJ-dh_MEzVvI1nFBpM-zTw_vpgjzW_D_ktZ_hvOl_Ud1zTF5NJfI_FZ-y_lzRdPnwF
+yR8zFpy_lt_czKF6blnJkBcv-G8
+}
+
+AWSEntityColoring(FreeRTOS)
+!define FreeRTOS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, FreeRTOS, FreeRTOS)
+!define FreeRTOS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, FreeRTOS, FreeRTOS)
+!define FreeRTOSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, FreeRTOS, FreeRTOS)
+!define FreeRTOSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, FreeRTOS, FreeRTOS)
+
+sprite $InternetofThings [64x64/16z] {
+xTU54YGX30JGxWWJyl__UqQbzYXRmhdqkhmL89aPu7zu6PJ7LOfH06a74AAyv6mcvUKLCjiHw6_l__k8R_5301dNtg1ZAEpIF_3y5CTpvLEvxb3pnZliYqk3
+jtq-17Hv1VXapmz8E28_yO27O7Hy3jWdI8avGnWv3IFF_RFcB0WHCDPSFkUUzNYGezxFKv-Eo9f3hNi1poF_AE2rx5Mh41pGvy0RQ0h6xeDG8-oj7_2P6UJk
+oSYSZl7EY-RwjoDVFiSQaLHvuyjDeQelxwgKMXTnxiar_kJcZt-_bRVjzv-EtzT-6x-p-TjzpLzZ_Mo-razZ_Mw-rc-ZVdO_XQtwtNspVjDXkpTudlYAG-Bb
+G-3z_ad6PnzagtzMd03NsQ-s7qOtqfoMbpvJDVFMr_ZTUfVbnPk-4dNpj-y__VVPvLd-kno_NENbLQqTrVAWN8Mey2hu7V8H
+}
+
+AWSEntityColoring(InternetofThings)
+!define InternetofThings(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, InternetofThings, InternetofThings)
+!define InternetofThings(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, InternetofThings, InternetofThings)
+!define InternetofThingsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, InternetofThings, InternetofThings)
+!define InternetofThingsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, InternetofThings, InternetofThings)
+
+sprite $IoT1Click [64x64/16z] {
+xTO5WY9130NG7y_F_U-xWepGGgthcy49IPVpz_7VVrNDhnS2m9gxobI3Pnmm5oZt13vJ7Yj8pz0Gmuq6agrm7fcu1lPUal7BXmqvZdSKFnFXbbq_LFHo_ks7
+SvQV3QdJw-zI18y5O2O7AHAV6S-a092t-OStan2rv1DTR44E6IOGZUQDeeOhfe0k0KG5GDpBDowQW01U93i0kwVdCiEzs6c5pqp2k4wHmviMP9WifjzUwoGk
+WiiS-RuQxrmlWFCmoBikLTXmJGcQ6uBenUeXtBB5Dd18DdTqhFn0GNgE1kP28zh9C9-43yy9UAoXV4Bas-8L_Itn4_0vNo7FjI0ukz5CeFbC0Hgv8mn8FjUA
+8pbSeB1u0SHD6fnFp2MzSUuQDdUKPmLav2NyeCNhlFrAjbk4eTulh0e9xXDu6kHiE2eWW1-jUZFpBc4vT1vsIBQWzWTNpkt-nXxNpKJSlx9LKCxRVIAW6O9y
+6-_7yLIelsrzGSyKx64JFnp5RUzFNv3Db4jy5ckdFqND1EpX46V5DGcu0SMl5G0a-VMwYh-n__xx2
+}
+
+AWSEntityColoring(IoT1Click)
+!define IoT1Click(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoT1Click, IoT1Click)
+!define IoT1Click(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoT1Click, IoT1Click)
+!define IoT1ClickParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoT1Click, IoT1Click)
+!define IoT1ClickParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoT1Click, IoT1Click)
+
+sprite $IoTAction [64x64/16z] {
+n9G7TiD024IpTDt_mY4oRhnbqXFSZUPJnkkNNusLyJKbYNh4aH7XAlGviSRH8lJ32F6Ik6c6US5SFgIEIpb-67pnfQ5ubq1UlGupEPv2J_MmydKI5BXbcRVr
+rGjMueFnVFnspHv0cV9CuLYU01ggsqSCike0ovVpfm3UgYSE0RmRrx-ItFJejNSRwMof0s82h6XmttIhnTm5FxShDJm4z1N8qx8MNdIFbQd7yZekUeqdHHwc
+N-EYVMZWdg6XF0PeML3lXbY-MMsh6W-h-FYnA5c1C43H009-wIT_070vOBLz291DOpMOe_6hqXOGXp-yOC1knYeSsSQN07Rg5rW__ZlGN5pJGq3yanxt_rfw
+VGW00C003FEt3aHciDzM_RP_Epyxlxi_kxzvF_P-xVtC-xt_8__N_i_ytyiFoI_9JyjloO_9hydFoU_d3-ylxq_lR--Fxw_lpny
+}
+
+AWSEntityColoring(IoTAction)
+!define IoTAction(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTAction, IoTAction)
+!define IoTAction(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTAction, IoTAction)
+!define IoTActionParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTAction, IoTAction)
+!define IoTActionParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTAction, IoTAction)
+
+sprite $IoTActuator [64x64/16z] {
+jPQ9Zkim24ND3l__mq-kquULu6pgtDapEa3DXRhzaG0HuItBwj7bWYzmyKWPFQInqsx2n68zWZx2gTCCts3QIu07sJDXbkEt0u17oEwHHTXTNXDFMJwyhjxg
+eg2ngj9rUgpFr3P3d4Q0rIkr0VTlPm4uWfPDPMWW4G6dvSDg6aPWFhMJNJVACiKhdYFmnFbsfyDSLj2jVit36EjZ1AhQYsgcs6RnnmcE1QxxXn9TXu7W7W4F
+PN4hSBCCa9BzJ6g1moWJk_kB07fbN8gW_5dwe3Pkve0jk5J1kJ1kPHMCuAgFEbVZwsLWfUKyxCgusfqYFcTQ89hvTvilSl_M-VEe2lNaBWiVQtcQgRftDU7X
+i1WtlBC7E4AVyEc_ZATmmTV-pntl37TueDuNAfjbfaEyvqatbVFVnHuftVCQamJAdfAQR-fD5nsyVlxmhvIJhfKzwVtFtV3y8h9zuaCqUzBbh-zXdlZB08c_
+4fWb_aPm1oT_9ShryqewyVfOCVFU7ikFFB3mpcggRHOErJpvuTrsgd8-AAvudFuvNmfehdb8AzuY6CZ3r_xrC6RscXyFPDfOFI97sExCx8pdv2L2yqgTl2_h
+fpxqFhruGlpyoFeHSS7JTiNb-R26_CxvDOxiNyrR3Cd2FwA2qphzB_W-uey8zhornxAPTwQ7OW_zrVpAEpud1L-f_KB_
+}
+
+AWSEntityColoring(IoTActuator)
+!define IoTActuator(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTActuator, IoTActuator)
+!define IoTActuator(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTActuator, IoTActuator)
+!define IoTActuatorParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTActuator, IoTActuator)
+!define IoTActuatorParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTActuator, IoTActuator)
+
+sprite $IoTAlexaEnabledDevice [64x64/16z] {
+vPU7hkmW34Gn67lc_t_uCMHx2rcjshj79VLWqqNvDMOVBti4KvTEwDz6LdcawoqOUtuIcyy_vvj8eevBa6rSdFHnQMGVbmgcYLUsWykWFUiyn5C18Bilqaay
+w3RqiaoGzkJxkj__9pzI7FLJn1PP7FKtv2V4KHyYBs_gt-s_BkAe7xBy5_s7xtrSbgrsrAyc_eV-QyAF-jx4mVwpmLF_BVhc2GwGRhT-gM8l_ngy8RrkhBRV
+38ZexdrcWSlFAxwbOhPBW-inRDatR3jUzSWC7s83cKMiZDyaqqhDI-thp2YAs6__JkQv1GQwzbceB_cLX9KW6LM_jtaxAsL5kEZlV9bDqI5xqg0C6XaBxMTa
+ddAuK45MrS3sVLVurFytpDXDogwVXCB7KvUOaR6_Vu1PNE7lQ5jMK6HCtlYcfWhY_MlZvBtl2lISLfnNaH3vlJ-ndVnjfrfshFtgbbQkzP-HyRm1BFNVPVoq
+XwmmlznLwFFuhVU5Ui5Tgu2C_WgSvyzDi1d-FcBZ6_n-_WfLn-Rh6nhuakhNzQEUPtGOI7zpVj0bjXtMvPpMhnYNqsAQDSbOFR_8G9jnjsC6EbJMgb-K3RC5
+wSa1gEZh_lFf15xMVM616xjRUKSWTN5W-e1yOHwGcz7i-xErr9_o3m
+}
+
+AWSEntityColoring(IoTAlexaEnabledDevice)
+!define IoTAlexaEnabledDevice(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTAlexaEnabledDevice, IoTAlexaEnabledDevice)
+!define IoTAlexaEnabledDevice(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTAlexaEnabledDevice, IoTAlexaEnabledDevice)
+!define IoTAlexaEnabledDeviceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTAlexaEnabledDevice, IoTAlexaEnabledDevice)
+!define IoTAlexaEnabledDeviceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTAlexaEnabledDevice, IoTAlexaEnabledDevice)
+
+sprite $IoTAlexaSkill [64x64/16z] {
+hPU9MWKX28KJ6PRtV-2xU6WilwnXYDOh_hWVyUE_hALiWKdCKsP2Nt3n6oOdhkwk1oVi6CXiNUaZQQIVFQ0NtcxCjxeJciVVh55qm32GlAdRkn_knpt-S6-3
+vtiy_y4twlooJkq6trZDmqovvNWINqpeEjyERF5trz-3mE4usaM-lwjh_rQaxu3z4i-JNYFm1PvzRWZgBwEvtCv_yC0xMlpK19Cec06sV0UE_axJFfs_ySsY
+XWoAEr7d4KaYWBNVU8cnwxbUvtfgp85iUKX1u4RVzfDD3-rvGUy5YhAgXM04ik77lxgESfqPVK4xdgFAZu94Pt3UyUg66iT6BZhaQiCtZ4sYXzCsxfKd_6Uk
+Mxq3HJ_pVNIGTde44hLMVlKljiRVyctKegtWTzIlykN-r-SlltvOUKJ9xvypiBYrM_kNK8uesVE3Vc7ud3-_qwa3Iki7VA4VUVqQe2vZs-jdWtukyaFGpwlw
+lPPpp4pY_k0lk8Jp-lrbRbEzvThzXMlocFizGWeSdBc_upoDkOpnPFA7mOz4nZZoXrp-ycBCnt-R_AMKFzNpjth-MCzVg_bpCN-llX-gxvVY-wduVYk-7yll
+r_hxkMvF
+}
+
+AWSEntityColoring(IoTAlexaSkill)
+!define IoTAlexaSkill(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTAlexaSkill, IoTAlexaSkill)
+!define IoTAlexaSkill(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTAlexaSkill, IoTAlexaSkill)
+!define IoTAlexaSkillParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTAlexaSkill, IoTAlexaSkill)
+!define IoTAlexaSkillParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTAlexaSkill, IoTAlexaSkill)
+
+sprite $IoTAlexaVoiceService [64x64/16z] {
+h9Q9sfmm24KBXEMy_mDtSVZoBpQZiRspJpnoao3uutz9jlGDrYYsLA6VyE21Ok89f8yD-O7CwAJkBfScxK0XvS5w9sY7x-XxqZPGFP5j9VN71_Wpta4EVZpZ
+nmKlDlx8P8y_PsI5RV8Z-QeQ6xmLGBgfYAXv0fJTvHqeryyhuGN4BLuISFc-bWwaNFDIK1rRrCoq8KqekU8bwJ0orp3RJK391HyGxVUpN7emt_EZZz02AeQg
+cjTS_GH_nqixj2PQbi3enT4tVC1et4zRQg-HMFC2sL76UQ-Fo0cwvFqL9C_uN1c5MF95JOydzToIaWMluA_mSgBdv0ROWX-Wn-zOb9iUzWKVr0nmqhHNv8BF
+OoJ-Rd-IIItu8kRuMVFy5_ood3Vf8F_AF_LVA__xwxU_VpBtxrd-65XdmNx-ziJQtjNra-lyJ-hHzTk32h5NFrfAXqSVrAy3jAuDk_MptKVNpzlrExySMjBr
+-tx_AFbQFGFoVl-A3jRLk_lNHlyiSZPaw_wvqx_puCVhXDs_T-uVafG_D6d7HspUlnIj-bLw7Gi000002FEt3g1pKRJ_Y_-J_vl_e_-h_ZF-k_f1_O9-Gh-X
+7zclxcSl
+}
+
+AWSEntityColoring(IoTAlexaVoiceService)
+!define IoTAlexaVoiceService(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTAlexaVoiceService, IoTAlexaVoiceService)
+!define IoTAlexaVoiceService(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTAlexaVoiceService, IoTAlexaVoiceService)
+!define IoTAlexaVoiceServiceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTAlexaVoiceService, IoTAlexaVoiceService)
+!define IoTAlexaVoiceServiceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTAlexaVoiceService, IoTAlexaVoiceService)
+
+sprite $IoTAnalytics [64x64/16z] {
+xPI7ZlH828G_Ea7n_kzxORmMQjswPxGAb_vIci17WS7e7wjV-YNtqC-r36ZnOnpwQ5WbYD3d2iCpDUXtCmriV8hdOgGa6LyuM8Fs6IqDrejlN5KRIuhEoFTu
+p0RS_Yv9N-K4zfRs3bWtbb83wAwSMpad3R0PoWMj6pODnkqlE_kd6xQKad80z4WjmvPPPEQa7_45GtaFyDg_gmk3CJiMRtPctgac8rLVC0EQdt27TJC1PQK6
+jdovZZBcZUTWPE7qYIdF-BshPL_uA-4P3onKzZDLU6tIiteXbQlmNFGysskpt_6hW8TNkEPLkGgl2A3xO_drJzaNhZ2i6pmaCDjQARmCXbBpuGJ45Zcpy3rf
+LfsRd95xv8sNGLvFONs_-ZDt-nrFfvN_YNVi6_SEpCnqJ6U-i_B6YyOcz3bWwRd_iYyyOu1DfHjWwsdzMjaNNlIhzLczFypVQULUz1sIqdd_6YjlVAVbz0Us
+BhpJRlUC2Soeay9AFSk8LCClF3KDHkGMSC1pq4UZHQDlzFQ27XIyP7Hjz7RH3fhOYcKqhHVzS9xE_MSO1lqlLeEce_ph_Hf5xyN5U_vnIWDplJ_V-UsKCjeH
+hmvTtgW7NolSGk_L0MW6tKFAJ2dyMk6Fj7fhwne-hOynUWEiwlbCgJMCIzQNKZzGk2_tq3zNl_HBlmC
+}
+
+AWSEntityColoring(IoTAnalytics)
+!define IoTAnalytics(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTAnalytics, IoTAnalytics)
+!define IoTAnalytics(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTAnalytics, IoTAnalytics)
+!define IoTAnalyticsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTAnalytics, IoTAnalytics)
+!define IoTAnalyticsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTAnalytics, IoTAnalytics)
+
+sprite $IoTAnalyticsChannel [64x64/16z] {
+xPU7qjmm28IDGC3t_Y-Sk2M_oqqiCpSrUxsmta7KwGjetRstr-QT1RrWdWdOE_6GEasQ82ylt-PNVIaWoFLDubNxglwA_m2fdHywP2VQhQq4EtGuwgBjyIi6
+-Jo8dHKfVna721HIfJd4KT93We2soMXZ1CTWQM3JE85miH_pGMvHQv0cumHz5Q3CoDv62IGXFO18WD11WfOii4aiLX5o8b2FpEZtNBDPfhULp9dX-eD0amtn
+m1zY2NzywRjbHFAqCkecekq4NLPjZqkhzDMN9WSVwkUWKWy_SElgIqWv94lSNY-0yscrVgqb3deV0omFEVaIuXBkzp4ea_JBZmBzMgGlI6Bx4LCpwpFSFU8Y
+ru_snzHJhj2BL7bcdpCk1-x_qA_jDsJ6lRkI6F3V52Uv2ZPoVdcYJ931-C4EuTC_nw_UnAydTDa80s8mVwO0icjhwa3ASFx-XCju_SXcmOBGL_Lh_ekQgRoh
+dyNwNUmVnVvLx9_5_bsS7uhpIt5-AirljEByM9nV_-yVDVrL_nNtn-h-Mj-VluzV
+}
+
+AWSEntityColoring(IoTAnalyticsChannel)
+!define IoTAnalyticsChannel(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTAnalyticsChannel, IoTAnalyticsChannel)
+!define IoTAnalyticsChannel(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTAnalyticsChannel, IoTAnalyticsChannel)
+!define IoTAnalyticsChannelParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTAnalyticsChannel, IoTAnalyticsChannel)
+!define IoTAnalyticsChannelParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTAnalyticsChannel, IoTAnalyticsChannel)
+
+sprite $IoTAnalyticsDataSet [64x64/16z] {
+xTI35KD1443HCVflE2VMOcBU62_u2xWFzHg5DiiQx_S-D-e3vk8TUh4bkRhtNFAhUuk8J6lrsBP-PTilHRltR6AGJB--bsKVXLwqYO1KfT0F_VlAyKT0NKBG
+Or8RVmBA9OGy5fK-0e4YStaRSPHxeOVjN5_Uuh7_-C_xentZo8NxXmBb2R-ivxnY_h1i4A2SuF_uFxnNwzFo-BT5eRVei__uFRn7QW00Mhfo_0E0wlj7mxAl
+xXyjs-V_u__GFdLkr9VSt5kdnwfsNpViaHblwJcJNzo7LsIlhshtv6KAzx4
+}
+
+AWSEntityColoring(IoTAnalyticsDataSet)
+!define IoTAnalyticsDataSet(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTAnalyticsDataSet, IoTAnalyticsDataSet)
+!define IoTAnalyticsDataSet(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTAnalyticsDataSet, IoTAnalyticsDataSet)
+!define IoTAnalyticsDataSetParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTAnalyticsDataSet, IoTAnalyticsDataSet)
+!define IoTAnalyticsDataSetParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTAnalyticsDataSet, IoTAnalyticsDataSet)
+
+sprite $IoTAnalyticsDataStore [64x64/16z] {
+xPS5iiCm30NpnBh_XVyuPR3SdpBiO663tXbhUab0B6g-nbIOSAbBOf5d21CQoj3O2U4piVULejGr6-4gXBr_0YJgaGtjsuWcQ-zMGJh_0Jq_Cfsd4lRCcCuZ
+cJODiKpftZp6FZArwnk6kbL-Xg2q9RBm6s6CZipMxChNM1z3UMy10CIwTaChVuButlgBS8_OMtykc2eVgylqCm64hsuCjR_VdzbSd-trD_GBtiCNTuOtQ97V
+-a0sU96ly_aZmkdzdf-D_K6_NDjyttxNV_3TWj_buEl3txrVCSypkCb_-_MPB-lNZ66DQ_jTvci48nfFw_VNhma3UoPOx99-0V5g_-S2bFvu_pdqV_qIh84h
+--MlwFVw_VlryyFryylryzFryzlrysCzlxuaVm
+}
+
+AWSEntityColoring(IoTAnalyticsDataStore)
+!define IoTAnalyticsDataStore(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTAnalyticsDataStore, IoTAnalyticsDataStore)
+!define IoTAnalyticsDataStore(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTAnalyticsDataStore, IoTAnalyticsDataStore)
+!define IoTAnalyticsDataStoreParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTAnalyticsDataStore, IoTAnalyticsDataStore)
+!define IoTAnalyticsDataStoreParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTAnalyticsDataStore, IoTAnalyticsDataStore)
+
+sprite $IoTAnalyticsNotebook [64x64/16z] {
+xPS55iGm20KBVD9o_mElAxNmwZ8hrUX4Y_L08GeFAWjGmOTN2w4DuHMQ1RGvF6LNrGJXCI0ytL0pkHrwL3Q7XttW-tMoDhWnl0uCpm1ACmL0zsj16pIW_bRi
+ZvcJcTmEyV3UNpTP_b2sGHd-ulvz_MbPjS2xy-VhVudmB2B93BV3vxgPZFeB-_V-XhSVuZPsvY-U_rd6JtLTrX5hFn9llqW_qEblpVEVdp-Mg7ySrT_fpw-V
+b_EtSFZX-wSGEdp_E7p_kZnN
+}
+
+AWSEntityColoring(IoTAnalyticsNotebook)
+!define IoTAnalyticsNotebook(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTAnalyticsNotebook, IoTAnalyticsNotebook)
+!define IoTAnalyticsNotebook(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTAnalyticsNotebook, IoTAnalyticsNotebook)
+!define IoTAnalyticsNotebookParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTAnalyticsNotebook, IoTAnalyticsNotebook)
+!define IoTAnalyticsNotebookParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTAnalyticsNotebook, IoTAnalyticsNotebook)
+
+sprite $IoTAnalyticsPipeline [64x64/16z] {
+xTR50GCn34JHCMlwBpZCP0wjtbb_6OnVffIoxiGsJ4TU2CW8l10165v11g-ONH_TGQGWGowd3xt7GIZf0mxyWvu-Wva-PtPlCoxxtkkNxrsIdUGGaYHVstiU
+U2IIiNx_UxlzfwBzP_nnhxtsj1dV_ltp6KE_V_t_hzx_P-V_ktVzyCkKKci
+}
+
+AWSEntityColoring(IoTAnalyticsPipeline)
+!define IoTAnalyticsPipeline(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTAnalyticsPipeline, IoTAnalyticsPipeline)
+!define IoTAnalyticsPipeline(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTAnalyticsPipeline, IoTAnalyticsPipeline)
+!define IoTAnalyticsPipelineParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTAnalyticsPipeline, IoTAnalyticsPipeline)
+!define IoTAnalyticsPipelineParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTAnalyticsPipeline, IoTAnalyticsPipeline)
+
+sprite $IoTBank [64x64/16z] {
+xTS7hkCw38LXKOKyP_yRVY8D2FQZevioVUP7IVrSnDJoYwKml-Y0p8iAr7aXG2ypWtxfYV1aU38y6Hxyaxruq_l5c71UDBBDYqeEcKqltfrkngUpbZbVAct0
+I1rFfgILQp9vUJeb9Vdnl1-_YPTkrkKBhv7xX1bPb-mrAZD6uJC6yYR27yNauPszD3smjbAQWfusEVj0TdF-4Y2mv7lswvVtbezewosTRLeHstZ9E6z2_kUx
+DmwVfbWbJUxm8zXrVkwrNeZPUV-rgllh_73s7Xvvq3jvh8-jwlxqZAEcn6XhzyjCNuDTrkzyX94oqkAjizlE__ZaNTSCCA9uwrFuQU_Ih4ZR--gr6m-QUo_x
+5kmolxn_TjC7_cZh6sTeExyz_bADCskRuz-idzV0MNjl_JspHjedtiUuzUBL6p-w55D1sl_rzOl7yuC2k3__2DlvzVN0TdxT6yaxw4gCMkxy2FRC-ddFhx-C
+dH-oz_x8vJ4vN-TixBsHX9JR12GjUOEtF7ej3weTomUoDB_fTTFqQNuQBRzlUOtI-NV3DklX_x3VJv__VepVh_t99hTFVpz_-llzy_yF__v_VVx_zUVt7m
+}
+
+AWSEntityColoring(IoTBank)
+!define IoTBank(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTBank, IoTBank)
+!define IoTBank(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTBank, IoTBank)
+!define IoTBankParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTBank, IoTBank)
+!define IoTBankParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTBank, IoTBank)
+
+sprite $IoTBicycle [64x64/16z] {
+xPTNOYen302HR9Mv_uKV5elVOdhuIfa4jewBN3dyD4Jauh3SUqeGurMmuq51ZmS3cO_kyEUh-P64SO1qzu1OxxdfJRtpClrMxa2-15Mf5ODsU8bMiLbnyl0Y
+YVyaNsB0EpwboEPJlEKNSZT_iIFwDF-b_aiEzkNuoKKlrTQQl1V_94JsYTaZNmQnz-lYWH-b7Ex6tq2dxs1o9_vtV8NyJxtvmBT1Blu5gv-bt6-_1X1U1D3V
+xF-z_1aByatVoG2VjQKzydKGJ5yrYSEMW88deKUcJvHoi_t4iYww95WLNumYJPwsNqisOfoswYp1HhR5NyklbRKpY0uOUEdMUW9wKVurVbkP7TJ1EuE4BHO6
+AO_YRs3dXIf0EqK5Kqu9s2F_r0cbSjFnxGnqplb9xlob_-vMpNukXKKIGvm5aBN_2aNv9QgddajqpgsdopYS_1Ft_8qu-p4EzVBYh_D7lLlin7LYsSyVQ_mS
+T3U6-kvOAFYZ-6irS35F9IlHUNhVhs-o7JKnPhOTi76l9VYJzSk1ZClvtvWt_UdwPJc7ogITxzaBwvTqZ_2JFMdZNfTb_VhRVtosV_jy__Zv_dNTFmFk7kl-
+EUOZD_rq__xdV_3xyMVn3m
+}
+
+AWSEntityColoring(IoTBicycle)
+!define IoTBicycle(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTBicycle, IoTBicycle)
+!define IoTBicycle(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTBicycle, IoTBicycle)
+!define IoTBicycleParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTBicycle, IoTBicycle)
+!define IoTBicycleParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTBicycle, IoTBicycle)
+
+sprite $IoTButton [64x64/16z] {
+xTPLOeGn20JW0I8CzxzltKjIeRhxVwzn1Vu9XuEFUrpOLeYEUyxKnBsPjsz9zya43IDlF-86L-9MNxRdUvnz-rOUVpBZN7j_nRd5lMc2BR79jGQ8jRxKJ836
+1LV886E7Gw3EbC8ONF6k8ZQ21brCthWs00W0TLgwX0dXMWUwqwT2d8APtgf8t-njvvXnFyiOQA-h2fo9tYP9U-nSuKocwb0c382J8azkRmzzFTQ4CG408npw
+j68OvZlRAm3Vjj_Ftyq6i_cd-vTBzoy_lqn-ViNxKxo_nVTJVR-r_wF-VvN_p-h_NOqVfVRjYF_L_AcQlzNpnth--liEXqi
+}
+
+AWSEntityColoring(IoTButton)
+!define IoTButton(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTButton, IoTButton)
+!define IoTButton(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTButton, IoTButton)
+!define IoTButtonParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTButton, IoTButton)
+!define IoTButtonParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTButton, IoTButton)
+
+sprite $IoTCamera [64x64/16z] {
+xPU7Rkim301DIXpt_p_y8Y424RtODH2iZciJpzEWPewVXeYy7BPxNnB4U1NiSL3Gny50rgCp_dmrVv0m3f3k7X3xFJTzgtTkqz_b3kGjc9NQCMZ7BTgCpOwJ
+nqqI_qc-n83__HuBstnY84-VoVAxkvlC5YbyyoVoBl--qX8WOfAWP_dlzG_8-RvMFrFeD-EdINO7QmvQHhI9NliIK5H0wtR8_xuCWbplLT2qcrlN6biGmu-f
+77ly1Q8LFPRJLTiaG2h-kwylOyZdpKoezkllV1laydMq_xFEfYggzgnt-JcLhVsUlYKmSmzjdfdUD23AFud_I_uDGXmcBW7zfhzQFAVkDhyboLDV1_7YArXx
+rbe2ca4hFwPodCVVG8EKOo1309l-lVPpKi6h9JNn4x_Al_kzMbs3E2d_CZPVQfgrolzE_Al-rHXL_rj-WzvN09nvqKxywhzR-mUaDKi86TTx_xqQF_tPwoOX
+3dRSRRz9W4jF86teSPpuQ_xOV4d8heEMa59-pH_d_N_DPH7pa7hS7N-59KnorlsMtrzQfdb4U9TA4kHy_H8WBe6yMhywNz8lrw_cSOctRVtwstzyl7_xVF_u
+-Vwrzi-0kyU-VmvVZzpqq_txd__1xyUVnJy
+}
+
+AWSEntityColoring(IoTCamera)
+!define IoTCamera(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTCamera, IoTCamera)
+!define IoTCamera(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTCamera, IoTCamera)
+!define IoTCameraParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTCamera, IoTCamera)
+!define IoTCameraParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTCamera, IoTCamera)
+
+sprite $IoTCar [64x64/16z] {
+xPS73kGW301ZYktv_uTliL2AnUQokbv69NKK1BXa-ziGaSiXtVigXerNeRyE1Shhq47cexVyzqlN5mxZ0Awg1fRlQIzBlV6Ojlewu8y05YFeKBT7r9YRZEBR
+Gnpzcton0P_uX2BJ9_Z83-HRl_-3vw_KC_AfhtdNl_DbODclPChkMoZRxVmhr1CDDC__hUzOIYp8sky3Jtw5zYRi70_bTlqK90y8UJh_KcFuEK6rHxuqMsOf
+nvii_3AmwPUG0LrcI2yniw4iraz2nZMsMqOTaBlrCqBUtY0TzEJdyGjOcMKtCUyPo3x-F7-px3G7JxFN7Qp67DIR-H--BkRFc25KRtnHXLx1U_TBEUXn3v1o
+zjF-BG3c4MXb63kEI-nWq-7FHtd-Ypi3sqTyq8_0gJVhrnpm_Tq3dI_czSlvGqIXIooqxDYOEb5e8Zb_vFqlJk2IYZDWJ-AdE7EZ7zIuP_8m_bJR_lNzNg__
+wzVVr7zyU__sxVtZj_UlkNy6LDLo_spx8-tbM_lt__ut_3_-NNm1
+}
+
+AWSEntityColoring(IoTCar)
+!define IoTCar(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTCar, IoTCar)
+!define IoTCar(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTCar, IoTCar)
+!define IoTCarParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTCar, IoTCar)
+!define IoTCarParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTCar, IoTCar)
+
+sprite $IoTCart [64x64/16z] {
+xPU73kGW30LZcZt__yENe9Mr-vG8JjVBg6pB9F2mC7lyRPZPnujyjyJnwrBevqk1ShvqiFpfWVz-wUCau7g166Cuk7utUhdL6zkqkwS3iGLpKag7UcnHPpRA
+88vDWl6x-drK-rhV_8Bf1yGeIv-fsCldOlhc0B7s9wRFFx7cK3QVVvjVWVPD-GTU7oWxlgygNtsxyFI3P-8rmAaScdy-lzu3BldV-UrX0J9PzVj5f6ymRltn
+KeAOYZtKVqOX1BxE_ta21Vg6dnSg7SgjNoxU1nqo0VasyAde-icJReU_M3-vL8SllenVaXRoWXo_vYShdMXLhFU_2atR2zGTFxCUdsJwuclzvWIKbAH-DV-9
+UI0DpUVbo_LBxlT1zNN_o3avZC_UNjB7f_ASNma0bzxUj_Dt2A2zztQWRFe5nc6H-G5jjkrb_yhogR8FszHM_Ijh5I-Lh267KJhqHV_IygcoOhReNuav6L-k
+H-pKVngjsV56RTL-p_FBjv_Vllty-Etdrpm_0xDYvFpi-TFevLlFx__zR_Z_-7Vn1G
+}
+
+AWSEntityColoring(IoTCart)
+!define IoTCart(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTCart, IoTCart)
+!define IoTCart(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTCart, IoTCart)
+!define IoTCartParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTCart, IoTCart)
+!define IoTCartParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTCart, IoTCart)
+
+sprite $IoTCertificateManager [64x64/16z] {
+vPQ7TkOw28Gl8Cht_W-ycvXp_ogvf9osawumb04Z__UB4BKFg7o5goCB6fL3hx57ye8S5zW5KE6c7p2F_lka1qsWN9_El83KCy6tKFAcvIZWE0K7Oggu1E07
+zDWBCe0uYbww8qtjPp2QlkzWhO42Q_gnIO8TwMkGw-pZkB-nga2AaYNjs6mi79-rA-h_KSkgIb_fLDHSMRzDO2DaDIIwF9K4AYAArJ3eT8YIwX-KjLdIIids
+jznzrQI50j5Pf3oqAZV1SviyVpYNIL9Z-ruV37aOA4aWj02NMmTqCbVQ8cX2TWd2CwgYOxtFQViiKjdG0G8WExW1aDAvJkINptZk40xH2NY4Rpy-Y_CeADtC
+bloakXbJ9EIKFw3vGQdUEgJFw0KYCERw5M5iQ0Fd3J7Nhyy2nDjgGyte7Ui5NPDz6gYxtZV2U8BTj7f5bvoFfHap6HVgzb0gTsq7NUTyr2S2Zlv1kQcEN5q5
+0soz5kokMOtJ-wDLiVjD1-Mosi0-EvUxMch3bbk-OB6N5exFMac17j6LzPQtoVycCMmljvHTUkxN6FiE98-kk8JIlTix3_HPJbtFSvxf3saJSPDJ_Uq1pl4a
+WuoaBvOJw0r2kgbiBy6UqEl_9CIBHXMideOrFDoYkA72FFmyluX-YZp2-r4AwYh_Zd-MBn7o3VuegF5LlWGRGhx4jmB6wBc_pWyWjL_3YAlyAi3lJtJLDNu7
+RtGAL_d-UE3N-4dPsrB9ytmnUJlhen_7Nm
+}
+
+AWSEntityColoring(IoTCertificateManager)
+!define IoTCertificateManager(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTCertificateManager, IoTCertificateManager)
+!define IoTCertificateManager(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTCertificateManager, IoTCertificateManager)
+!define IoTCertificateManagerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTCertificateManager, IoTCertificateManager)
+!define IoTCertificateManagerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTCertificateManager, IoTCertificateManager)
+
+sprite $IoTCoffeePot [64x64/16z] {
+xPU7qkig30Oj4EZRzt_X6yBVBEABvsJQAPiUs54iqNByQPZPwILzjoM8qHNQuwL0URmqiDdqpx-cjFv0C5v0Z-U0oD_rLbxgpctyLNH0jm3AwZUenotgp4sY
+e-Ccej_pNRAtV2Y_wbiB2QJmZMynuEmNyKLOzec1VVWCphu9r0SXYEnFx3f-X_Rz7h-8VtNz1lWd3U9-_keOteKpkkbR4yJgO__dso3GoDhiNC7B5ntAsGyR
+73d_1dfcoqyHAzIB_AVwYNW-siale72xzDj0Q2PXkEV1Q0patxxQOAsVGodWQQKI26ZR_0_t4DBP3y8Sy9rlq8yEqCzjp2pOIxyC0itIpEAtTHux-FI9CiZr
+cv7i4BDdAg11tzHlHkgaWXVmcORavzy_UzQymXgqwUVVd-UFFNCZi3nZvlDs_WMQxzTDpS5t_XovrkhIQ7MjNnw_NwdED11Gy_XTrxy2RVKh0z_Cl-kBAw0H
+Blbv_VXAOCQWNQmVUVrhK2wsd7lh9tIxE9Li_K60mbwsLacnsx-AM6iu5xGEiDs_hAyfSFWu1xNz_kMhNvbelt_D5FgP02J0_SR-BrP6j02uuHUzr0y7jFK7
+bld-EldldD_UFp--VtxDvsVWyHpv_1nVJRsLTy_l__mt_Z_-MVm7
+}
+
+AWSEntityColoring(IoTCoffeePot)
+!define IoTCoffeePot(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTCoffeePot, IoTCoffeePot)
+!define IoTCoffeePot(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTCoffeePot, IoTCoffeePot)
+!define IoTCoffeePotParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTCoffeePot, IoTCoffeePot)
+!define IoTCoffeePotParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTCoffeePot, IoTCoffeePot)
+
+sprite $IoTCore [64x64/16z] {
+xPI7akCW44Hx0fF-_tytGEsXjMKjqkKxlwBIu9xaHlb7ykH9LULrmbjh5XVLBXYmNQaj06apKmROJnUdTr7L-t41x6HrWkQa0USwOBJAIHaeQbbT3N8JKKXZ
+8bcRWn3t8O08q0MvGMkdfUXhNKWWUzlgeOhUsZ75Y8FLjFgoVJem1iZYA-F9eJD0xU2UzzrQyr7fKG7UktDXZPag-6420-ST3G0eSaAmH-Nlcm-GXK9gTk3W
+_Udtujh_Ce9_gXEBpZC2j2e9aDYy1zlNjxej3W6Q2vX1FcsqfbUGbm40zrn-h7V8hHMZkgTqg6ZkUUNb4loZN8snntvyt-Bp1uC6hTdk9Z_3we6zvuqne9_7
+TG9qZhc30vgZHu09ij7N276cnz6NczIYzvZ1iF0nVtW8MgR0yeXG0599r0i3u5wV0Bo7kiSE2LFhgweIi83oNGy8mQk6dO-fldpITstIq8FBHYXo2GN0iT6F
+bqoUYqHtmrOVg-hflzhgPSw-X85ywal1UOu6s3VzNDsf1A1eC1_RF8qpFj2y1841Od1Tqy_z_oOzlazlBRr5DilhL3z_84-Ul08
+}
+
+AWSEntityColoring(IoTCore)
+!define IoTCore(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTCore, IoTCore)
+!define IoTCore(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTCore, IoTCore)
+!define IoTCoreParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTCore, IoTCore)
+!define IoTCoreParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTCore, IoTCore)
+
+sprite $IoTDesiredState [64x64/16z] {
+rPU7hkmW34J71Upv_nz-Y8lI55ORTbyxAeu6JdepleP8OrBHECTdJ81amo1aGs5i9E1i153PA43yJ8DWfxBS-zpzxXscPTtqw1ioRqWJVghq2gWtR0mhuAKX
+A6HiMsSe7g91rhuaoS02GMfV45Sie5a4Ny1Dy052-arQBznimp9avZjFpEQyylF0YY_Oa5T-X7tW3rPyCSEolrEAlkNx1K04xvy_umLxTlwT5_onhxAX2_ua
+gTK-yXjhFaJmaVz3XAtvOeQFprzVaiWJ8SzyvmL_xDS3ZtouJ_VsTMAP8rdpqVZSbqnRyxMKoTY3vB_tORPw_Ml55ww_wgB__6Z51pBs_pnRLENYgnxzu23k
+pdz9Cil9Lr8FVhxodHq_-a76QVjL6lNE5pBTavHzpDdmau_6oOVqJOkItWtTnYJPI9duMWewCx-IPcIT-4Csa_lzLpBDajJT3ssqSdFz2pi-lLhNys-Pa-it
+yoi7TRTUt3ywc2IFdr_SFlyHvcJnZKBwcudC_bRVIVR_DqsUI7qd6RAKLCWPxC4iWOxsmRZQlwHyt3zrWdJ8wDFK6xhtQvDsBezxNLEsVhEoKKU_w5ixgRqA
+V4mhhDYHlSyiR9JDHzxxeZWnxvSdzKly0W
+}
+
+AWSEntityColoring(IoTDesiredState)
+!define IoTDesiredState(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTDesiredState, IoTDesiredState)
+!define IoTDesiredState(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTDesiredState, IoTDesiredState)
+!define IoTDesiredStateParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTDesiredState, IoTDesiredState)
+!define IoTDesiredStateParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTDesiredState, IoTDesiredState)
+
+sprite $IoTDeviceDefender [64x64/16z] {
+xTI7Zkiw38JX8IMAd7d_1xvm2xQPmHhbjlDlJUHF9Ot_tFxqfqpoUIf3wIbcXG4MHVrIYgmC1n01m2Dhl_TzLPahvZ3WNBhsUM1ZnigiQhdZoiSgIgB4MkF3
+GESDOr-dYlkXSwtayM_j-nf0TTuelGvQ0m361RJbx_o771xXS7xe5pumA74W7ldhqe8_zTnxwWTIf1BZcL_maignddaEO6m_VEXvl7_usAlCIh_mS4gwcr1w
+vsVLYgYVVKMigjbv1RRY9tyEYKqBY1M6q5UlWCKAO7NUaA8AgAtBrnPGeXBMyCGGIKrSUpMxpeIv3mravwVElRexnk47tFqyasRdhxUQ8wN2owUKhw7YVOv9
+ClPhF_fzA4XE33QLmOR1yhjF74FLUTMuFl6-Ufv3wdo9LKN-vBaFAJjlaritVcks1u2zyuREstjlR1f8TLu9xtp2IlTUT2nsJTYwzsaOx9k0hvzzEdh-kihN
+5t_TdxtzECD7NpUwdI4kFn4tkfy1W-VwdUvFORQyr_qCGA_xqY_zj4p-S_lJd_u2
+}
+
+AWSEntityColoring(IoTDeviceDefender)
+!define IoTDeviceDefender(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTDeviceDefender, IoTDeviceDefender)
+!define IoTDeviceDefender(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTDeviceDefender, IoTDeviceDefender)
+!define IoTDeviceDefenderParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTDeviceDefender, IoTDeviceDefender)
+!define IoTDeviceDefenderParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTDeviceDefender, IoTDeviceDefender)
+
+sprite $IoTDeviceGateway [64x64/16z] {
+xTTPigmm20PWfa3O_uQlj9tY35mDdjV-dx3WArFEmjTyGWoNORfkkryEa3jVy-pt1zYp_M22FRkjaUpflLUFcPeptNjw3TOyZgyolxhCHQ67FqTB7Zv20EWH
+_5KuhU62R_arNl3mWuXU9HN52B_0Rmuxno_9Bxxf4sNLzSaiJST7RQStQFk4bQSosvwz3E_wKVlHyC97X3FIymWWDerX1RjUFI9F_L5DZOD6PwJfnxhJCrsF
+V_4Swv_kylJugqV6u-CFOquJUEeJoX1yxcdw4UxvdCA3Hx3fvugxehXBqsS27BRfJS-OkzBexnzpA3BngKSBJj3tAopSF__JvZiMEJORNhoCx7fKAwAuwIzo
+wpzUhhoKtfNInwqRcpE20FYryFIeVdh9v-JczrTavDk9BFRARs-gYZ6WNueHNbNjxJbMOcifkRbt_7A7aLpEsF9hTYKFXq-zznfhLIfwqRZtQ-b5nfuVyB-W
+tly_ALuE1D_lV_8F
+}
+
+AWSEntityColoring(IoTDeviceGateway)
+!define IoTDeviceGateway(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTDeviceGateway, IoTDeviceGateway)
+!define IoTDeviceGateway(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTDeviceGateway, IoTDeviceGateway)
+!define IoTDeviceGatewayParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTDeviceGateway, IoTDeviceGateway)
+!define IoTDeviceGatewayParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTDeviceGateway, IoTDeviceGateway)
+
+sprite $IoTDeviceManagement [64x64/16z] {
+fTQ7Wgqm20JG8I70yFyV_Du5tQPkqTbowqaXiV1BuhVn3Xysm4Dk-0SZuCC6U9OR_ku8-B01Vjy0UTENOwmLlESPf0aWTjFJ1p0dC9mtV2WmZBG1QF2lVWca
+viweft_pMwVTwpQKttkVmFGFAz6bE2t3-SJ5-gcRUP31C07qDzu4ihPX25wPrcK0PFtaVPiu6HEGgJe5c56Jc5M6QrzcU3yT4Ek6J31g0RSoN7ghYNS6Pdne
+TaIboh0kV4uejoWcFsH2tzToNljW9o3HJxO7WRE1_yOlhFoq4HRqtVD7Fs2cgW8HYAgQOPpxFFM2ZfAAZWHFVHvycQ7c0quwXfkEsWIdFWz-0a8o5rQLeWlO
+cu17dr-yOaWzqpv_Q2_8W5xu_EGTGeMzda3grqd3387ntET7Fs3f6EI4qVr5wqqQnfNFTnyOlNq5MBtqa5bl2fmNFdUVXfKrTWnK_Ue9lEgnBdtkVi6I9CIh
+4jMfTpqDUkspVAR2g_-Pv81N9JZXF_fit_q7X1coRpn1_DRt_3anL33-1wBIHxF2VlO1sJSXj1MsSuaWVlJCsGLap1f9hatNHcZFxxn3efOpqFtX_HooUrxw
+wd1q0miI8LWxLtBtFFTyUKw8CVzd0O3MR4pQCRR7Kx-OoNAYPck-_5osL01jffldqPj0h1g8YOge2YhJkGq3nix1PntnKItGrp9dPlXQo-FzZYAuv-0pOm3w
+uX-Fw_nmH-7yaAFlIIpc-Hs5yNDEVDOHwvcdTnHVS-AhUbs6FTixF4cUnhiCh2ItYV_U9wrcc-J-b7_okNNwFfI_-gqCNGhoXg--Uobk-gHL3Uxw2XzvyfdF
+fpwV-dpgywdFfpwV-ki6_W4
+}
+
+AWSEntityColoring(IoTDeviceManagement)
+!define IoTDeviceManagement(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTDeviceManagement, IoTDeviceManagement)
+!define IoTDeviceManagement(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTDeviceManagement, IoTDeviceManagement)
+!define IoTDeviceManagementParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTDeviceManagement, IoTDeviceManagement)
+!define IoTDeviceManagementParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTDeviceManagement, IoTDeviceManagement)
+
+sprite $IoTDoorLock [64x64/16z] {
+xPS5igr030L9XaZlVyF_fcgUCRnS-6vTWWoDd21X-ziGaG-JTLrF4BKfs6EYe8-9WSoXJ_dlg_c3X9f0kdj07DUvwQc-SvdzH5SWBm7ewXkCxHAZibbmSdj3
+5hOt4kzz2HP2hll92NdP7n3xWO3nYIzHyERl9m4hx6y-KSZqASvzaNEVGfuSNpqXNVlZJtpnToRxzBlyLh_qC0lAlEyBC_41IEjB4GVVNeKTxE2755kNVv3l
+jZ_Fl_7VdwIJhMz5BdviarZyjAAhNqbpN9Aud_yEFaTAlL__17zCrAcHpjSYZhuca0ca7ltGegjVhO-tDyVz-XLgystT-kVd_u7k_2VU-lVpdvf-Ywy9gOtV
+tByra00fgvzMTFdFgLbvNra_0n6mpY-aYDKVa0bZzKEAf_a5G7n3_HpyM-gle8tVV3ywl_z-zVxrxrSXxj8S_mSzFmDSFp8SnbLVaXDIBlc51WkXsy5l-ZSP
+2xBqRz_UFtvx_xhspu2xnx5_ZjSXD_tM_ls__mt_ZtyNNm
+}
+
+AWSEntityColoring(IoTDoorLock)
+!define IoTDoorLock(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTDoorLock, IoTDoorLock)
+!define IoTDoorLock(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTDoorLock, IoTDoorLock)
+!define IoTDoorLockParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTDoorLock, IoTDoorLock)
+!define IoTDoorLockParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTDoorLock, IoTDoorLock)
+
+sprite $IoTEcho [64x64/16z] {
+xPS5aeH034NZoR__XPVgoYfCaNNZZQ2lNUbJuOqtYMAHLOMDgWnJVeqSXHrfFBCviAYCy8t8B2ny57cjoEJvJOrrcy_z0b98zZdM0l9KDo28740nFOSJq3C_
+05abcBPxfe0F_3gEXArcFb2XJ0S5EFMx-jnjmoEw0Wk8Sx_44WUaSOtyxP_LEz9kmBuoDFKRRcWnztVy7l_oBv_f1ZpoaKA7I6BYxuRlnHeKfduFFwOBwx5W
+w9T6uO0AdPO_gqSzTzS0DF9Xj60MqGqHPbhOCF-fJ3jOSrv-bQuFqJABUXOmz0DDDMW2i_9ZYzgNll5hsZ-hUKHaHhYRya_lVvT_-PT_pPy6bDpUsJXD1l2G
+0tize7EyPs2c1xXdNwS9cZs7vFFzMyexDf0LyleDxEF-LRvs_ppd3W
+}
+
+AWSEntityColoring(IoTEcho)
+!define IoTEcho(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTEcho, IoTEcho)
+!define IoTEcho(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTEcho, IoTEcho)
+!define IoTEchoParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTEcho, IoTEcho)
+!define IoTEchoParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTEcho, IoTEcho)
+
+sprite $IoTEvents [64x64/16z] {
+xTO5ZkH038NXtwuoFD__lWkzKNe4MIKQuQW_GR2Oh9_au-EZt3o_aHmCGc-Z9vnKGKk7Yj1zZKcpgEDn6z2wp-YH7qassChI0u5jnoMf7GlDFEk4pLyvQcDf
+bClDV9Vkwkg4bB6bDC0CyD9ja-3iqO9LaZeNnCCCf8NNg39BaqOycmSJk1G6O35jfEvgN8sr75R4WgN2rBPrQKQdxjd4EAjdHktiMQGmNQc8qXU64dy_LR76
+wSkP0soTsjOuzUxHhUhPrEN2YpHIfrPZEbM_Nbuado1c2lmBO-cVzbDUfSzN-ZSpyBDsPiVBc8lwMvKJqg4pscWTAb-taVzTE4jlHWTxz3AB6acOhkHQgRS9
+jev9EzhuCGgZMx9aPC7AxdIi9SaftLAO2hATb_LAdYpTis1DmkxQQvtRHxHksRYnfmnMP8-UsLYtiQHm8EReaJkwEh3MiN-gAtj6jV3R-wVrUR-Ygd8RUDtU
+lvVUvyV1y_dv8OqgzjwH_VpyEinVZy_FRvxVtuqVVhoFZu_V
+}
+
+AWSEntityColoring(IoTEvents)
+!define IoTEvents(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTEvents, IoTEvents)
+!define IoTEvents(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTEvents, IoTEvents)
+!define IoTEventsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTEvents, IoTEvents)
+!define IoTEventsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTEvents, IoTEvents)
+
+sprite $IoTFactory [64x64/16z] {
+xPU9kgCW38K949Bp_YyySB5yFHDBcNtzxs9SVfM4Qfh-DaI45d7R7eEDGm7jYmpalb10vgx__ckojeu3Om5u_s-0yRQEvbkzufYQ8Xc07m4WHr-1aeueWAP0
+WwT37ErtzPlTLIURkvkyyCK66BwWu-4KobLpm0Po-HWiVvs2V2D_8dVNj-hX50elTzSFuv_JFgjZO5N8t-IF_4Id-2gVJ_76bu6HFodjoiNdliaWSVxPdyZZ
+5EnFPEFJAG3FW1MvztNWv3DIPCwiLgRlEdXHFsaVo0gkN61Wx_Elw50maMe0vCHtfs3HRlqyi6TVE5ZevLiUXFejFsSAsD_NBuv_xyVxh_YWhc1__t7-bzef
+QGN1t-S_y6FzE7-hTceAmV9v_Wec8Nyw0zvoNhyOH9-V7t7-n43u-N4__oLVGKeFV-qw_Von3npwdAsKGlusxo-kt_9Z_M23_VDl-RlFJxo-wyAdprja__uY
+fa_iyvVCyOJRpPQjduI8Mtv0__8j_Tktzu_Vthzo_mnWDixSFzlQrJH_Q__-t_-6xuz_5vy
+}
+
+AWSEntityColoring(IoTFactory)
+!define IoTFactory(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTFactory, IoTFactory)
+!define IoTFactory(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTFactory, IoTFactory)
+!define IoTFactoryParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTFactory, IoTFactory)
+!define IoTFactoryParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTFactory, IoTFactory)
+
+sprite $IoTFireTV [64x64/16z] {
+xTPLOiDG34HHuKYp_mtNK3QLyPsVu5LYjdolOT0tM_BYczMKAzz1bxuYto3ghWzvatXrF_hHcxlRJkygrpIRCspxwBoU4CY8RDQs5-TsmZudDlr4YuIVfngD
+AOoTVf8a6ww7SP5jKjJzNWoSTELcXdaM9wbJWUFjPyLL5p9Zba0r5x2bqyD-OjdSTRTwuLVxZsCpej9UjV-f9wfdLGZJpzh_Hp_wnflqNVzsKo_e4sIVW5nm
+qkKTZBHVsLla941YVVRACS5dudMzynb_vqsj_433S0C
+}
+
+AWSEntityColoring(IoTFireTV)
+!define IoTFireTV(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTFireTV, IoTFireTV)
+!define IoTFireTV(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTFireTV, IoTFireTV)
+!define IoTFireTVParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTFireTV, IoTFireTV)
+!define IoTFireTVParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTFireTV, IoTFireTV)
+
+sprite $IoTFireTVStick [64x64/16z] {
+xPK50WGn20Ct50Bv_uFFtLqxwpBrbk5jT3gT3kngjlpIrN1O0zr0RFcqgsYbtF9zk0vAdE6t-QabkDMlARVxDRtu0tsSDk1PLSGn7nauvJCPbEnu_gd0sMx3
+YVg7n7Qy_CKXwsJxMKf5nvvhaH81nPdszzA4OdWpJB7cp9AKRVeLP_klfVPOreljalutpzAQZHhXql43yo0poMXsx_Zx0lyDytS9xb-_xby_Ro3kZ1_tng_t
+q-bqEcC
+}
+
+AWSEntityColoring(IoTFireTVStick)
+!define IoTFireTVStick(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTFireTVStick, IoTFireTVStick)
+!define IoTFireTVStick(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTFireTVStick, IoTFireTVStick)
+!define IoTFireTVStickParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTFireTVStick, IoTFireTVStick)
+!define IoTFireTVStickParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTFireTVStick, IoTFireTVStick)
+
+sprite $IoTGeneric [64x64/16z] {
+xPS7ZiGm24MD9mR_-rzuOvafHA0bcbwUIkfB0TpAfq54PhCvzoy26RS2RTrKeAwR1f1U2ldvjV5A1yO6wCmiW6pFSQkklY3DuhqTG4y1mFc21XnAYiECpGP6
+Bqaw-9DyaW7s-901gO-9-iGXf3ucvBwV4SBk-rMxyAEwuKpy69sA0_MqF--lL0oXJmEnFZ40he4lD2Wc_iQdFa-HxqyezXdWHG39-6tGBtq2UAP2pk3izpQW
+C7uLM9mk9Hr_cbykzlqxyYVU_qT-7SYU-4iTsFnv-ISjfDtvKyqyoF73xrVCZqJVhvhl2o0B0pAqPFnjqZIHbFSjMaWry6tz1aNBvlscVatyu__dHFxoyLS_
+xZ_EL2__GeD4_apzFQZ_pFVVruqVruzVruwVl_d7jVEtw-UFryzVxVmP03FBTluifqlSwhNpzvz_nVhni_W3
+}
+
+AWSEntityColoring(IoTGeneric)
+!define IoTGeneric(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTGeneric, IoTGeneric)
+!define IoTGeneric(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTGeneric, IoTGeneric)
+!define IoTGenericParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTGeneric, IoTGeneric)
+!define IoTGenericParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTGeneric, IoTGeneric)
+
+sprite $IoTGreengrass [64x64/16z] {
+xPO5Ufmn34H7O5cZ-z-ty7yEnr6zvNPVO76U6VWNSETEHYHlPm20VqTSV0W6RqGmgrAGxCctNqeeoJ9CTeG24c_oGfAAREE0Al1QOF1CXsJVqAWA25-IWejE
+i1hwjg8v1DxN8A6RXfOXYmxbXoY232ZVovEqPXBDg__UoNDehfdmiK0lmwwQDQ7ivyzUG4EmvwrWMAuMAey5g__M9_DSy9IlmAXJmSe_pP5pGVZAKv2t28eB
+m-Inu8bo1Cy5Bhdo0y5ZGHas-LRGvdl1ok_RtmlcQFg_hG6RyMy4oMx-XOfuRWIENDstc_y34BmlLrYx_XAOfC7hqjUB1mFGhF-0rsKn6-Gmio3Tp2RfJ_dj
+_hFMjU1gWm6mkbwDoiUpesBRUmd9gW7BJ3BpyO7hrJg89ZSun1N8uePk_tTy9VRvxlp9cV6He3-1MO5D5IkjZvCr1VfU7uH0a-n90pnVIZdjuFuL0bWaMLyX
+SoYWazzASLpJo7oCuNOz3vvGdAx0GaVoc6BE-C9CilWdSkVEPm
+}
+
+AWSEntityColoring(IoTGreengrass)
+!define IoTGreengrass(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTGreengrass, IoTGreengrass)
+!define IoTGreengrass(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTGreengrass, IoTGreengrass)
+!define IoTGreengrassParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTGreengrass, IoTGreengrass)
+!define IoTGreengrassParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTGreengrass, IoTGreengrass)
+
+sprite $IoTGreengrassConnector [64x64/16z] {
+xTH50i0m20H0eh3_Vt2zr9KhSwiiyL37EUTSo9LdXLJXMSs1BiMAjQ1LiLOZdSle2Gy4Y5ft_RQJwKm1m2beiNLU8o4nW78UbqJga5T9pWeaG2AzoLCK8D6E
+ZlS-h_DnQ7xNfppFMJpcgHmwK86moq_EyW6e--uplM-VM0SG1zhzv_7h0E80i_mbdw6CUMl_3VDdMp_h_Z7kN-lvCPvVu_rXlB-CzwVz_dREETS2
+}
+
+AWSEntityColoring(IoTGreengrassConnector)
+!define IoTGreengrassConnector(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTGreengrassConnector, IoTGreengrassConnector)
+!define IoTGreengrassConnector(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTGreengrassConnector, IoTGreengrassConnector)
+!define IoTGreengrassConnectorParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTGreengrassConnector, IoTGreengrassConnector)
+!define IoTGreengrassConnectorParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTGreengrassConnector, IoTGreengrassConnector)
+
+sprite $IoTHTTP2Protocol [64x64/16z] {
+xTU5haGX30JGjWnjv_z_-0N9MnV8nfcho5cNM_bHT36t6f5SIWOkse8R2PF9aqolM4ZrPcpu85rbCUfaI0j8buquYN7tgJjUap4EBblnViTArZrVoU6nvt7y
+ySSVV_noZZzUpMJwtTnxBEREAnUZF_TLlqvzy6kl9VPynNllhUdGw37lXzAQhdrE4IH3N_bqaRO3CW4j209gh8WKaKBLGA5_yY8UqeB6Z2h6yj_f-TBNLrwR
+dxCZNla8e3xreBM7FsRYfS-8uAFFPEsFUpxyrSUFOY9ZL0hjojSlNxz-iFde_ttIFtXUVCtvuaq_wuUlxp-ydpCpTNgGVkrLHIwxTZ1fQ4me_Rnbtl-idox-
+NGeVlZ-N-isQ3xoB1ow9xY_res_zVbpgrogQMtxMpx9VHU_d3m
+}
+
+AWSEntityColoring(IoTHTTP2Protocol)
+!define IoTHTTP2Protocol(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTHTTP2Protocol, IoTHTTP2Protocol)
+!define IoTHTTP2Protocol(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTHTTP2Protocol, IoTHTTP2Protocol)
+!define IoTHTTP2ProtocolParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTHTTP2Protocol, IoTHTTP2Protocol)
+!define IoTHTTP2ProtocolParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTHTTP2Protocol, IoTHTTP2Protocol)
+
+sprite $IoTHTTPProtocol [64x64/16z] {
+xTTLeiKW30JG16Ap_mq_IdbUWSeVyp6vTgvRwA7mO7vhyS1GmkLR9yU5UFha0OIf34HjCUqA732cmR01NWz9uNGX1iXwyy5NF0Ty7KQNOlM66T1hNe7LopKl
+qqy__VJJ3sVwwJabQlvwjdsMlknvGr_uDHzy6Ztq5rw_fprxhfMyfWtEfRJBGsgn25no6H4Yf109w_AvNGc5hgTxAOt5SgUdJP_xl8defhUW7X_k_jyZ0ldE
+uvVCzCFhgF_r-WVikc_xmtLVXsrxIhMu59UgezPFt_QdY-__pVsjUZcD5x-vFmvyVspjhp7WD_Vd_dMQRkS3
+}
+
+AWSEntityColoring(IoTHTTPProtocol)
+!define IoTHTTPProtocol(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTHTTPProtocol, IoTHTTPProtocol)
+!define IoTHTTPProtocol(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTHTTPProtocol, IoTHTTPProtocol)
+!define IoTHTTPProtocolParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTHTTPProtocol, IoTHTTPProtocol)
+!define IoTHTTPProtocolParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTHTTPProtocol, IoTHTTPProtocol)
+
+sprite $IoTHardwareBoard [64x64/16z] {
+pPS50jmm30Iz8Zl__t0TAMd3fD8S-p9h2hdyKT3vBBEreTEClzZYSj3ahGqRlMggLeUEuPtUkgEJ0nsRW9Tw7GKG-KTz5z0tj_uXrJinTjxwvsETVMDqEwZm
+I7vHFRmFpKIiUTlneW5GYJuWfi9LKPGNY0z1q0Eal24Sb0b4rZk85mDAvVz5x3FYWvC0xhSDGnJT4lvcShr47tNy__8XoWa_JZdXdvyiI6QmyIqc9BwU1dHd
+WZP-dKeF0rWLDxvwAPTzGFpNQF890E_zE5qrEWY0HxVQ-ZEwI1lVOT5rW6hye679iHyi0txr1zDrhDEE_Nt0B4NBuYGS_MSYafs_3t1_A0w4x-Pl6O2V4rgV
+pZzPLSm1tW1gKrEMW6RAqe_Ujdcqmm8pdkx_6gEzy8Edlhal1pwq6jtwx3xsVWmZuG1T-3xiNFO-FpX_IaotbGDVaZvyEvK3wXE_S3ixdSaZlu1G4dxmH_tD
+HIk-F63o4o1x_VvlsTy_vU_VilUFsVlN_Frp_luzltx8hr_owwVy-Ys_ViolN_Fhvpm_
+}
+
+AWSEntityColoring(IoTHardwareBoard)
+!define IoTHardwareBoard(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTHardwareBoard, IoTHardwareBoard)
+!define IoTHardwareBoard(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTHardwareBoard, IoTHardwareBoard)
+!define IoTHardwareBoardParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTHardwareBoard, IoTHardwareBoard)
+!define IoTHardwareBoardParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTHardwareBoard, IoTHardwareBoard)
+
+sprite $IoTHouse [64x64/16z] {
+xPS5bkGm34GZsPPKzx_mZgNcQdipRnd-W-0FbFdusn2HfmsVs-FmUIimFZOAwCTc05AN_ljhTDW70SmD46RcWB-Uiw5lzOxJz8DH074A0Ch-0DfnYZQp8Gnn
+d2HWFydN2Fq6lm6K2llY4x3VaNJsaOfSV2JaZ-bs08FyGhRlj_hs1i0Mxz_ylpWGMXa2Bf_ChwINHvttMm1sUwSO46tjoyGHJy7RQnRzmVTKZaN-WpAlKvG_
+-Vmo_YJsnoGGd1OdMdwaygxy9EuwFo1acpyNDbU9hS-LZQia-pfnH2OPRUstoDG2dWgLN-tPxlNb5q9-Nl6LxtaN-VVlFqGrTdweod7_Viw_1XdncFHvEWgh
+IrJ_t_eDYTUeKEZdVBVqfSQiMFXKVs--rjrIJQ7VVQw_WkB97pqsVh7nanC-zH-LVzqnbhwdiipla2fVya_cV-Ed-E8JdFRtuvS3TiTllfk1yd_x_XVAB_ph
+urUFP_8kyKZwJvX__2J_s-Tltpv__FRvAy-VaVN7N-VFVhjaGxzr_lxV_uRruz_55m
+}
+
+AWSEntityColoring(IoTHouse)
+!define IoTHouse(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTHouse, IoTHouse)
+!define IoTHouse(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTHouse, IoTHouse)
+!define IoTHouseParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTHouse, IoTHouse)
+!define IoTHouseParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTHouse, IoTHouse)
+
+sprite $IoTLambdaFunction [64x64/16z] {
+jPUBakmW24I3HY3__yFNc5XdGf5zMRVt7MowXM57j_yAwVWRi-pDt8yETsjx-Hsv-H7WxSSfThiffgr3xKvc-u_OVibLuPdKov1_cw4ONhCz6P4CRR0b3yh8
+qDxPeZskyjS5ubsyRfkv0tkkhkUQF47feNDrEHxG868zGKdLnzh1Dvte3wEQuY2X3tx5RrAmD84DElm933mIM6mSZvxy7GF0uiCoBS77WAURBI7XpO6FWNsB
+gBTTrkYd5zrFJ2qC02LhB58DdM_u0NAGbHfDmHiobresAHYmq2CvGLBD3T2mVAXyjgIy6IZybl0fl8O5gDBXt00TISFlzgLWW0Ab6zYJyiWPe_CrawXtUdsP
+43gFWQ2XLyoJK3T0Zt83VXW_ujP6yhlpD1CWx1GNURDkWCwdKwI3Bz7QjUyo3PIioNEPH3uJDmqeER_du_McMZv5xtoi3chD3S2FzQDKzTq0zOlzerKOO8nB
+x1y_a9-4GNsECKOHvlNB_p9s7AQe9AzVvWTHsaZdgINp4-UNUY7SFWtCTsJc5m4qU3nyOc2W42SHyeKwniutrNi1jlcD6jD6Ei-AWYfxHZxKaSx39obMaISd
+78jygahF4K8U0_0fAWOKdIYFB_YAFE_VEjzvzpO9nDiLkQnKb3xE3mV0C9qd8awSyulO-x7DYBWCEzdvIS0MG2GzFmrBvCpn_G7mptJEhoc-FxzoVdu5v-V5
+y_lQ_M7z_h9-Vrg_lwtV7zVlh-ltvtNy0m
+}
+
+AWSEntityColoring(IoTLambdaFunction)
+!define IoTLambdaFunction(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTLambdaFunction, IoTLambdaFunction)
+!define IoTLambdaFunction(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTLambdaFunction, IoTLambdaFunction)
+!define IoTLambdaFunctionParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTLambdaFunction, IoTLambdaFunction)
+!define IoTLambdaFunctionParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTLambdaFunction, IoTLambdaFunction)
+
+sprite $IoTLightbulb [64x64/16z] {
+xPS7qjmW34QHGEMx_u6tOCqobaEMjTFplockpu0GnULVWuXsXtJlBGPxlWh8uy00Fmu2K3oQykMpw0C7dWV0LTK0o_TK-9jwmpAj7640lWG0Fle2rB94xR79
+ABmiuj1VubTHCvLwpc-EmDjtVR8dsFlitJJRZhptqHKA7vsTNtkntU9UaRhtEpGjdm48bO0404_BFxQV76WfDvtMuoSfG-BEgayOvyC1pNnwOiDfAPNZNXk-
+TQLCugzmoZuvT1R_x3ki733up9Sd3b-DZyExCka_clcqyFrBptDJgJsW4PI9pqzi-8B8refNvZCWmxUkpFgF0Ss-0hpQVyN26bbJ0IiJFzU_Ly0vJhQZnqcg
+_sp-4S3hyAi3yj7y9G2KDfyKeQ_wyG7RV4jwydF-1kp3Z-alv-ya_e4DtqhoDzxvNXlGga_zD7za_qNoq_mnMJzq-7fg_U8QS3dbL_EErVBv-ZN26WzMrg_i
+Uso8Q1B_T-LhchZMrg_XMtjW09s97o4uwHT182VtBnIKYNzv_tPz_tXz_vhtpm1KrVB-sLwFLFZg_ltBl_3_-6zn1m
+}
+
+AWSEntityColoring(IoTLightbulb)
+!define IoTLightbulb(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTLightbulb, IoTLightbulb)
+!define IoTLightbulb(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTLightbulb, IoTLightbulb)
+!define IoTLightbulbParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTLightbulb, IoTLightbulb)
+!define IoTLightbulbParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTLightbulb, IoTLightbulb)
+
+sprite $IoTMQTTProtocol [64x64/16z] {
+xTS7ijim38JX1OYszxzm1cAwwCXKdgVgTxVvkJVWYvBD_jIMnQqgxPVMv8rIV_0YAzmsycYZqoSPWiqao4HdPE16GTgy-P8xNeev3mAtYkE6XVHxtidfxPwt
+np_-yOz__7QFVxoeukHtM_jXx_NA1zzBFkPBBlD_Ubncd_KHnw8KG9FbW6VdbbrS-UG0q6k4EOo1OKutLJE6ZMiVmEWrKG2C2cZljMbovRC46IMec6RFbwT9
+ZHBC1UMRtaP5A4LkUaTHbOBv1vallR_ovcYVYQPZxOlnoWE77qspiFBd-U7i-sILhdqVnCgBe3k0Elt7gKxbXr_FJ-t_R6IDnVj_ERyT_ZIoLTgVvVJd-N7h
+--CylzQUFy_Fxu_J-E--0G
+}
+
+AWSEntityColoring(IoTMQTTProtocol)
+!define IoTMQTTProtocol(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTMQTTProtocol, IoTMQTTProtocol)
+!define IoTMQTTProtocol(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTMQTTProtocol, IoTMQTTProtocol)
+!define IoTMQTTProtocolParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTMQTTProtocol, IoTMQTTProtocol)
+!define IoTMQTTProtocolParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTMQTTProtocol, IoTMQTTProtocol)
+
+sprite $IoTMedicalEmergency [64x64/16z] {
+xTS5RaGn30JGXZttlt1ZM_fCqPIx8_Zu5i9v-s6fqlIGHK8_H97O3q4awzqczTP3p0Fc0VE0US5Vza7JlHvAX_sGWDGF4IYXf_kWETAfuN5QsdCCPVS13QZb
+OIhGDZnqFj38WB3pvRalVybNowXtfHUmp3vVPFOUxzIQoMTS94_UK9l__wZVbz_iOpXCVEh3IVySzR5QuhNFcdBaAopro1TZS_sTU94JFzUVN7ZfZo-yJCDM
+7FNHs5n-Ltwy_BtanRruBOpu2ejxJptpKPDsNdfQxjTDUdO-6JkfF_ldgyZMUrZF_dwk_FZwOziFstxP_iFsNtRyOCOlVlpanszs_c3dBtR-PEVlr_g7Np_E
+wzVyC9qtTltChj_v_SDh_yNlNxy_xm
+}
+
+AWSEntityColoring(IoTMedicalEmergency)
+!define IoTMedicalEmergency(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTMedicalEmergency, IoTMedicalEmergency)
+!define IoTMedicalEmergency(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTMedicalEmergency, IoTMedicalEmergency)
+!define IoTMedicalEmergencyParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTMedicalEmergency, IoTMedicalEmergency)
+!define IoTMedicalEmergencyParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTMedicalEmergency, IoTMedicalEmergency)
+
+sprite $IoTOverTheAirUpdate [64x64/16z] {
+xPK7ikGm24G_84BV_yBhDAkI3HvvS_XTOU9p0IrQ7pzQd_eKYTgYnjz4DyTBOVoOZfrSX5L6Zt0342OhHBnL4Z9FamFHg7_13a2dUGUSJlqyU801VlbI0cXJ
+k02HJ8i1pDX0KVnFZhA8Rdaj6pL0I6DpfkO3KLK610xPJVTwKnhWgWR0wlzGnHCE3xWsmn4tpiP1KTbbmARs0v2YH9tX2R2Idv6dXqnibhVa6903itp3AkVJ
+Yi1czvoROL7hE81dGKM6_W2gpqGjwKjPJ8xLOf4rsiQhoRA_ZFFa-Ov3MsyA9ETTZdcsD4OHRkQ1HQg892xy-2ibCGhZVZA0Czz1Xv_n6FsLIFcsJp0kl0r7
+NDnoNW39zax6WIfsfNnMVum3QHwhFEDvgpRcSYmna9D0IFou3ImUsatcMOW1-vhktvGZuEH-eibbqbvsGw-WlALQE8ruZp5z6m2ZJTG2W9moAKoLRzhrZLJL
+_JmEVsN39daJsunTeNI92u-8pkVRJXliRQJ7qP7kEWeShorQzFQ6kVPYjQirdvWzpHlJaDP1ptYuTBExMvFyxh0raRQzTPf3-mOeka8_deWYsbgsOrDXzeI8
+5tNu3zIdlW
+}
+
+AWSEntityColoring(IoTOverTheAirUpdate)
+!define IoTOverTheAirUpdate(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTOverTheAirUpdate, IoTOverTheAirUpdate)
+!define IoTOverTheAirUpdate(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTOverTheAirUpdate, IoTOverTheAirUpdate)
+!define IoTOverTheAirUpdateParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTOverTheAirUpdate, IoTOverTheAirUpdate)
+!define IoTOverTheAirUpdateParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTOverTheAirUpdate, IoTOverTheAirUpdate)
+
+sprite $IoTPoliceEmergency [64x64/16z] {
+xPU5iXWn24KB9C3z_n_kvbQPPQtwx8oiJ4w4-ASNXcUinyYKxQ6PkZqaSwo_aNxf8-a3z07w0Ft4M_PbuSZrc81k3mDiUoWmPIFXikXi2zmcRA_Z4RiC0l1v
+4mUYo8oGFnXaWEpyUT-VRybtyjIdn923FFL1sFEvgFwGRoc__PLHVKfnq7v3oDSN65yaOBVZ9mcaSXO2d7cQGCfTFx38I9INkEaxu1CWOm1aEk2jFnRpXpzP
+aix8c5iguOjkjIf99hMc_umjRP04hEc_BBxmhOEM53zfBFJdyj6NZv_BLsfT_0pmpdVgD-8VoCvFnBt-6u2qrH-jhmkhlkvzhRvHQ-UVz-NNyGFI-SBnioS0
+QVnI_nhdYW6-g_y-VihYEmBGw_WxeBslW5_xxEQUG3P-7R_zGborEduJvA5Fikc_X9-TBOgFPls8i_X5ituGAUk7jde2TXr_LivrPpkRUEr_RLtwqE_ky0Jr
+AxyUXS9sNutVxLywWoMcMV8PKxlzg_HVrsBYUh9_dkpVmdHJplVlis6d4Vh6pp-_Vtua0VYuYGFns-Vdtp-___xzuUF-zVp--iBu3
+}
+
+AWSEntityColoring(IoTPoliceEmergency)
+!define IoTPoliceEmergency(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTPoliceEmergency, IoTPoliceEmergency)
+!define IoTPoliceEmergency(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTPoliceEmergency, IoTPoliceEmergency)
+!define IoTPoliceEmergencyParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTPoliceEmergency, IoTPoliceEmergency)
+!define IoTPoliceEmergencyParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTPoliceEmergency, IoTPoliceEmergency)
+
+sprite $IoTPolicy [64x64/16z] {
+xPQ7SiGW34HHr_x_3sTiCHVkyDYarqskysHf1HgthzQ_B4yLUeuxhdGQW83qCm5vmPydw9_3SqLHUXtFkRyOabx5w-wp0U3Ny1KW2dyDNm6G_7h_0u2zld-6
+JVegll2q2l1A_vDt3-HLF2Lu3-Elp9_AUVcQ_J_hzVb_YNyAuBn_nAAcmY_TFnQ-rUM9KZglxzykIOmANZm_9V8DScKY5WlKkjNpspWtW9u_Eu2WjVbHUD31
+LslpYn9pJoc0M9kVFkFTB5sPttAxq9mMBUp_c1qfAU3NFDSgzSmmUenCX_oup01k72ZfGm9onFleO2Ah_-6v1o2JHiO5-W7les44s9QeKra9JS0IKDaAo9bt
+86aiNxe55U1PiTL6ZxmLFlBRCewW2ev8mFS0Fl9k7KzkzxmZM_GJmyADc1f901Xutv-ry9ctladzfhpd6O3gjFkflfMcKjqOvAD_vSqyl19EPKclxYQdH0p-
+ouoNOpkcJ1AJjpRsJsPyTqIReolvFZIFV2CwF6RPccPLJFVMnENzepIhB4LDfkDJwVhvdMlEPNKlu_h-MSjNddqfBnTKat6-EcGDhyL-jwjZmYypW7V_IA9t
+Sbrz08LxJ9rSamIwgfYNYzGZCwFg-2RwrnC
+}
+
+AWSEntityColoring(IoTPolicy)
+!define IoTPolicy(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTPolicy, IoTPolicy)
+!define IoTPolicy(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTPolicy, IoTPolicy)
+!define IoTPolicyParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTPolicy, IoTPolicy)
+!define IoTPolicyParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTPolicy, IoTPolicy)
+
+sprite $IoTReportedState [64x64/16z] {
+xTVLOiCm34PXIP4jdVT_u46vzY1snikvAtnbo2yVbGxLOAl9K5djXbScgXSUG1GVg1p8zTx3P32ByoCm29NXDC1ETsyoaPqUG18oLP0Yeb3cV04zU9SkhKqg
+NVw6TvfysETDCrxbadwQt_tkTw-HTuMEUQV9XtszQS8tr_v_VlUxLpDjlDbwNnAot7a3M-kTGtxh0sAbLqZt1Brw1_1rti0Fvzd5QmAapleAom9ryl4RvB8a
+s1elfNtzWbCnyVurVkhpOwU-ulDR_5BfptdR5wV9-tDUEtwM92ovAwq_f_T1NlP3Dy-qwVNzO10olL-sxwVv_RPnFsxUhzlty_OU0G
+}
+
+AWSEntityColoring(IoTReportedState)
+!define IoTReportedState(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTReportedState, IoTReportedState)
+!define IoTReportedState(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTReportedState, IoTReportedState)
+!define IoTReportedStateParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTReportedState, IoTReportedState)
+!define IoTReportedStateParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTReportedState, IoTReportedState)
+
+sprite $IoTRule [64x64/16z] {
+xTS5SWD134HHmKZgll-5KwkAfnBZ68ClOFpBA8-bEqS_aqkAExaV1qY4oZdA2VA9WGrseQ-ngRrUU-Gz2Ng-7xB9lJx8c8ytz23canjwdQCDKb_Gtpxzo0rk
+NdvJcKnMN5f_aWKqyiEOWXDCbcZs9CoHfytjTv5ZoxG719_xppgDhGJ9KBc9rLoGjvZhwtP6sa_knUosB0-ON25v8A_kKMY5s_fIQLetz9Zxge84hkbLagN5
+tbiDx1SfkhhieKdqJD2TFUbWAfRMmTYgxYNOGhftaaCkyTxZkkzXTTDzxuqk5sG7xxqui1NTz-1oeIyJDTlVZbMirdgomcIFHP6BVQkCCRn_8xjTx6417e4m
+BFKYOYCBd50vJ4IM-wPgvcwcAcsvF-47z3-y_-__-_zUx-c3B9UZlCXOkWL4-lxvnnCaIouBDbHbjAm2MyWA7SKZQgYiKeyiW0se3DURxwRbcTu
+}
+
+AWSEntityColoring(IoTRule)
+!define IoTRule(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTRule, IoTRule)
+!define IoTRule(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTRule, IoTRule)
+!define IoTRuleParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTRule, IoTRule)
+!define IoTRuleParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTRule, IoTRule)
+
+sprite $IoTSensor [64x64/16z] {
+xTL74kiu301H90Be-rzuogNlIBD4US9gtbPiHTYKVucggSgFF9kR6YRNHVDK9jTO7LSEZ-CknhMyeKFbO0cKNiY1V5tlVUK4sjFzQa79feIKJmMnVVVr_QPK
+VEJmyykRp1ogkMaJMTFLazOH0xYiEVZg04D51xJAKiBYQ1Do4v2oLBGiw7E9oafJSYB0PC4sUeDobIyquRnNW1uoyGOwv4pKrpbme5nsQFHq0cq8sJRDGKxv
+wGd6DBXNrDkenNAktTUZlZ6uiNekXN4-k04GvxDQr3AVJp0dHQzpYBFh3z2l-O3nzGGAAG_-ROarPc0sJUjKQDCoCPDRBsPdtry6fCoEVZR_3nMaxlRp_8iU
+szvMxyKyhre0bQ_yw2rVLGFjCXdDXpZwu5EgVA6HrQ_yJzzlAbGs7VtiF-h_xnrSJaKlGI-5_97y95_wlEojRxcicNiFLtcJkT_Rl8Kdv6vl77pQF_RwX641
+_JezDxRND_Mn5HH4GFtO3yZZjhRwWb1lMWuEX7i0VkNznMF1G-_q4jmC-RKNZJ5CxjGUzAmlkQnU-mw_A9hyftw_mMNlWsq_aN_2Nm
+}
+
+AWSEntityColoring(IoTSensor)
+!define IoTSensor(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTSensor, IoTSensor)
+!define IoTSensor(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTSensor, IoTSensor)
+!define IoTSensorParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTSensor, IoTSensor)
+!define IoTSensorParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTSensor, IoTSensor)
+
+sprite $IoTServo [64x64/16z] {
+xTO56jj030LXlGL9S_yBDohv2--w37yOnapsI_ttt_1tuev_CinCV0DLJqO-HyahK4tabtxO2m6uNV7gPMEfd_U_opTwGKJ83hrtcBROMm24VJKeMkuxLmEO
+5BVbtkPi2SsQ9EiLGrlkYvAK0mn1c6HR_G22aWuqixrUJl6WfFRwqYQaTI26RBSl6ksIr9DjzjT-vxv7nfGT5A7rVbAoN-sfljmF809ILvj-N-sJR5Vxkn8W
+jTOBPhqcVapz6E0d-mvX5j1FJRyIcbc3r9dbvv1-aU0drf_We1FRZqT-5lwjs-yVqxSnwacdUlK0kYNCjjyhAU4KrsxVgafA06Elbon00y2LfBRw1WvqazIi
+GROvDtgdV2s2qfTxKSRTMNkrdz1xjuCY0hJOAy5r__jSxXzV9SLIdn7Ly-x2xLer-lRhHnlFhrBV6VPB_VVV1m
+}
+
+AWSEntityColoring(IoTServo)
+!define IoTServo(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTServo, IoTServo)
+!define IoTServo(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTServo, IoTServo)
+!define IoTServoParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTServo, IoTServo)
+!define IoTServoParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTServo, IoTServo)
+
+sprite $IoTShadow [64x64/16z] {
+jPO7pYGh30PjRB3h_WT-RtVG08i6YVv3ANKgmWTOBR-4gifNAJKIoAWcp_5aaYxFi7nfhNfj0P0c3t0WQv6EUW9Lhgb0LPbe1TgJtcqFCwyRA5DVqBoTGe3B
+P6sWNEX-6gX1YAYvcygP90-l6tZj2rlbX9sdgKn2vTY9olaTwQgU4CVXXvmexsWqm4zZh7B4wroCF7NXbrlK3l6PN50Eu_HBNv8qbGqBm2zzoAhx-a2gt62n
+5nODe1MvHJrOKmY88gN57Kr5F6S3tZTbunRlPG4REq9x1faP4JbPR-95PlUbGFRkwG_QwxvOaGMLWRuG1PTr8mNey1lh2TD8M-iOK8UlqEQvwNxF86Qmi_9K
+NkJm9SZrt3IYG5g0BKhgkAarYUbNq7zz0viJT8W6CRuMQGT_zX_bdOi1rHBQYAl4Hx-D-GTpoCaRc_CV_YnOGGvV0yWY7tpV_25MA7FzpKqwMjx82_C_cCg-
+VWMY-qH4QstiypVhRSI-VwJr9uqxzlqhsXzPv1rHblCpLahb2GxK_Qz1vOxYEVNrSEGTitvDF7b0Llqmgjhkg2O_Ytw99VulCH9iV8as_VJ7vEg7F2PMFtkC
+NbrbHIDqlRLEBm-xRpbJcSaqcGIT-ial8zQ1R_T9ftto6xZQEDMpnRBuKOhbPp-9KLH7TpOR7Cwjtw2-7hJDlnk_0_w79O8ap2nfD_cnSCxll7x98C_hTzu_
+MWQwFP8__Ep-hO_9rVyIxRlru_lrw_ly3m
+}
+
+AWSEntityColoring(IoTShadow)
+!define IoTShadow(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTShadow, IoTShadow)
+!define IoTShadow(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTShadow, IoTShadow)
+!define IoTShadowParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTShadow, IoTShadow)
+!define IoTShadowParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTShadow, IoTShadow)
+
+sprite $IoTSimulator [64x64/16z] {
+pPO7bgim34NLBEdjVyEVmSw9YVWCddvFfLorA01z4yp2_55PFV56DFc0ROad8OksHCziQhsAjgOdaCRK4GSGlA03yFb-pPK0dALU3Y3k-WvuEHc0tgu-gC0n
+zARlfvUBve3KAvqVwLah--NhJknnEL1fHDm0y6Nv_MgYuYE3_zyF90q_L5KsT933Ywi24a4x_MusOneyVBkOi1nzmuQz-0A4yfdD3im-OyVq3Hj-Fvkjwfe0
+qfw-0cQ7-UrOO2FbLGVGrspoMol-1bkM09ozrSddx8awsVr10v9dtxi--oIvwwOypXm3U5dSexyXGWr0wj6lUs207ltGdJw0hBu2LXPtyfze0wJu37XPt5FV
+lFgznDcFrukoetWZwE1NfUPtwjXuV5xdRm1NloD26zVzAs1r_XqHtRYUFoVow5Vgxt-wJnVFhmahyOudj21qjV_4XzVUDHedps4ER8I_H_F4-NkW9UxYJ2Um
+UTuWZEblq-8CkwipJia5F-ELDT-8I9jDI-UhVc33FkmxTlI3FWCXEWqYrtm1xFWS-41-c_BZP_lVX8_FltioFb-OF-Pt982G3_k27LdqmmO9k0Envizuh_t3
+VX35ijzuu40cu1-T7oSsaZ_g4xU8nhJekpunqur0_jJpZm9dEDr6pg1luHy
+}
+
+AWSEntityColoring(IoTSimulator)
+!define IoTSimulator(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTSimulator, IoTSimulator)
+!define IoTSimulator(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTSimulator, IoTSimulator)
+!define IoTSimulatorParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTSimulator, IoTSimulator)
+!define IoTSimulatorParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTSimulator, IoTSimulator)
+
+sprite $IoTSiteWise [64x64/16z] {
+xPG5ikj030HdnAlxt_U30ezXdSAKEs1iaM4zAISd9vLPn-rK0A0Vr1sWcW1IntJ6wbuba2Ej0zbhKEotq0RlUoYkRGGlNIjosoTVQd74GxuX7gfVa0VcPtrT
+JSYsdWIYPxK4h4qz00NilnO4mUnDFJe8Y12mPNi175Dx6G5gpXxyAa2PQDnFxaLMpve34IfMt-f9_EUbMFAbfU7xIGgiabFyMtygO9P1lwiUCYVwPxvDMF97
+Fmxx0VXAGkjZ_wMGMWR4byCJtB7tlXCt93_t2NYPI1HlMHpmMsNC4B5oW5_cdygTj_mowMRL0CQyah_CFxSwzByz_RT3gXGs6sK0_zknlgHNtEr9Nzq5UPdW
+Y_rrXB5dNL6z2jBt3cDjF4L1Q9LEtzlCD0dCd-IHzp-qNCHBCIFSPERjS-FGQktJ4-7bUXoBCFPnQkodvEJav2y
+}
+
+AWSEntityColoring(IoTSiteWise)
+!define IoTSiteWise(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTSiteWise, IoTSiteWise)
+!define IoTSiteWise(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTSiteWise, IoTSiteWise)
+!define IoTSiteWiseParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTSiteWise, IoTSiteWise)
+!define IoTSiteWiseParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTSiteWise, IoTSiteWise)
+
+sprite $IoTThermostat [64x64/16z] {
+xPU7VkuW2CKBYiBxl_1LpZSakRHspzFXByH_1alpyCNKjC-Xgj8OM9N7GAfrMhks9tbJvysSDtFUp7crdypJrE3d80CSGp4hOs0pcTR1qzJ_wAAsBIrdt9wb
+SkJLhCcccfaUS3AJXss96Ptuki_NBPwBj24f_0AUPOc72Z-FvtO1XypLEEERA_0LSF59LF0eyJoeUM3G_JpDctTTOjJn2BJm48fwwivJzmIhzoJXmHOrwtJd
+7UgdzmVUoItjVdk-s9_stvo69ActssaBPnxZAoOTXDaTar8Uez9Y5bcF55pawvHS-BQM5jTcnh58suKNnuxnev0fWmQ_1fAEyTE5bn1eqSXJLJDPU7Nh58DN
+qmupWBBoeiw0PySE_kDv-TBkcShWbwnnG-R_4XjJQNtbgHNCI7c1FVSV-bJaUQeuts9VgrqZZoN0-U9OY1_u84vvwBNyQv__jVxRZn-Kn2_apwFlBuVyEUVl
+SRe4WyRyFTLFU07gDjGfF7widtFzzb2jgh3azPlt3nue4LoOzu-yVy7N-9_thxn_ijyDBIphdtd_XcVxqaws-lUwJZ0Q3WTxvFFr2nr3jM5cidxbwsS9QTkp
+zJDVlrKsrk_NxHzUltzv_VxfzVktr-yVaMjIDpLmVUt--RNxzzT_F_nzVxt--_NpzGy
+}
+
+AWSEntityColoring(IoTThermostat)
+!define IoTThermostat(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTThermostat, IoTThermostat)
+!define IoTThermostat(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTThermostat, IoTThermostat)
+!define IoTThermostatParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTThermostat, IoTThermostat)
+!define IoTThermostatParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTThermostat, IoTThermostat)
+
+sprite $IoTThingsGraph [64x64/16z] {
+xTG5iWDN30NH5Zn9L_jVSARy7OufJCSCFQWQ_Rlyxt_J5-tzpKYhZpYNF67SMDJe4qO61kQH6Mv0p4UzcgoHzY9r6kH7VM6PkjjL6TRxoVelVTmzPi8zCg7s
+tNwA3DgurE5YghSNO5nEqcPpgEACcRQWzOxqImU9RU5EoKpQmaPFzUNhPHI0gu1xhqr2J-pX4kkt9abyYvFKcjtth9_rYGU-JlXz_qzGXpZS-YrYd_OZN8QQ
+xuz_SJ6fukXaF-rxk9XkJKzTfBgC1kW3vrNlc1hpqFTM4jpaFkzz7HLdzKDXZX-FUBR-m0oNOSQFLrE0kU41ZwUWx78sxT8_wXioC8Tmg0TzH-jkCdpqdItS
+RBQ8mFhX_jT-Fqe_seN4yTt1i7ayVwNl5sKcRNlg4d2CcYGUp-3zg5TBwoZ9EO1BIi2vM3hCWxu9wK1qOcekLiP84m77RpMkH-wJS-kaAO_f-z_NSIpnUZB2
+GJUcZgET6QqKj6uC38XTFR95RXAhdG2y96E-WcEkWjGJOuoSsWOBXxD5z4YNqKwqdjaaDsWPHrBRxItOFGjgzSna5wOYL_VhnPnqplsZwOKqoFt-e9bs9xaj
+RepMSutbw4VzE5ZfugHUzjwZFPpLPV0zU8squuHU6GDCW_NkoZdhp4hRHkYrgUFa7iWwHcWmQISXzPQLCNkCIsgLf1Aiz2vdTbMdPkUCd0EfjnMndQrT7ODC
+ecVrDgSFOBK9QM2p-e1Zs0byWrvLj3uJnEmwuwPVfU_3ZklN6yEEVeCP_Stzxt_V
+}
+
+AWSEntityColoring(IoTThingsGraph)
+!define IoTThingsGraph(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTThingsGraph, IoTThingsGraph)
+!define IoTThingsGraph(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTThingsGraph, IoTThingsGraph)
+!define IoTThingsGraphParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTThingsGraph, IoTThingsGraph)
+!define IoTThingsGraphParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTThingsGraph, IoTThingsGraph)
+
+sprite $IoTTopic [64x64/16z] {
+xTS5ajjG48JX7fw-_uKJQMVPeZ3ehtBX-ypGniz87dQQ5nzM9xbm8xdWEzxLLpqTUCrvpHV9m4j1igvuroOJKvAjVibZhk25uvoNq2SFxNd5QkLFNcF_EhoP
+uo5DbiZ21UEJxJiyIHR6Ow6rN0GONoHpZxTZ_5p1yF7mthu2dRFZbt9EZvz7fO-zauRt7kvuxs6aR_fMZF_KUEqzJuO0Pe9FYHaWGUvxCaS_k8OazxqtbofS
+vHrLZ-9I-vu7h3XrrzJDgGpOzlCAUJOVrEdpwkxvr_kRwoslzo9V7y-Ht-cVzBU__UrlV_lRtzwElMrwdVstcsxlJyJil-raFGBiN467OYED7hwLzImj5RnB
+T5PP6_PwtNzTbHbVowpgr_sttz7-EvbQP7Ntwhehm_HR_qZZf_O5
+}
+
+AWSEntityColoring(IoTTopic)
+!define IoTTopic(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTTopic, IoTTopic)
+!define IoTTopic(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTTopic, IoTTopic)
+!define IoTTopicParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTTopic, IoTTopic)
+!define IoTTopicParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTTopic, IoTTopic)
+
+sprite $IoTTravel [64x64/16z] {
+xPU7rg0g38G5qkRzN_Xgpg0db_LVtTxc51iVXXJAzel9me-BHBJzqYFwVcaHiktoiC_oYEI1v87aWUG3VpBV3XdYk2ZGzyi0ndxfWBPT0Sj6dwA7ux5yh3XU
+QUd00TE7Ci2tgWROYoG3siBhSrw_b6_j5T_DzMee7WXzmNViYlaGIEd_UKkjVE81Z3E-OHg8v95GkXmK-MPkqecB03BnOoX6dih8nw79DmUGlphm7i3PLpQU
+V49UnqyyCANijlFADBdn7t5lRQW7A9EM-4oSyH5lQMUgYmLEsOoxVnW_gTLr64ASVu-sy798QM6tz9xmC_lG4-yRUKriZT_iGTjQeHElyOkJfvf6sjpB03sD
+htoSqrOdpyQoz921sIw-9tQV_yEhAntHNjKl7T4ByfWlyM81Z6seh7m_DB3oSlwUcMl83fCVYTNuLGrEizcgXab1tVCiEHhEr8uHyCBVsjyYyHo4SpJHcAR5
+_kA_OLHS1N5E0QeS_wt_1ouP3TMyfGEYR_Tyukvno2S-DaUsTkA5B_dRQ-dDWgDlb7Z9tnAOZfHBl_0hTpiWI_tK-7LrVh0TY0EZwvLpN-Mnp1zR6nRiBMET
+2iISUzVvOyt_hWbSl02IL7jIFtGGUIPJC1EVyFGLUGA3RHxnoPBdPpywzOKlwrVTOJYRyrdOfgnVT_Kdm21_BULh_6xNxmP4sINvXPVr-sx-SjHTsY3-TFxJ
+WcUQROzvHl2hzb-zRm_vhzy_Slyg3sM0V-t--IltxrztVlXt_lgAy-klfVy
+}
+
+AWSEntityColoring(IoTTravel)
+!define IoTTravel(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTTravel, IoTTravel)
+!define IoTTravel(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTTravel, IoTTravel)
+!define IoTTravelParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTTravel, IoTTravel)
+!define IoTTravelParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTTravel, IoTTravel)
+
+sprite $IoTUtility [64x64/16z] {
+xPTNmjmW30ON0K9p_ml7i8rOBk1DppylhhD57_NsXw5MwY6PXUKWPh8SWbcgTulfgOyr7veFpOVc6_-o7ogArKC6MGuHud8Go671q53PicDXc1AzpXJk0mfe
+7aIXhFG0Ej7883W_Z_lvp0-EALzPOpBZ6uwqwsjZvPVKaxslZNf1m_izthzpxzILsTzlbJ9Ll_dyCiX4Vexatli9_ZEXwalw3eMSxiJG-y_xg_m21wXivsU3
+FgIrRwzQozFFOHE9fVk0Lowh-hLnSey4YAkVztU9K2PyZu9uNohnwQjiSTS4qjEFKXdEJvjdgC-lzuqzufxV__vRY9jaxqUf38w_udrV_sDVqy9r_udp-_Qx
+GrTNIwxzzlrdd_1We__W_6rIYQx_hiQF8mJCZHyJywS2UMxyyn64otu1XNpLbnfzWU1yDt_jT_q8oSrVO_bP7Nh2Pl_JngolZU7_hw2nG9gfd-y1TZt_0fI9
+_1qYrN7-vVMZRrzf48NoyVhvy_Nxv_k7h_tN_Fxr3-CR
+}
+
+AWSEntityColoring(IoTUtility)
+!define IoTUtility(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTUtility, IoTUtility)
+!define IoTUtility(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTUtility, IoTUtility)
+!define IoTUtilityParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTUtility, IoTUtility)
+!define IoTUtilityParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTUtility, IoTUtility)
+
+sprite $IoTWindfarm [64x64/16z] {
+xPS7ZWGX30INQFV_FtmqdEH9BA2B6qfXOfbimUsVaLLuYQgkNBogBnUd6lbMD0zzQFM1wWFL1wglU6RVaUBpaefOBW48vUA1v0h5T-JA3e9f99nrB74A841E
+asH03heh-i8a0zp9J_UT6Eq-hVkiu1TyAl4BlbDef_wvGdzSl3qrYm_u94qNJx_H5ZMXFoxU7fN8LFkj-FN-i-A_u5lngxuLt_SZIVJ7nPkVgZOUFok-Dtvw
+r_SfmuhV--sz8xxZfylGDRkHKVy55W8cqSd-Jtc7GZrpSPhr1GV4qdR7zoHy-bbq2w3kvd7X1qz6unS1bSlsDuRZdq7KtV6j_bT4QQtertyy_xC5M5y_8NWB
+iEwtmSk0k8vlyxVlMmtEyrT11hu5EAqVZ7qBiFTX-MFWMu1T_fZilts0zVwtlP7_Yd_BrB_WavClIbPz9J8_VltrbokhVhE-slu7yBrt0_-B-qVRlyP9YYvV
+tJz_SV_-jVF3-_prXVFh_-83
+}
+
+AWSEntityColoring(IoTWindfarm)
+!define IoTWindfarm(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, IoTWindfarm, IoTWindfarm)
+!define IoTWindfarm(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, IoTWindfarm, IoTWindfarm)
+!define IoTWindfarmParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, IoTWindfarm, IoTWindfarm)
+!define IoTWindfarmParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, IoTWindfarm, IoTWindfarm)
+

--- a/awslib/MachineLearning/ApacheMXNetonAWS.puml
+++ b/awslib/MachineLearning/ApacheMXNetonAWS.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ApacheMXNetonAWS [64x64/16z] {
+xPM7Zjum38D9oKFg-xzlfucBSxxVJZ4wYP7vGHFqfzzL__LVcH6PFyT6SyDtMMdnD73xpjBSZG3WxKaQZO3L64ZsQW3RSUO6b5l6uO37MV3rds70IGeLg2--
+x77sosEV7eYwJPxnSTN1NGdTtW9c1So0cc-VmNmmH7vDj_8wkXvFXlWzLXR07YoW68zh6qe-eEjztHgdDknw2Dv_pafOF-FNYzO0E-LLxjIGBTzYy5IvSqFu
+ca-O-07SkYU-UQxuG16Vck1rUYdU4SkservuRP2svy9Nz6Nv4wyDrlPEVDlowflw-9INIDrj-OvonfTr_G5_mU_xdsHkUVstaYEqFnClqUOyxwgZWSGwFZZz
+jcY0ZJpOtlED8wwjoXzWrzIjptmtRK9N-gi9sjstoRkFst9w-gR45OzKFYhZbGi4c5VxRb_vSJEKHBmylNoo70DiCYFVd62ECXzVym5Mu1lhDfJ9YaVXmYrt
+tazuVl39rPvD1kpBwN8VNNqhxveSvVmCwmIyN_sxEvJLYRBnxjziUGWh8giUAfND4sLETx-X_kk_lW
+}
+
+AWSEntityColoring(ApacheMXNetonAWS)
+!define ApacheMXNetonAWS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, ApacheMXNetonAWS, ApacheMXNetonAWS)
+!define ApacheMXNetonAWS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, ApacheMXNetonAWS, ApacheMXNetonAWS)
+!define ApacheMXNetonAWSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, ApacheMXNetonAWS, ApacheMXNetonAWS)
+!define ApacheMXNetonAWSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, ApacheMXNetonAWS, ApacheMXNetonAWS)

--- a/awslib/MachineLearning/Comprehend.puml
+++ b/awslib/MachineLearning/Comprehend.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Comprehend [64x64/16z] {
+xTG7cjim34JXGI49ZEz_tqHqBzHdCZthVulhWxhuL_Zuo5OV96TKF9AOwxtUAfC3Akg1Dm9zm4pF-zvB7x3Uq_k0zVv-m7n_Fs2-dndG-ppRUkilxmVizoau
+QGnSQBxRwrbZcfu0x_QlwJ_Jfug8PiYLJ_KzMU_9pEp_BtxMzaSnLQ-vqXlJSIHrhq_JHuKi6GAfaTaSyBqUJuna2ZpPXQ2CU-Opadwpq1IqoUqFIFAYmIRx
+Wl9mE4Pz-aMUdbVI4BpXQAC-S16dv_gqm88wwXaNcQV7cVxU_GgVfz7GvlhQ3vy2w8SOCjv_vIfl3tcGrI4UToV3tlv3ygBsHIRiS7e-whDT9S-23cbRJnQW
+pLv_rkX0RdtP1itsAab7stf3hDq_2cBRVaFkz8UztXnIP6_vQg-XzoV9WOOXpSkH2Gxb61agdNDD0AegC2uob5eLZOiQDifbhNuN_8jyV7m3
+}
+
+AWSEntityColoring(Comprehend)
+!define Comprehend(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Comprehend, Comprehend)
+!define Comprehend(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Comprehend, Comprehend)
+!define ComprehendParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Comprehend, Comprehend)
+!define ComprehendParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Comprehend, Comprehend)

--- a/awslib/MachineLearning/DeepLearningAMIs.puml
+++ b/awslib/MachineLearning/DeepLearningAMIs.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DeepLearningAMIs [64x64/16z] {
+x99decOX24CFY0fv-r_l5APyvHNllwddzf88KVrs_ES_jLU--NQNBh0CyD8ZwO2bZco8wSy6POmru6pWB4c3fRgXO4gQX0uKrkM2tGFL7_sejzPlpE-vhE_A
+LNr-o3Iaxk94mWXxo7ex61wEbKwK0KHWULEFp06Cr95W1bkQj44E6BiBozIPmYf8gGqgm5jzbM2-jBuDm5QltI-aBf1OgVMg2KG7De3ExjhijNuP34Bb8ISc
+fkdxml2jtmwHMbK63YN3WNrXU0N-OwxA28UGfc5nC4XSKlejT6UeLhNLIirtK-YGdVrI0ImrjrMmLaVgXDuXw8mdc9Dt7StltqPfu-_BBG8CPkKiDUKENVLS
+tObXdky7dn3ry1OBLNyhPsiQBBt1OdwluexCRdSJjr_MvtRhem0048QXg7_NY7X0PyviskJxV3s_lX_-7zOFro_s3_Ol-WVv5_kd-pVdX-QNvgVcj_A3yWlp
+a_ERywFpQxnMgmC
+}
+
+AWSEntityColoring(DeepLearningAMIs)
+!define DeepLearningAMIs(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, DeepLearningAMIs, DeepLearningAMIs)
+!define DeepLearningAMIs(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, DeepLearningAMIs, DeepLearningAMIs)
+!define DeepLearningAMIsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, DeepLearningAMIs, DeepLearningAMIs)
+!define DeepLearningAMIsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, DeepLearningAMIs, DeepLearningAMIs)

--- a/awslib/MachineLearning/DeepLearningContainers.puml
+++ b/awslib/MachineLearning/DeepLearningContainers.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DeepLearningContainers [64x64/16z] {
+xTHdTiD020JWeIqmkVzvKrPErLkluj_-t0i2pnFcBqzFJs67v4CIDz9yX65qLRLXy5ywtzM0SYf8VgZhZQUZRJZzv-kzXCGxXnqlkcE-lfg38bzkZsn1yiOH
+l630sBVyLU3yr8BcLWiW4aUzuBC-cmmujmBoBhxdhraEcxaMDnfeJhE40_wPHG8mlilYqWnf-BkZSmlStM3p68Oa1n1ScLKAVFRYm5HCA0Cn0qBSIvyrDQUg
+CZZPdWqq1w84oGKzdMOl_Ndc68AqsomB1Sa_33OV0qgsI9EAMYUubcJFrexaGezOIP8jHxrwPFC1YlvSKOa-TT-QetTL3HVOUVVtb8UNW9wtHpVCWbCxf4xr
+mYigmkMp_9JEdfxJEnYAUmdDQl8iCBXdoEMH_L9xBinTsL7aVhIrWErdMwlx8-ecmHOCtb50SQrrbt3ScwyDnWs7rBgxDdSSYv-O0clk1Q1vRkw0yv9IG4Vn
+Xt90abVbN36FpAhAuNfQk9qAnGywcl_LESBDxDv_xTFJqni
+}
+
+AWSEntityColoring(DeepLearningContainers)
+!define DeepLearningContainers(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, DeepLearningContainers, DeepLearningContainers)
+!define DeepLearningContainers(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, DeepLearningContainers, DeepLearningContainers)
+!define DeepLearningContainersParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, DeepLearningContainers, DeepLearningContainers)
+!define DeepLearningContainersParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, DeepLearningContainers, DeepLearningContainers)

--- a/awslib/MachineLearning/DeepLens.puml
+++ b/awslib/MachineLearning/DeepLens.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DeepLens [64x64/16z] {
+xTLbmg0m38JXIT96XlkVTmLPjvJrZnVvz-2q_FjwUae_2fOdmptPQUAg0fC2O3PuGgOVxUTtduB65GJcne_Q9gBb-Kb_ngTxhliq0B1Sz2NGEHLIQzumk6qS
+i2LV4DAT5DIAJnW321fopIjJ9Abhde9a5HF29U-G84FWQvu340465pt3H2pkVl__eZT-adLyAUIJeCKVBsqtP_8cIxQgY7JiUKOKcrm1TTWO1bT0YwqCmyCH
+snRmy05ZfuIIp2Yo8lVBoURy8sTZ6nBQct-eaAl18Qa2RV22Vdx4wjp-u2UDvlp7EUxzFo95bbcHh5hqWPsfzhqPh_ENIC-d1T_Nz6S-zxql-lVtVyUdIDxn
+hE8jdtdB9v1tVApxY8_swSM_hQUdrm
+}
+
+AWSEntityColoring(DeepLens)
+!define DeepLens(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, DeepLens, DeepLens)
+!define DeepLens(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, DeepLens, DeepLens)
+!define DeepLensParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, DeepLens, DeepLens)
+!define DeepLensParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, DeepLens, DeepLens)

--- a/awslib/MachineLearning/DeepRacer.puml
+++ b/awslib/MachineLearning/DeepRacer.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DeepRacer [64x64/16z] {
+xPK7ZkGm30IBfCIW_Vz_RmbOs2XVHdGXzi3CBSpwJpmyF3nKDNyOwqC5GCI6PwsVulCT1Y3wYWY0HlmiX_8UcN5zNyR5kCsGSJ51ubrV86EEOOBakYVy5VbO
+IBUiYTpFKD2CJtjPguPQh3MOFwrlsDUy2k2hZWsKQMDca5_JOYlGdYKFosFpNOiJdINKClB6QnckkyESDc9T342Ghb_7tKq5qBmgDbRx1DFelSZn0AMWDhok
+Wk8PkcSHL62iGjS1VN_qWROehxUpThB43k6ElHTIAuVizWlDclWAnY5-7wOZIeWL0kDTSmwv73zCVrdR9Rhyx1mpgzCrAT2XWpYVtrU6CrlreMV8CDlvtNFT
+s2U0dCXUKA8E_kdS1NMiFmA97J-OGlJTvuSbuyVzXP0lru9BPFQv1RfYXR_IGvtkLoBUeHDlcLYlAa69bn0QIUJWlnsm5nJC7jsHYHWCTnU4UNe_mJ2grtOD
+wXrlI0fNqmPIv_XEtT-eQdJy81DqlVq3TFAR-au4DDuoHodWcPk9bKWT_USEKKtBAiES3xWT_JyG1NydGViHRPH6Zyz_WCOxAJ8_V1iYeltJYQgpR7gkVyJ3
+myF33m
+}
+
+AWSEntityColoring(DeepRacer)
+!define DeepRacer(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, DeepRacer, DeepRacer)
+!define DeepRacer(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, DeepRacer, DeepRacer)
+!define DeepRacerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, DeepRacer, DeepRacer)
+!define DeepRacerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, DeepRacer, DeepRacer)

--- a/awslib/MachineLearning/ElasticInference.puml
+++ b/awslib/MachineLearning/ElasticInference.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ElasticInference [64x64/16z] {
+xPQ7ZYGv34EV9CiAy__VUy7TnkGATqYxEqJiy0gc8BBSlxT-zAFwBr2ePIzD6NMNBWFmwWu5PDx37JIc87E0fOFcdQE3TtSDGAAxq-2IYKr5BmLQUmWNJKn1
+TVE9lNsidPj8yFPt_5OgTkwTqJq-yM6ZNWgzmPjLRpu0pRZAJyjkuPKVk05N-IMHLtuYCCO5Fh_aUo2pwvnFGzRioddBTrLtWTVPwWXOzXIOtVb-xHmaleFt
+ZgM2B6wlSbNjuts_H6-ED-KrBkKWWjNh4lctl7PdzTwVh6sADr0SyUNOvajaxkydexV9xtb1M8mlVkpKspEGLSVydbezZvi6SyrWnFfMyv17yZcnFUM9zTP0
+qMDU7yF7Ky4_v5UPGhx42JyU7YROUtu2uFE4htmKVWhLyORlQJu5lkVt-5phaHy7-zphVhY_5Ggn_0eV-JImwkzKllEppi-8zto0ngNybeF6s_ncp8YrNNNU
+7xljDvz3012lKgtJ_jlnJQpgKGlcqmr4iJxZSsSy0IbTXwcgPOiwuz-w4JN5gbm0dGFmItpcukt5iKu1DGKOGXpEZr6xFZiPXTIkGGCEto9xz2j43zwPBSnd
+VOAr4ISb_3Q_Iat63f0hkIr-gtnpVnXeA_d4hITUsy2nYPWWaOmMpCnWlr64kdG9mQihieIdehiYE-BM_QrpoSJ_xpNoTzEFVlGt
+}
+
+AWSEntityColoring(ElasticInference)
+!define ElasticInference(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, ElasticInference, ElasticInference)
+!define ElasticInference(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, ElasticInference, ElasticInference)
+!define ElasticInferenceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, ElasticInference, ElasticInference)
+!define ElasticInferenceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, ElasticInference, ElasticInference)

--- a/awslib/MachineLearning/Forecast.puml
+++ b/awslib/MachineLearning/Forecast.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Forecast [64x64/16z] {
+xTHNOiGW38JXaGG2JUv_tZIb5xoGdkL_SVtS3R-htMxNH5MTRnPzMAG7KFbc5SFoh3xoMWRrt0Vslcyyg41Q4t_F7pqOWtOoEET3S9-bdVCLQbabvtq7ueBP
+YY-ehTxcP5EVz1r2msqIRAYd-QWb4pWDjRdBZ7VSPwGXI4vvXJz-zuO-wJkKaN7QvxoB013fAruG5QAgm9oFsnei5sbplW5PM_IQMQpvnzPyUDPNFRAoxCMh
+bmzu8za-uFL7_VRswDkZZvEz52kQNgzd9RqLCyn-lrddpFZzE6Z6wraU-XXtu24O9nXuLpbEdP_KRhUx0W
+}
+
+AWSEntityColoring(Forecast)
+!define Forecast(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Forecast, Forecast)
+!define Forecast(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Forecast, Forecast)
+!define ForecastParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Forecast, Forecast)
+!define ForecastParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Forecast, Forecast)

--- a/awslib/MachineLearning/Lex.puml
+++ b/awslib/MachineLearning/Lex.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Lex [64x64/16z] {
+xTG5ekGW48JXWgQjSl_xBbc3F9aXhCi_BbyS-7lql_-5lPSlyO9tQmlU8APlXxBaxU3RbKLFvZL-UbhsYKlA0hGxNYuvcuZTy6_s4ttMJoafzNDwnvUlrqiT
+rqxUFt_pcVoP-w_jQyheJtdB1qQ52k2UJny5ytmwAtLZ_sFa7dFvdZ_MPeEQRtkPfXg1N6gZ2dim__ZvrhfFljtntebECrCqCejSlLV9XGkb5z3EePDtzm98
+M2vuXtRUEBoZrog0aYjUwic7RwZYJ9K2N_7eVFOAFKAxg8YL_UzyzbuG0Q1I8VdKCvopJw1Hu0hB2Xd-MSChAzAxaGrF1T80bFvS_9OVny-bnJX-zto3Q8Uk
+5RxZ5JqLz6B7qrG1L6lEBTzJb61lrpEd3yUYLviAdgMTjHLlkEOdB_XKy7bkKmeu6QZdUmlUpW3lNWzkPe1tp-qCQFj-J2txEM3ybiAJlrF_-zy7
+}
+
+AWSEntityColoring(Lex)
+!define Lex(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Lex, Lex)
+!define Lex(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Lex, Lex)
+!define LexParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Lex, Lex)
+!define LexParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Lex, Lex)

--- a/awslib/MachineLearning/MachineLearning.puml
+++ b/awslib/MachineLearning/MachineLearning.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $MachineLearning [64x64/16z] {
+xTO5qXin30NW9xBWl_zzErPuo7RARLvewLibfWb-LpwXsoT1ncaCu8SVNtMOVFNrce__-3I9-UcUxtWd5bXVI1gdFeIixn46DmAF4vy6H6-mY5Ib4tBNTrcz
+NY-IlK6oNpzWvSWocVvwI4zyr42MKlkEGQeYjxrBbZtv6X25RlkP5ry398Wzx_sfxVrc8XEwuGS1bXK2dLuWzwg6N7bdo62GWBocBoUAExA5J_1aW_hAzfLC
+MPtUMdZ_YgpklmfDaQUo1kYo_Z3OrJk1vDgICq9PImzOr_UvfsW_qD2erbwovm_GpIxj_S1xVsyBHVVVQ_tSyjAba-dccQz349eBFpUpdsLNtutHIS7ACsmA
+6jDVsiyVlSQy6dzfuC7TU0OY4fS73upr-0_kCTYjM2B2VYEboDtv6mA9v_bRGaQwl_vGbtruczV7hW_BUl46g_0wM3zITFe7xspu95YMWSQpZsrVgI26PKqV
+8_josVVT-XHz8nLefH7qnFSwfeDWEU_Ha_7CFsPBe7_AiQ-yrepyn___VBpbQUB5lv4Vvy7oJlXHbjuA_eLy0m
+}
+
+AWSEntityColoring(MachineLearning)
+!define MachineLearning(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, MachineLearning, MachineLearning)
+!define MachineLearning(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, MachineLearning, MachineLearning)
+!define MachineLearningParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, MachineLearning, MachineLearning)
+!define MachineLearningParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, MachineLearning, MachineLearning)

--- a/awslib/MachineLearning/Personalize.puml
+++ b/awslib/MachineLearning/Personalize.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Personalize [64x64/16z] {
+xLQ7akim25oQ1Bd__zwxYumqwQIy_hBJBCOBQ2dsxa_56s_4QtGdUv6FLno4Avvs45q806WxFQf48u24WJwEJFQ8Xyw0z9rF-au1wdVJ3H3VPwsByuWKUZ5M
+9yYzT5yYVYFcWUzoOE2D4SOOO8lfm6hfPdG3m6gc32Gl28M8wvKGm3orCq0YdKULlMIgWn7kCRpbfHHMXHz11RAwg1qOeaZ0IG-oQ80Aa0viIw3TJc2a2yHA
+feyHc3Q_fuOsOirt6N5W94J9P_Wvty5R7viM7WASOkulsyOf_HWOGAjQIES3c06VVTtt5e2lCza7pRA1CM1JbJvSmczKdtpnGq3Mkn5ayiSOset90yXd_WgE
+mx7HxEmRzmO8clhvQZK78lKhjfP2UcJz6knZityeMjQlG81MgoXO4WnDOmM1prvL7C0sMuc6DJ_X1rZpO-p5_COQruKqv4WLewE7-oEnzeT1NzbV3efwVyRL
+_SbezVg_ihzJX1fvrxFlHufG8WJavsRdfDTGm6BnRCwonWDVVqeFlY-86-KUlnEXe4WwAUCiU0dV9E1LWUTW62FzFApwSQcrz5T_OlzKlF765m
+}
+
+AWSEntityColoring(Personalize)
+!define Personalize(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Personalize, Personalize)
+!define Personalize(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Personalize, Personalize)
+!define PersonalizeParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Personalize, Personalize)
+!define PersonalizeParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Personalize, Personalize)

--- a/awslib/MachineLearning/Polly.puml
+++ b/awslib/MachineLearning/Polly.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Polly [64x64/16z] {
+xTPNOZ8x38RXJx8w-z_lcHfYwXZEttaIkF8hffXIluMFZtJxnckKeoCroD1CDyRZ0mnsgir9ne_0eFL5O0nvfuzao1kzLpzWlEy7ZFVTWE6UU4A0lDGROK7W
+b_hALGptlMmwtlVUxDErJTJpGCyqu_BfAPTQ21kIFDpRzBoiZYcpc9W0q6TzhghcfyNvi5E1bkzSls1mFknLUf4oswDiQ0zxNB34B6gJ3AixqhF2Uranoze5
+AEibkKuHQDtNlNPtR268zG2uxagShSlDbYU7R7qnecuAyJ8zoveGSawMtcKUfh21-q_aR6thmTkoaTwWNtshAeVyZ3uqzkFthdzm_7Rgf_NNRpj_WT_hMThE
+0tnv_zpcaf47lh-b675h_pXQtH7VP1darlvjy3eawTRAWSzp1yMjgLa7wQq12gcZ1EJTmUVO0PG2RP-Gpc2hqyW1b3D0ecRQ2220BGbHntd3YffND80PyiBl
+oiYQnJ8kwcNB1AztXDVluUFZFm
+}
+
+AWSEntityColoring(Polly)
+!define Polly(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Polly, Polly)
+!define Polly(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Polly, Polly)
+!define PollyParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Polly, Polly)
+!define PollyParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Polly, Polly)

--- a/awslib/MachineLearning/Rekognition.puml
+++ b/awslib/MachineLearning/Rekognition.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Rekognition [64x64/16z] {
+xPHN6jim38D1YGk-_u5hCSfgFpcZkmqUl7yOXCVsf-gZZvZXxf5y2_Okc6gMh-81GBgQk_KsBE8rFfjUSzCRq5xBmA_oTC1UBp3ZKfyB-ajmTBchBzih1Yw0
+D5Kj5-LmVDw07UZ1sQK9nClWoGvIxkkceKWAyXZan7MxLqWPEDfXR14kOgPWZD0HHwLLGGhTw6Osivus0-1kSnYW8SSbmetOvJCKQdg3paiMckPzS8JukVy8
+XPtBSzX1V2kIOzdsHOujSek2h4uV3A2Z7A-OR7rJT8vzOOXVuZLmFJwdIKaRJwauloQfy-i2H7XRq7b-Fz-mZrE6M3_z6U9uFlzvF6_vovgtlAtuGkUG9OiJ
+tlDsVbtEN-UdFptcbMmWFI_v-hh_GXDzExqceSPjN-fywG9zcYmKXGfuuY-QVB_O7nReqC6ZjPXZDO7DxweoBgNmiK3KHpUlP3jjjh5WfLif9NTSwWCUch5g
+KskY2hSM1qv3uxVT2X__00klPTpxAWfKw6EyxWRbbNQ1PALlV0O_rTSzIMQOJBS0ybbSNN1HBoo0U1eVrrjlkzGv6uI_WjyhUtMwbjtXwRoZjOOuK4BoZFUn
+4FLa_N_36Y2-7SgX5xnkMFN9Bkng5US9ll0IHts3R-ep-UFyEV6pk6jxJWfHhURV4nMxR7jVwJNetwAFFle2
+}
+
+AWSEntityColoring(Rekognition)
+!define Rekognition(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Rekognition, Rekognition)
+!define Rekognition(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Rekognition, Rekognition)
+!define RekognitionParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Rekognition, Rekognition)
+!define RekognitionParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Rekognition, Rekognition)

--- a/awslib/MachineLearning/RekognitionImage.puml
+++ b/awslib/MachineLearning/RekognitionImage.puml
@@ -1,0 +1,19 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $RekognitionImage [64x64/16z] {
+dPVX5gCw28GDIO2Pzt_WkrOufh9wtSw_LZy24yA9sxrag8Exu3Pa-oTrTNxBjR-ccnC0uQQxp440zDbU1Z3GPszdG9c6NIyZT9MQr7GIthVVDHoajkrtJH0k
+xusK_aVh--8aNjKWqq22867pZA6l0WmdWEWV0FIHTS__3z1tch0vzlod7S56nYOXJrKR2NprcoX0Mb2Jz7PVk8ErKTh4cRS2UflxkL1DYr63a_qUdxUxdm44
+n9hXoAuI4EFULsG94rXNSNYUF8wdZM6kwsi2Wn5DGJq2LUNUsJUo1kkannPKUO-ZFP99N0ZD_-GeXmNdyNvBvoROJry_M8yu3VHnbIKNZTW0lRXdG8j7MLkO
+SN0jWmU5U8nS5hR-aPha33uybZNhhSUMZwpemeF4maiuB-JuAb_pZGjlW0KVYLiKObjofmsLRtEsbJVWOfidLVX0SfMlV8tuoeUOLzvW2P79zpXyIgwy4EF2
+6uXirnzu1KdeZc3XXUXHnpsVW_9p80MaFwrVwyynAI06o77wFqX9_jx_d1M3v1vvLl-1s_sVvo2Q8FHf_qVjFnhEGQIksyeZ-u_wrV-T7CcpJD7I_-VhzVoH
+PS3Vdx_L24dUBdWz_rd-EOea4zXvlSWlyoU7tievaKCILn5-l4jV5yq2v6Y8us4pL7aSki3sEAaEbsXtwlQacQcEeupGE7n5Tt8-u8DC5udjLE3oiNu-uf9R
+DIg--rElQENgaovMF09ulxbN1DwSx0LVxmacLrgNgvyHMl5K9mdQEAjetR3KfQJVuZbiGBZECSPK1u4iAaVf0mxTvDg2rbSNvHd_vBnyV-XPIpEym4EjoH-r
+xvlbQxogAGbRuys_uR5YeIUktTd9YhUul9O6g9T_8tf9VW0WT4XRl-K8qCSbA6X_gRrRJWpRvI0Gz4L15Eja1XGYVCfMHLh5isUdckyopM-v8YUaukyro8-Z
+_ISyRmXg_0cFUKgGcBz_L9Am_Xly7m
+}
+
+AWSEntityColoring(RekognitionImage)
+!define RekognitionImage(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, RekognitionImage, RekognitionImage)
+!define RekognitionImage(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, RekognitionImage, RekognitionImage)
+!define RekognitionImageParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, RekognitionImage, RekognitionImage)
+!define RekognitionImageParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, RekognitionImage, RekognitionImage)

--- a/awslib/MachineLearning/RekognitionVideo.puml
+++ b/awslib/MachineLearning/RekognitionVideo.puml
@@ -1,0 +1,18 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $RekognitionVideo [64x64/16z] {
+dPTjsl8g38GbtpFxN_1vwmENKQpsEF_KtY4JIAItSub5WOTGQNBxNz8eFgj2BzEZ282eZ4DP802MZui14YpNyGWedZXqCOB6xdTuaIYz_Iuha35klyj1b5ml
+fEW_zUUbI5po89uWGP18VyI8Im6i200y100iMxxzUm0zQ2BTZlmz_uBPYar2FhbE4WZjPW8WSr9ErZWtNk1-K8RZaNS0SPfxMsXBYzD3aNgE-zdkSmKG43r3
+MwTAGDXvNR4iED1NATJgF3PyatAjMpq1uumMODpZlDFSktn6UZ0bxtaatYbdQzjY5Yv4hE_aM1taHfCyrXYhSWxgewlalloCCy2oL-NYva4SGBnKBu4nV_9z
+yu2nWazg6bYH1f3zYvrVDPQUzKtdbXkedTTAUSFBhBoGzcG_WD7v016ZyyjkJYDvMrmhG-S9sCRdo_E9QbJdCKTkurk-IJpbG_WhFsprVUDrDb-GdHV2NldL
+z_uZl-OT5jyVT5pW9K70JjR_wjyn_t8QRwHq_hp-1CcKlVvZxkFN_MVfk_r_QXixFN-jZngFwHUCf_Elf7LUCiRP-TyV_xt_UY7aQlyl-tqKoSDPnQkgpPys
+z3ftAqA_p3y1go-w3CZVWM1D8wVpbnCxuYmfIkP-CswVv2jLkzjOiddSj4Z_W1k9LKMqxoSkT-l-4PUrLRRZHttsAzfszLbLtF4PeFJaNZ7nKQHkUBydfBpI
+qQv-ISIEBob9CAtTVpNHV0LP9_WoG82eS3FpA11edKnYVC8HV-bsfVOgoXVyoBczVyJ3oqXynvV6a7_gkMhnChvh18diyVmTBkCzxNWzdSet-EYNrtu0zij_
+4hebRm28C1dzNOu0orw2Wld6koOE4PM72WGQtJI9hNJY4veYokMsYyopoW_ro3gKuNhIaKN8Zb-NaVUAwY_ueGIHaJpmdvIy2_xxIoM9rD_W_m
+}
+
+AWSEntityColoring(RekognitionVideo)
+!define RekognitionVideo(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, RekognitionVideo, RekognitionVideo)
+!define RekognitionVideo(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, RekognitionVideo, RekognitionVideo)
+!define RekognitionVideoParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, RekognitionVideo, RekognitionVideo)
+!define RekognitionVideoParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, RekognitionVideo, RekognitionVideo)

--- a/awslib/MachineLearning/SageMaker.puml
+++ b/awslib/MachineLearning/SageMaker.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SageMaker [64x64/16z] {
+xPQ7rgKw28KtXEh__kzxLrHMFDLufyySxELBtH2Mtz4-zh4GhrkNk8mhWBPYqG3eDTePq7vaAi3zy7awPQkxOmperWR9ITm8vAEW3NC2sGmT343gYQZkrex4
+LDCTxP6VwuJtLkOJldhcPtmVhITyYERofVDyiXnu1y2vo1IVt4_W0o-mXcuJ_6Rtl32OwOoF5tmGUgSKSIRxbjMI8x-a-VfPpsI_oIna4n7XHdJspX4wqrpw
+BufTmbfUUDHGFCSxMFvAcaFE4cPPlpdX-I0OfEx0UICw03JU2EmvRr-BzQ9pAydsQhAX2NJy-98FNfKR-ncQrJATuHdWKNzg3M8IGEk7VCk3xAR_ANiaIDME
+AqZVyIqF8YXtFlv017_N_ttsMcZ5BJhm0ZFe2Tzs4J38xtX7DydtzTStBVqFKo8XW64d-edT_r8n-F8ZmdC-zkboXcoy4GP_gj_XFssh7u1GyQV-CwREQ-uv
+glzJ_dkC7xOlDtUyGcVYbtDfdwZqj_Cn4xz7q23ApD9_vwVYhrez4uW8vN-p_302CnEQNEPpz3yPu9paoLPQ8OVnSwzPyQdKmncGw-jt1TmAHDVpXmguhI8d
+P29_cSoVVah-Dfy_pkUl6illQ1_xs7y
+}
+
+AWSEntityColoring(SageMaker)
+!define SageMaker(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, SageMaker, SageMaker)
+!define SageMaker(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, SageMaker, SageMaker)
+!define SageMakerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, SageMaker, SageMaker)
+!define SageMakerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, SageMaker, SageMaker)

--- a/awslib/MachineLearning/SageMakerGroundTruth.puml
+++ b/awslib/MachineLearning/SageMakerGroundTruth.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SageMakerGroundTruth [64x64/16z] {
+xTO7SkqW30NGAmbK-FlVxxSr3BmEpjIKcqvoRACHoci_Cd_vYzPecQXwNJi3REs8CS1-JKS1vFnm5q04A761Au4qxunyYbomNPstZ7Qc0dK-aE_eg011-qz4
+jmMfiUOCKaKTVX8bS2mzAFwzyEwj1M73SslfJMFwaYMHRQ-j2Nnu1pE8iUd3uxpbz9RTW4sVkVF107dmsXiuMYVf-sNrh0R3rdqBqjw2XvYTqAjOOj4wMW5M
+xdzPxy-EqgScalnbzY_4PziLBNfp2tdd6HrLbFjx0dNqCVYzRr7gIUvs7GG5ZPy--KhWw7v6m90jtwkcgFUpA8lefSR2Y_SQtK-BY3Wu08xF_ho-4Z06bith
+L5I1BtrDQWpo5hSDes02syfxxk6Wt9n1DFed1620F_cxNIlw_DM-uFbSR_rzUyS9ZKWLaB6QEth3xzhRyy49G7ZMOXwGpyEtNxxaLqAUmZ8MboFOmNDwD6Es
+N2pZW2mIDpvwRdpiUnFgOVkI1pW3w1KlmxFf4PFXPSUJ3qy0GCCxRVWSOjrhFQ9y-ZwwOk-VlwK7PP3U2AJRBpxiy8Lxn53ioaiGaoYthUA75MjNykYtuV1g
+8_eLVvVBtijTlFt0_EKl_m4
+}
+
+AWSEntityColoring(SageMakerGroundTruth)
+!define SageMakerGroundTruth(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, SageMakerGroundTruth, SageMakerGroundTruth)
+!define SageMakerGroundTruth(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, SageMakerGroundTruth, SageMakerGroundTruth)
+!define SageMakerGroundTruthParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, SageMakerGroundTruth, SageMakerGroundTruth)
+!define SageMakerGroundTruthParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, SageMakerGroundTruth, SageMakerGroundTruth)

--- a/awslib/MachineLearning/SageMakerModel.puml
+++ b/awslib/MachineLearning/SageMakerModel.puml
@@ -1,0 +1,18 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SageMakerModel [64x64/16z] {
+pTTNelCg30HW98eqi_y5tsC8KOu9JhdjdvSqV-wUGFep8pK_VinLFk8LeEdyf4QWlg-pymZ6HgM2Hpo_fwMHG6aalAHK7AGLW6po1hylcJiq4fxlQtsbrKcw
+phCm3cFvQPDb8sAaoR9hIxQ_AwcRzI_HUQWRhwN8xQJeCuvng3jV0I2Fam9TVUw7klMPHt0xAVcfptTMMvNVlW6vZa_vbSy0u7Bs-ifR7G49elto6NF_zvuO
+8Ljo-FGZZIJofJyak_S2MFYUYl5-xuiON4GQ2A8CtyejHigrpybWntkRjuB6GO7NlatVdKgQFk9f-dRMnKbgzv7kYwewN7yINzBBgN1wMJppXpBuxurXrb4y
+LLNIwlFmFdoa8fvKkR-F1REFeFiAeZvhYexolLMaDypO3yvphgE6K9uqrUbsQdr1wnvsn0_lH0Lzzy241rmCwDxZ_06M37ZBgw_UG11sxMF_szahZkXhduoW
+oTadRTOwB_uGh3xbqj_-zX47SGyN7zbvmkxnBpniS_pBlG7ztYjwLuMNh9zu0vtmkoyWNIzyrOYaUSF9yAD4UWDWun-373Vyy0qiZIEsFZy2t2I0Ndm51573
+Gyhu6MrzVllxmvMVLABqUkXy-09Y_YvBVyp-6eKatISHURZ-1e1bsr_HdmT0MVklj7x_R_ep-dlZ8xBszqn-xOl3yrpoSpykItxBQzQRZmSVX07sZc-zIC8x
+67_hrvvDjTwAB3nX1iBuSliZo4v8U5XAunxKIoyuGheOJhwV1TEqz_s8oqzcOvzy36hpzVXHV3JswcFyU3r-BNq0kFZT-7K_VWuVu-TFn-_Tn_e_dpzq7pzz
+Fdzn-cRNjmTXZ_EdaIP_O_u6p__5_74_V_qpynS
+}
+
+AWSEntityColoring(SageMakerModel)
+!define SageMakerModel(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, SageMakerModel, SageMakerModel)
+!define SageMakerModel(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, SageMakerModel, SageMakerModel)
+!define SageMakerModelParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, SageMakerModel, SageMakerModel)
+!define SageMakerModelParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, SageMakerModel, SageMakerModel)

--- a/awslib/MachineLearning/SageMakerNotebook.puml
+++ b/awslib/MachineLearning/SageMakerNotebook.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SageMakerNotebook [64x64/16z] {
+vPS54iCm30HDgU_q__-METACmhHbs48sO8SL4JlHqi5En9OlGYyYafJlRxnKrQ_1I-6w_1XJ0d6zZe_7IIT6tGVb0N7NAJg4xZ-Ra4zVQA7xfPI6WkjDVZqs
+qFpjzqjNGDmAzV8XBz3F_-qNgiL9z_ErpAkVlx-z_2eCwdhxaRZTBDJlTmErSVKBsSIr_28fAeJJbq5-IDaWcVqonTbl-F8Vxjk_VmtxlmY-GUtX2x_eiVwU
+lcZcw2SliC3-OuF7FxlViEFNy7v3Zzy7wMUFtnpOuyVX-yz1u-VZz1i-Vnf__jQ9E7J-kWek
+}
+
+AWSEntityColoring(SageMakerNotebook)
+!define SageMakerNotebook(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, SageMakerNotebook, SageMakerNotebook)
+!define SageMakerNotebook(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, SageMakerNotebook, SageMakerNotebook)
+!define SageMakerNotebookParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, SageMakerNotebook, SageMakerNotebook)
+!define SageMakerNotebookParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, SageMakerNotebook, SageMakerNotebook)

--- a/awslib/MachineLearning/SageMakerTrain.puml
+++ b/awslib/MachineLearning/SageMakerTrain.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SageMakerTrain [64x64/16z] {
+xPDN5jqm24GDae2P_UytLUSH1RbzfjnVduj7bEElvZ_IBGBXrkLuJtFYWxUNjZe18jmyG83-AaC72My_7MaE0YyY39AkQnooF_uxYLuIFIwWu2Pi0w6F_23R
+FbKywntis650V-23sCzAy2H08qOnuyVu1zXkVGEawFXHKmcxzGDHTRgKRtkaTYy8BzdEqB8wJiQq1lZQTo0abr1lsp_zCQREgLTVi66EhvEswZM_agm-RQux
+N5AVON2iVjZlWFZvCKXmwXF0zxrASiaaKi_LlFMLy4_SgMTyANx1iyb3rj7GZtjVJyvCWcmxl_KLaBxndMJenlSoGT9sEaZepcTX-TESPgY1qEAB5WA4PVFK
+vYYpGFexn4Z0UrFHDXpWN0KZeTMljE1i1K4mvXNF1DMlD0Dd3M_pah90zIkY_HjEokUIymdfMvmoVZrwMnFK-LSy_JK19FtXfupqrmBmz6z8Fmiu8E_zB310
+VUjd0TNW-_zd0P8O-NwzeFg74Q2L-zi1Jp_HFlHuwrSoVpj5x_qR_cwVORS4BtpY5fxwWeV8yVVndwy
+}
+
+AWSEntityColoring(SageMakerTrain)
+!define SageMakerTrain(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, SageMakerTrain, SageMakerTrain)
+!define SageMakerTrain(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, SageMakerTrain, SageMakerTrain)
+!define SageMakerTrainParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, SageMakerTrain, SageMakerTrain)
+!define SageMakerTrainParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, SageMakerTrain, SageMakerTrain)

--- a/awslib/MachineLearning/TensorFlowonAWS.puml
+++ b/awslib/MachineLearning/TensorFlowonAWS.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $TensorFlowonAWS [64x64/16z] {
+xPM7Zjum38D9oKFg-xzlfucBSxxVJZ4wYP7vGHFqfzzL__LVcH6PFyT6SyDtMMdnD73xpjBSZG3WxKaQZO3L64ZsQW3RSUO6b5l6uO37MV3rds70IGeLg2--
+x77sosEV7eYwJPxnSTN1NGdTtW9c1So0cc-VmNmmH7vDj_8wkXvFXlWzLXR07YoW68zh6qe-eEjztHgdDknw2Dv_pafOF-FNYzO0E-LLxjIGBTzYy5IvSqFu
+ca-O-07SkYU-UQxuG16Vck1rUYdU4SkservuRP2svy9Nz6Nv4wyDrlPEVDlowflw-9INIDrj-OvonfTr_G5_mU_xdsHkUVstaYEqFnClqUOyxwgZWSGwFZZz
+jcY0ZJpOtlED8wwjoXzWrzIjptmtRK9N-gi9sjstoRkFst9w-gR45OzKFYhZbGi4c5VxRb_vSJEKHBmylNoo70DiCYFVd62ECXzVym5Mu1lhDfJ9YaVXmYrt
+tazuVl39rPvD1kpBwN8VNNqhxveSvVmCwmIyN_sxEvJLYRBnxjziUGWh8giUAfND4sLETx-X_kk_lW
+}
+
+AWSEntityColoring(TensorFlowonAWS)
+!define TensorFlowonAWS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, TensorFlowonAWS, TensorFlowonAWS)
+!define TensorFlowonAWS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, TensorFlowonAWS, TensorFlowonAWS)
+!define TensorFlowonAWSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, TensorFlowonAWS, TensorFlowonAWS)
+!define TensorFlowonAWSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, TensorFlowonAWS, TensorFlowonAWS)

--- a/awslib/MachineLearning/Textract.puml
+++ b/awslib/MachineLearning/Textract.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Textract [64x64/16z] {
+xTMrWGHR44DH5PUq-SUxpFZcWpV7QRpDeF_3rTKLvulL1GfVjOxTbFEJJQGERKRaHoqLWZfIiCyGKiDvrXlrKGCX3MpFUdtf6o6j6V_X_ZbFHx0dFRxsiuKu
+x3lqoU3Hx47FgSmQVfYtSm_zTxy9cBl1alhae6zOyy4MRFG1_-uBoGa3B9U1o7ZL1tsZ6F3gBaCgOVxge5yapKQF6a6tYuu_ZO4L7qY3MhIqJ_XNpqKDvgO0
+Wr4gC5moFAg_UiSzboe25PI86kpP_ciqWKBTI6hJe_3579r_8cR2YPnP9RWFmeZYmVw9HqxSQndQNcQyobzwDP8iq8EaThaFB1Orp_QtNhETWJJJcqKtU7h_
+mmnmrDFu0nWzf9r7_D9_KTX2I-gwPvZ1YAVtNwAv4adfHWmKBNJw_3rQ11lm38SDpNZX-plmPOTx3iTiTM6lTNWlkUq8wk9UQiUZ6Eca_ufTivGE-hF_p-Kz
+l-zh_jN-pN7MOx-5dD5H_uFM4SuFgF_6rTNL7G
+}
+
+AWSEntityColoring(Textract)
+!define Textract(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Textract, Textract)
+!define Textract(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Textract, Textract)
+!define TextractParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Textract, Textract)
+!define TextractParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Textract, Textract)

--- a/awslib/MachineLearning/Transcribe.puml
+++ b/awslib/MachineLearning/Transcribe.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Transcribe [64x64/16z] {
+xTG5ikCm48JXrl1qxd_U1LL0ZsKlmrSKy6yIyFVqtt-TyLJnaCGp8tb4GCCN0F9OxnS-z02Gntek6X90ValF0F9R-dc2Gttx5DT-dk18dvZasXyvmUmxfo8R
+aAy0r7Q_qZ4c84xrKpTziozDikChLbmrjtjUxekW0rUvqtUwgPfddxb--y3Li9g_tCrlrNn7340Zgofi0DuKt0K_q3gJguw1fibTVfnBSL758nJQF2yW7-Uf
+oTVrG97T94sQz36_DXVlZP_3ICheQa6JYY8TkTlFotECW2igowvzvbPVK9RNjK-OeR8SCSPM7_2B8sJf4xhVEvBn3RtzujuHz6Uz-dwVSARbRVmiR-FdlZb-
+mZd-vNLg_WYAP2R9sS_hLpRP3-_q0ULLrRhJr5XWxLzEu1SgM6CbnTSrHh_ySI2vn-0lSu5nJytBTt6H0yfDXhWm19fDJgM0yS3bGu013FK8jm58SfT11D1Y
+AguqkAs0MN_L5Lzayu2SzNcTnJ_BV_zz1W
+}
+
+AWSEntityColoring(Transcribe)
+!define Transcribe(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Transcribe, Transcribe)
+!define Transcribe(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Transcribe, Transcribe)
+!define TranscribeParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Transcribe, Transcribe)
+!define TranscribeParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Transcribe, Transcribe)

--- a/awslib/MachineLearning/Translate.puml
+++ b/awslib/MachineLearning/Translate.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Translate [64x64/16z] {
+xTPLWYCn38JXacIBSl_xReER9gHbclzbyAiudFn3-kopC3qLkJR_qgBY7UTu6C8KQS4RHBVQFc3hJxro-VrsRAq38oTunUVXUpiFADhN-fJJW4E-rjzoFq5a
+p3w-ndFlsutOE6PlP7MFqKm4x103jEpJbzhibm7Gu3K_qjMd08DNlCdshttubC5Bde7ObZoNecbMlOEXULVPDpWuvqBEUSq7SGfyknUFo4lUe6dRjpss522l
+U45a4W-VMmf-Cs1ecHaWDsVudLTzFH3TblzRQ_V-riV0gnZcKqHnvpFV3HnFz0Rxw4540CLBtw7RY-7LEzCSOCzec6UwZNspuQyr-AlR_zhX8_RpUVtvUtZc
+-6OVaK4K6V7EjxYq-62Q0cYAuvKtNADOl330Km3BIn_oeSLFCNpSeJbyiSKFoh2grnONduBU8Ldq2iZLEm4KHQ-OaeiF0IHhNW42GmuVIY02QHIy0YPmXWmV
+3K2B400IRxsHfI22s_0fr1TYZQHm_iZPPvpEdwCetdyo_cVuew9lqE_o3lBXzPQNRXMV7MYgUdoYEn9Olay9Ks70VLxzB6iHfdTPv1_IPvzz0G
+}
+
+AWSEntityColoring(Translate)
+!define Translate(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Translate, Translate)
+!define Translate(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Translate, Translate)
+!define TranslateParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Translate, Translate)
+!define TranslateParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Translate, Translate)

--- a/awslib/MachineLearning/all.puml
+++ b/awslib/MachineLearning/all.puml
@@ -1,0 +1,347 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $ApacheMXNetonAWS [64x64/16z] {
+xPM7Zjum38D9oKFg-xzlfucBSxxVJZ4wYP7vGHFqfzzL__LVcH6PFyT6SyDtMMdnD73xpjBSZG3WxKaQZO3L64ZsQW3RSUO6b5l6uO37MV3rds70IGeLg2--
+x77sosEV7eYwJPxnSTN1NGdTtW9c1So0cc-VmNmmH7vDj_8wkXvFXlWzLXR07YoW68zh6qe-eEjztHgdDknw2Dv_pafOF-FNYzO0E-LLxjIGBTzYy5IvSqFu
+ca-O-07SkYU-UQxuG16Vck1rUYdU4SkservuRP2svy9Nz6Nv4wyDrlPEVDlowflw-9INIDrj-OvonfTr_G5_mU_xdsHkUVstaYEqFnClqUOyxwgZWSGwFZZz
+jcY0ZJpOtlED8wwjoXzWrzIjptmtRK9N-gi9sjstoRkFst9w-gR45OzKFYhZbGi4c5VxRb_vSJEKHBmylNoo70DiCYFVd62ECXzVym5Mu1lhDfJ9YaVXmYrt
+tazuVl39rPvD1kpBwN8VNNqhxveSvVmCwmIyN_sxEvJLYRBnxjziUGWh8giUAfND4sLETx-X_kk_lW
+}
+
+AWSEntityColoring(ApacheMXNetonAWS)
+!define ApacheMXNetonAWS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, ApacheMXNetonAWS, ApacheMXNetonAWS)
+!define ApacheMXNetonAWS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, ApacheMXNetonAWS, ApacheMXNetonAWS)
+!define ApacheMXNetonAWSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, ApacheMXNetonAWS, ApacheMXNetonAWS)
+!define ApacheMXNetonAWSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, ApacheMXNetonAWS, ApacheMXNetonAWS)
+
+sprite $Comprehend [64x64/16z] {
+xTG7cjim34JXGI49ZEz_tqHqBzHdCZthVulhWxhuL_Zuo5OV96TKF9AOwxtUAfC3Akg1Dm9zm4pF-zvB7x3Uq_k0zVv-m7n_Fs2-dndG-ppRUkilxmVizoau
+QGnSQBxRwrbZcfu0x_QlwJ_Jfug8PiYLJ_KzMU_9pEp_BtxMzaSnLQ-vqXlJSIHrhq_JHuKi6GAfaTaSyBqUJuna2ZpPXQ2CU-Opadwpq1IqoUqFIFAYmIRx
+Wl9mE4Pz-aMUdbVI4BpXQAC-S16dv_gqm88wwXaNcQV7cVxU_GgVfz7GvlhQ3vy2w8SOCjv_vIfl3tcGrI4UToV3tlv3ygBsHIRiS7e-whDT9S-23cbRJnQW
+pLv_rkX0RdtP1itsAab7stf3hDq_2cBRVaFkz8UztXnIP6_vQg-XzoV9WOOXpSkH2Gxb61agdNDD0AegC2uob5eLZOiQDifbhNuN_8jyV7m3
+}
+
+AWSEntityColoring(Comprehend)
+!define Comprehend(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Comprehend, Comprehend)
+!define Comprehend(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Comprehend, Comprehend)
+!define ComprehendParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Comprehend, Comprehend)
+!define ComprehendParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Comprehend, Comprehend)
+
+sprite $DeepLearningAMIs [64x64/16z] {
+x99decOX24CFY0fv-r_l5APyvHNllwddzf88KVrs_ES_jLU--NQNBh0CyD8ZwO2bZco8wSy6POmru6pWB4c3fRgXO4gQX0uKrkM2tGFL7_sejzPlpE-vhE_A
+LNr-o3Iaxk94mWXxo7ex61wEbKwK0KHWULEFp06Cr95W1bkQj44E6BiBozIPmYf8gGqgm5jzbM2-jBuDm5QltI-aBf1OgVMg2KG7De3ExjhijNuP34Bb8ISc
+fkdxml2jtmwHMbK63YN3WNrXU0N-OwxA28UGfc5nC4XSKlejT6UeLhNLIirtK-YGdVrI0ImrjrMmLaVgXDuXw8mdc9Dt7StltqPfu-_BBG8CPkKiDUKENVLS
+tObXdky7dn3ry1OBLNyhPsiQBBt1OdwluexCRdSJjr_MvtRhem0048QXg7_NY7X0PyviskJxV3s_lX_-7zOFro_s3_Ol-WVv5_kd-pVdX-QNvgVcj_A3yWlp
+a_ERywFpQxnMgmC
+}
+
+AWSEntityColoring(DeepLearningAMIs)
+!define DeepLearningAMIs(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, DeepLearningAMIs, DeepLearningAMIs)
+!define DeepLearningAMIs(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, DeepLearningAMIs, DeepLearningAMIs)
+!define DeepLearningAMIsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, DeepLearningAMIs, DeepLearningAMIs)
+!define DeepLearningAMIsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, DeepLearningAMIs, DeepLearningAMIs)
+
+sprite $DeepLearningContainers [64x64/16z] {
+xTHdTiD020JWeIqmkVzvKrPErLkluj_-t0i2pnFcBqzFJs67v4CIDz9yX65qLRLXy5ywtzM0SYf8VgZhZQUZRJZzv-kzXCGxXnqlkcE-lfg38bzkZsn1yiOH
+l630sBVyLU3yr8BcLWiW4aUzuBC-cmmujmBoBhxdhraEcxaMDnfeJhE40_wPHG8mlilYqWnf-BkZSmlStM3p68Oa1n1ScLKAVFRYm5HCA0Cn0qBSIvyrDQUg
+CZZPdWqq1w84oGKzdMOl_Ndc68AqsomB1Sa_33OV0qgsI9EAMYUubcJFrexaGezOIP8jHxrwPFC1YlvSKOa-TT-QetTL3HVOUVVtb8UNW9wtHpVCWbCxf4xr
+mYigmkMp_9JEdfxJEnYAUmdDQl8iCBXdoEMH_L9xBinTsL7aVhIrWErdMwlx8-ecmHOCtb50SQrrbt3ScwyDnWs7rBgxDdSSYv-O0clk1Q1vRkw0yv9IG4Vn
+Xt90abVbN36FpAhAuNfQk9qAnGywcl_LESBDxDv_xTFJqni
+}
+
+AWSEntityColoring(DeepLearningContainers)
+!define DeepLearningContainers(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, DeepLearningContainers, DeepLearningContainers)
+!define DeepLearningContainers(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, DeepLearningContainers, DeepLearningContainers)
+!define DeepLearningContainersParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, DeepLearningContainers, DeepLearningContainers)
+!define DeepLearningContainersParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, DeepLearningContainers, DeepLearningContainers)
+
+sprite $DeepLens [64x64/16z] {
+xTLbmg0m38JXIT96XlkVTmLPjvJrZnVvz-2q_FjwUae_2fOdmptPQUAg0fC2O3PuGgOVxUTtduB65GJcne_Q9gBb-Kb_ngTxhliq0B1Sz2NGEHLIQzumk6qS
+i2LV4DAT5DIAJnW321fopIjJ9Abhde9a5HF29U-G84FWQvu340465pt3H2pkVl__eZT-adLyAUIJeCKVBsqtP_8cIxQgY7JiUKOKcrm1TTWO1bT0YwqCmyCH
+snRmy05ZfuIIp2Yo8lVBoURy8sTZ6nBQct-eaAl18Qa2RV22Vdx4wjp-u2UDvlp7EUxzFo95bbcHh5hqWPsfzhqPh_ENIC-d1T_Nz6S-zxql-lVtVyUdIDxn
+hE8jdtdB9v1tVApxY8_swSM_hQUdrm
+}
+
+AWSEntityColoring(DeepLens)
+!define DeepLens(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, DeepLens, DeepLens)
+!define DeepLens(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, DeepLens, DeepLens)
+!define DeepLensParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, DeepLens, DeepLens)
+!define DeepLensParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, DeepLens, DeepLens)
+
+sprite $DeepRacer [64x64/16z] {
+xPK7ZkGm30IBfCIW_Vz_RmbOs2XVHdGXzi3CBSpwJpmyF3nKDNyOwqC5GCI6PwsVulCT1Y3wYWY0HlmiX_8UcN5zNyR5kCsGSJ51ubrV86EEOOBakYVy5VbO
+IBUiYTpFKD2CJtjPguPQh3MOFwrlsDUy2k2hZWsKQMDca5_JOYlGdYKFosFpNOiJdINKClB6QnckkyESDc9T342Ghb_7tKq5qBmgDbRx1DFelSZn0AMWDhok
+Wk8PkcSHL62iGjS1VN_qWROehxUpThB43k6ElHTIAuVizWlDclWAnY5-7wOZIeWL0kDTSmwv73zCVrdR9Rhyx1mpgzCrAT2XWpYVtrU6CrlreMV8CDlvtNFT
+s2U0dCXUKA8E_kdS1NMiFmA97J-OGlJTvuSbuyVzXP0lru9BPFQv1RfYXR_IGvtkLoBUeHDlcLYlAa69bn0QIUJWlnsm5nJC7jsHYHWCTnU4UNe_mJ2grtOD
+wXrlI0fNqmPIv_XEtT-eQdJy81DqlVq3TFAR-au4DDuoHodWcPk9bKWT_USEKKtBAiES3xWT_JyG1NydGViHRPH6Zyz_WCOxAJ8_V1iYeltJYQgpR7gkVyJ3
+myF33m
+}
+
+AWSEntityColoring(DeepRacer)
+!define DeepRacer(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, DeepRacer, DeepRacer)
+!define DeepRacer(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, DeepRacer, DeepRacer)
+!define DeepRacerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, DeepRacer, DeepRacer)
+!define DeepRacerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, DeepRacer, DeepRacer)
+
+sprite $ElasticInference [64x64/16z] {
+xPQ7ZYGv34EV9CiAy__VUy7TnkGATqYxEqJiy0gc8BBSlxT-zAFwBr2ePIzD6NMNBWFmwWu5PDx37JIc87E0fOFcdQE3TtSDGAAxq-2IYKr5BmLQUmWNJKn1
+TVE9lNsidPj8yFPt_5OgTkwTqJq-yM6ZNWgzmPjLRpu0pRZAJyjkuPKVk05N-IMHLtuYCCO5Fh_aUo2pwvnFGzRioddBTrLtWTVPwWXOzXIOtVb-xHmaleFt
+ZgM2B6wlSbNjuts_H6-ED-KrBkKWWjNh4lctl7PdzTwVh6sADr0SyUNOvajaxkydexV9xtb1M8mlVkpKspEGLSVydbezZvi6SyrWnFfMyv17yZcnFUM9zTP0
+qMDU7yF7Ky4_v5UPGhx42JyU7YROUtu2uFE4htmKVWhLyORlQJu5lkVt-5phaHy7-zphVhY_5Ggn_0eV-JImwkzKllEppi-8zto0ngNybeF6s_ncp8YrNNNU
+7xljDvz3012lKgtJ_jlnJQpgKGlcqmr4iJxZSsSy0IbTXwcgPOiwuz-w4JN5gbm0dGFmItpcukt5iKu1DGKOGXpEZr6xFZiPXTIkGGCEto9xz2j43zwPBSnd
+VOAr4ISb_3Q_Iat63f0hkIr-gtnpVnXeA_d4hITUsy2nYPWWaOmMpCnWlr64kdG9mQihieIdehiYE-BM_QrpoSJ_xpNoTzEFVlGt
+}
+
+AWSEntityColoring(ElasticInference)
+!define ElasticInference(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, ElasticInference, ElasticInference)
+!define ElasticInference(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, ElasticInference, ElasticInference)
+!define ElasticInferenceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, ElasticInference, ElasticInference)
+!define ElasticInferenceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, ElasticInference, ElasticInference)
+
+sprite $Forecast [64x64/16z] {
+xTHNOiGW38JXaGG2JUv_tZIb5xoGdkL_SVtS3R-htMxNH5MTRnPzMAG7KFbc5SFoh3xoMWRrt0Vslcyyg41Q4t_F7pqOWtOoEET3S9-bdVCLQbabvtq7ueBP
+YY-ehTxcP5EVz1r2msqIRAYd-QWb4pWDjRdBZ7VSPwGXI4vvXJz-zuO-wJkKaN7QvxoB013fAruG5QAgm9oFsnei5sbplW5PM_IQMQpvnzPyUDPNFRAoxCMh
+bmzu8za-uFL7_VRswDkZZvEz52kQNgzd9RqLCyn-lrddpFZzE6Z6wraU-XXtu24O9nXuLpbEdP_KRhUx0W
+}
+
+AWSEntityColoring(Forecast)
+!define Forecast(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Forecast, Forecast)
+!define Forecast(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Forecast, Forecast)
+!define ForecastParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Forecast, Forecast)
+!define ForecastParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Forecast, Forecast)
+
+sprite $Lex [64x64/16z] {
+xTG5ekGW48JXWgQjSl_xBbc3F9aXhCi_BbyS-7lql_-5lPSlyO9tQmlU8APlXxBaxU3RbKLFvZL-UbhsYKlA0hGxNYuvcuZTy6_s4ttMJoafzNDwnvUlrqiT
+rqxUFt_pcVoP-w_jQyheJtdB1qQ52k2UJny5ytmwAtLZ_sFa7dFvdZ_MPeEQRtkPfXg1N6gZ2dim__ZvrhfFljtntebECrCqCejSlLV9XGkb5z3EePDtzm98
+M2vuXtRUEBoZrog0aYjUwic7RwZYJ9K2N_7eVFOAFKAxg8YL_UzyzbuG0Q1I8VdKCvopJw1Hu0hB2Xd-MSChAzAxaGrF1T80bFvS_9OVny-bnJX-zto3Q8Uk
+5RxZ5JqLz6B7qrG1L6lEBTzJb61lrpEd3yUYLviAdgMTjHLlkEOdB_XKy7bkKmeu6QZdUmlUpW3lNWzkPe1tp-qCQFj-J2txEM3ybiAJlrF_-zy7
+}
+
+AWSEntityColoring(Lex)
+!define Lex(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Lex, Lex)
+!define Lex(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Lex, Lex)
+!define LexParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Lex, Lex)
+!define LexParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Lex, Lex)
+
+sprite $MachineLearning [64x64/16z] {
+xTO5qXin30NW9xBWl_zzErPuo7RARLvewLibfWb-LpwXsoT1ncaCu8SVNtMOVFNrce__-3I9-UcUxtWd5bXVI1gdFeIixn46DmAF4vy6H6-mY5Ib4tBNTrcz
+NY-IlK6oNpzWvSWocVvwI4zyr42MKlkEGQeYjxrBbZtv6X25RlkP5ry398Wzx_sfxVrc8XEwuGS1bXK2dLuWzwg6N7bdo62GWBocBoUAExA5J_1aW_hAzfLC
+MPtUMdZ_YgpklmfDaQUo1kYo_Z3OrJk1vDgICq9PImzOr_UvfsW_qD2erbwovm_GpIxj_S1xVsyBHVVVQ_tSyjAba-dccQz349eBFpUpdsLNtutHIS7ACsmA
+6jDVsiyVlSQy6dzfuC7TU0OY4fS73upr-0_kCTYjM2B2VYEboDtv6mA9v_bRGaQwl_vGbtruczV7hW_BUl46g_0wM3zITFe7xspu95YMWSQpZsrVgI26PKqV
+8_josVVT-XHz8nLefH7qnFSwfeDWEU_Ha_7CFsPBe7_AiQ-yrepyn___VBpbQUB5lv4Vvy7oJlXHbjuA_eLy0m
+}
+
+AWSEntityColoring(MachineLearning)
+!define MachineLearning(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, MachineLearning, MachineLearning)
+!define MachineLearning(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, MachineLearning, MachineLearning)
+!define MachineLearningParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, MachineLearning, MachineLearning)
+!define MachineLearningParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, MachineLearning, MachineLearning)
+
+sprite $Personalize [64x64/16z] {
+xLQ7akim25oQ1Bd__zwxYumqwQIy_hBJBCOBQ2dsxa_56s_4QtGdUv6FLno4Avvs45q806WxFQf48u24WJwEJFQ8Xyw0z9rF-au1wdVJ3H3VPwsByuWKUZ5M
+9yYzT5yYVYFcWUzoOE2D4SOOO8lfm6hfPdG3m6gc32Gl28M8wvKGm3orCq0YdKULlMIgWn7kCRpbfHHMXHz11RAwg1qOeaZ0IG-oQ80Aa0viIw3TJc2a2yHA
+feyHc3Q_fuOsOirt6N5W94J9P_Wvty5R7viM7WASOkulsyOf_HWOGAjQIES3c06VVTtt5e2lCza7pRA1CM1JbJvSmczKdtpnGq3Mkn5ayiSOset90yXd_WgE
+mx7HxEmRzmO8clhvQZK78lKhjfP2UcJz6knZityeMjQlG81MgoXO4WnDOmM1prvL7C0sMuc6DJ_X1rZpO-p5_COQruKqv4WLewE7-oEnzeT1NzbV3efwVyRL
+_SbezVg_ihzJX1fvrxFlHufG8WJavsRdfDTGm6BnRCwonWDVVqeFlY-86-KUlnEXe4WwAUCiU0dV9E1LWUTW62FzFApwSQcrz5T_OlzKlF765m
+}
+
+AWSEntityColoring(Personalize)
+!define Personalize(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Personalize, Personalize)
+!define Personalize(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Personalize, Personalize)
+!define PersonalizeParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Personalize, Personalize)
+!define PersonalizeParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Personalize, Personalize)
+
+sprite $Polly [64x64/16z] {
+xTPNOZ8x38RXJx8w-z_lcHfYwXZEttaIkF8hffXIluMFZtJxnckKeoCroD1CDyRZ0mnsgir9ne_0eFL5O0nvfuzao1kzLpzWlEy7ZFVTWE6UU4A0lDGROK7W
+b_hALGptlMmwtlVUxDErJTJpGCyqu_BfAPTQ21kIFDpRzBoiZYcpc9W0q6TzhghcfyNvi5E1bkzSls1mFknLUf4oswDiQ0zxNB34B6gJ3AixqhF2Uranoze5
+AEibkKuHQDtNlNPtR268zG2uxagShSlDbYU7R7qnecuAyJ8zoveGSawMtcKUfh21-q_aR6thmTkoaTwWNtshAeVyZ3uqzkFthdzm_7Rgf_NNRpj_WT_hMThE
+0tnv_zpcaf47lh-b675h_pXQtH7VP1darlvjy3eawTRAWSzp1yMjgLa7wQq12gcZ1EJTmUVO0PG2RP-Gpc2hqyW1b3D0ecRQ2220BGbHntd3YffND80PyiBl
+oiYQnJ8kwcNB1AztXDVluUFZFm
+}
+
+AWSEntityColoring(Polly)
+!define Polly(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Polly, Polly)
+!define Polly(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Polly, Polly)
+!define PollyParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Polly, Polly)
+!define PollyParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Polly, Polly)
+
+sprite $Rekognition [64x64/16z] {
+xPHN6jim38D1YGk-_u5hCSfgFpcZkmqUl7yOXCVsf-gZZvZXxf5y2_Okc6gMh-81GBgQk_KsBE8rFfjUSzCRq5xBmA_oTC1UBp3ZKfyB-ajmTBchBzih1Yw0
+D5Kj5-LmVDw07UZ1sQK9nClWoGvIxkkceKWAyXZan7MxLqWPEDfXR14kOgPWZD0HHwLLGGhTw6Osivus0-1kSnYW8SSbmetOvJCKQdg3paiMckPzS8JukVy8
+XPtBSzX1V2kIOzdsHOujSek2h4uV3A2Z7A-OR7rJT8vzOOXVuZLmFJwdIKaRJwauloQfy-i2H7XRq7b-Fz-mZrE6M3_z6U9uFlzvF6_vovgtlAtuGkUG9OiJ
+tlDsVbtEN-UdFptcbMmWFI_v-hh_GXDzExqceSPjN-fywG9zcYmKXGfuuY-QVB_O7nReqC6ZjPXZDO7DxweoBgNmiK3KHpUlP3jjjh5WfLif9NTSwWCUch5g
+KskY2hSM1qv3uxVT2X__00klPTpxAWfKw6EyxWRbbNQ1PALlV0O_rTSzIMQOJBS0ybbSNN1HBoo0U1eVrrjlkzGv6uI_WjyhUtMwbjtXwRoZjOOuK4BoZFUn
+4FLa_N_36Y2-7SgX5xnkMFN9Bkng5US9ll0IHts3R-ep-UFyEV6pk6jxJWfHhURV4nMxR7jVwJNetwAFFle2
+}
+
+AWSEntityColoring(Rekognition)
+!define Rekognition(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Rekognition, Rekognition)
+!define Rekognition(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Rekognition, Rekognition)
+!define RekognitionParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Rekognition, Rekognition)
+!define RekognitionParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Rekognition, Rekognition)
+
+sprite $RekognitionImage [64x64/16z] {
+dPVX5gCw28GDIO2Pzt_WkrOufh9wtSw_LZy24yA9sxrag8Exu3Pa-oTrTNxBjR-ccnC0uQQxp440zDbU1Z3GPszdG9c6NIyZT9MQr7GIthVVDHoajkrtJH0k
+xusK_aVh--8aNjKWqq22867pZA6l0WmdWEWV0FIHTS__3z1tch0vzlod7S56nYOXJrKR2NprcoX0Mb2Jz7PVk8ErKTh4cRS2UflxkL1DYr63a_qUdxUxdm44
+n9hXoAuI4EFULsG94rXNSNYUF8wdZM6kwsi2Wn5DGJq2LUNUsJUo1kkannPKUO-ZFP99N0ZD_-GeXmNdyNvBvoROJry_M8yu3VHnbIKNZTW0lRXdG8j7MLkO
+SN0jWmU5U8nS5hR-aPha33uybZNhhSUMZwpemeF4maiuB-JuAb_pZGjlW0KVYLiKObjofmsLRtEsbJVWOfidLVX0SfMlV8tuoeUOLzvW2P79zpXyIgwy4EF2
+6uXirnzu1KdeZc3XXUXHnpsVW_9p80MaFwrVwyynAI06o77wFqX9_jx_d1M3v1vvLl-1s_sVvo2Q8FHf_qVjFnhEGQIksyeZ-u_wrV-T7CcpJD7I_-VhzVoH
+PS3Vdx_L24dUBdWz_rd-EOea4zXvlSWlyoU7tievaKCILn5-l4jV5yq2v6Y8us4pL7aSki3sEAaEbsXtwlQacQcEeupGE7n5Tt8-u8DC5udjLE3oiNu-uf9R
+DIg--rElQENgaovMF09ulxbN1DwSx0LVxmacLrgNgvyHMl5K9mdQEAjetR3KfQJVuZbiGBZECSPK1u4iAaVf0mxTvDg2rbSNvHd_vBnyV-XPIpEym4EjoH-r
+xvlbQxogAGbRuys_uR5YeIUktTd9YhUul9O6g9T_8tf9VW0WT4XRl-K8qCSbA6X_gRrRJWpRvI0Gz4L15Eja1XGYVCfMHLh5isUdckyopM-v8YUaukyro8-Z
+_ISyRmXg_0cFUKgGcBz_L9Am_Xly7m
+}
+
+AWSEntityColoring(RekognitionImage)
+!define RekognitionImage(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, RekognitionImage, RekognitionImage)
+!define RekognitionImage(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, RekognitionImage, RekognitionImage)
+!define RekognitionImageParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, RekognitionImage, RekognitionImage)
+!define RekognitionImageParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, RekognitionImage, RekognitionImage)
+
+sprite $RekognitionVideo [64x64/16z] {
+dPTjsl8g38GbtpFxN_1vwmENKQpsEF_KtY4JIAItSub5WOTGQNBxNz8eFgj2BzEZ282eZ4DP802MZui14YpNyGWedZXqCOB6xdTuaIYz_Iuha35klyj1b5ml
+fEW_zUUbI5po89uWGP18VyI8Im6i200y100iMxxzUm0zQ2BTZlmz_uBPYar2FhbE4WZjPW8WSr9ErZWtNk1-K8RZaNS0SPfxMsXBYzD3aNgE-zdkSmKG43r3
+MwTAGDXvNR4iED1NATJgF3PyatAjMpq1uumMODpZlDFSktn6UZ0bxtaatYbdQzjY5Yv4hE_aM1taHfCyrXYhSWxgewlalloCCy2oL-NYva4SGBnKBu4nV_9z
+yu2nWazg6bYH1f3zYvrVDPQUzKtdbXkedTTAUSFBhBoGzcG_WD7v016ZyyjkJYDvMrmhG-S9sCRdo_E9QbJdCKTkurk-IJpbG_WhFsprVUDrDb-GdHV2NldL
+z_uZl-OT5jyVT5pW9K70JjR_wjyn_t8QRwHq_hp-1CcKlVvZxkFN_MVfk_r_QXixFN-jZngFwHUCf_Elf7LUCiRP-TyV_xt_UY7aQlyl-tqKoSDPnQkgpPys
+z3ftAqA_p3y1go-w3CZVWM1D8wVpbnCxuYmfIkP-CswVv2jLkzjOiddSj4Z_W1k9LKMqxoSkT-l-4PUrLRRZHttsAzfszLbLtF4PeFJaNZ7nKQHkUBydfBpI
+qQv-ISIEBob9CAtTVpNHV0LP9_WoG82eS3FpA11edKnYVC8HV-bsfVOgoXVyoBczVyJ3oqXynvV6a7_gkMhnChvh18diyVmTBkCzxNWzdSet-EYNrtu0zij_
+4hebRm28C1dzNOu0orw2Wld6koOE4PM72WGQtJI9hNJY4veYokMsYyopoW_ro3gKuNhIaKN8Zb-NaVUAwY_ueGIHaJpmdvIy2_xxIoM9rD_W_m
+}
+
+AWSEntityColoring(RekognitionVideo)
+!define RekognitionVideo(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, RekognitionVideo, RekognitionVideo)
+!define RekognitionVideo(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, RekognitionVideo, RekognitionVideo)
+!define RekognitionVideoParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, RekognitionVideo, RekognitionVideo)
+!define RekognitionVideoParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, RekognitionVideo, RekognitionVideo)
+
+sprite $SageMaker [64x64/16z] {
+xPQ7rgKw28KtXEh__kzxLrHMFDLufyySxELBtH2Mtz4-zh4GhrkNk8mhWBPYqG3eDTePq7vaAi3zy7awPQkxOmperWR9ITm8vAEW3NC2sGmT343gYQZkrex4
+LDCTxP6VwuJtLkOJldhcPtmVhITyYERofVDyiXnu1y2vo1IVt4_W0o-mXcuJ_6Rtl32OwOoF5tmGUgSKSIRxbjMI8x-a-VfPpsI_oIna4n7XHdJspX4wqrpw
+BufTmbfUUDHGFCSxMFvAcaFE4cPPlpdX-I0OfEx0UICw03JU2EmvRr-BzQ9pAydsQhAX2NJy-98FNfKR-ncQrJATuHdWKNzg3M8IGEk7VCk3xAR_ANiaIDME
+AqZVyIqF8YXtFlv017_N_ttsMcZ5BJhm0ZFe2Tzs4J38xtX7DydtzTStBVqFKo8XW64d-edT_r8n-F8ZmdC-zkboXcoy4GP_gj_XFssh7u1GyQV-CwREQ-uv
+glzJ_dkC7xOlDtUyGcVYbtDfdwZqj_Cn4xz7q23ApD9_vwVYhrez4uW8vN-p_302CnEQNEPpz3yPu9paoLPQ8OVnSwzPyQdKmncGw-jt1TmAHDVpXmguhI8d
+P29_cSoVVah-Dfy_pkUl6illQ1_xs7y
+}
+
+AWSEntityColoring(SageMaker)
+!define SageMaker(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, SageMaker, SageMaker)
+!define SageMaker(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, SageMaker, SageMaker)
+!define SageMakerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, SageMaker, SageMaker)
+!define SageMakerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, SageMaker, SageMaker)
+
+sprite $SageMakerGroundTruth [64x64/16z] {
+xTO7SkqW30NGAmbK-FlVxxSr3BmEpjIKcqvoRACHoci_Cd_vYzPecQXwNJi3REs8CS1-JKS1vFnm5q04A761Au4qxunyYbomNPstZ7Qc0dK-aE_eg011-qz4
+jmMfiUOCKaKTVX8bS2mzAFwzyEwj1M73SslfJMFwaYMHRQ-j2Nnu1pE8iUd3uxpbz9RTW4sVkVF107dmsXiuMYVf-sNrh0R3rdqBqjw2XvYTqAjOOj4wMW5M
+xdzPxy-EqgScalnbzY_4PziLBNfp2tdd6HrLbFjx0dNqCVYzRr7gIUvs7GG5ZPy--KhWw7v6m90jtwkcgFUpA8lefSR2Y_SQtK-BY3Wu08xF_ho-4Z06bith
+L5I1BtrDQWpo5hSDes02syfxxk6Wt9n1DFed1620F_cxNIlw_DM-uFbSR_rzUyS9ZKWLaB6QEth3xzhRyy49G7ZMOXwGpyEtNxxaLqAUmZ8MboFOmNDwD6Es
+N2pZW2mIDpvwRdpiUnFgOVkI1pW3w1KlmxFf4PFXPSUJ3qy0GCCxRVWSOjrhFQ9y-ZwwOk-VlwK7PP3U2AJRBpxiy8Lxn53ioaiGaoYthUA75MjNykYtuV1g
+8_eLVvVBtijTlFt0_EKl_m4
+}
+
+AWSEntityColoring(SageMakerGroundTruth)
+!define SageMakerGroundTruth(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, SageMakerGroundTruth, SageMakerGroundTruth)
+!define SageMakerGroundTruth(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, SageMakerGroundTruth, SageMakerGroundTruth)
+!define SageMakerGroundTruthParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, SageMakerGroundTruth, SageMakerGroundTruth)
+!define SageMakerGroundTruthParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, SageMakerGroundTruth, SageMakerGroundTruth)
+
+sprite $SageMakerModel [64x64/16z] {
+pTTNelCg30HW98eqi_y5tsC8KOu9JhdjdvSqV-wUGFep8pK_VinLFk8LeEdyf4QWlg-pymZ6HgM2Hpo_fwMHG6aalAHK7AGLW6po1hylcJiq4fxlQtsbrKcw
+phCm3cFvQPDb8sAaoR9hIxQ_AwcRzI_HUQWRhwN8xQJeCuvng3jV0I2Fam9TVUw7klMPHt0xAVcfptTMMvNVlW6vZa_vbSy0u7Bs-ifR7G49elto6NF_zvuO
+8Ljo-FGZZIJofJyak_S2MFYUYl5-xuiON4GQ2A8CtyejHigrpybWntkRjuB6GO7NlatVdKgQFk9f-dRMnKbgzv7kYwewN7yINzBBgN1wMJppXpBuxurXrb4y
+LLNIwlFmFdoa8fvKkR-F1REFeFiAeZvhYexolLMaDypO3yvphgE6K9uqrUbsQdr1wnvsn0_lH0Lzzy241rmCwDxZ_06M37ZBgw_UG11sxMF_szahZkXhduoW
+oTadRTOwB_uGh3xbqj_-zX47SGyN7zbvmkxnBpniS_pBlG7ztYjwLuMNh9zu0vtmkoyWNIzyrOYaUSF9yAD4UWDWun-373Vyy0qiZIEsFZy2t2I0Ndm51573
+Gyhu6MrzVllxmvMVLABqUkXy-09Y_YvBVyp-6eKatISHURZ-1e1bsr_HdmT0MVklj7x_R_ep-dlZ8xBszqn-xOl3yrpoSpykItxBQzQRZmSVX07sZc-zIC8x
+67_hrvvDjTwAB3nX1iBuSliZo4v8U5XAunxKIoyuGheOJhwV1TEqz_s8oqzcOvzy36hpzVXHV3JswcFyU3r-BNq0kFZT-7K_VWuVu-TFn-_Tn_e_dpzq7pzz
+Fdzn-cRNjmTXZ_EdaIP_O_u6p__5_74_V_qpynS
+}
+
+AWSEntityColoring(SageMakerModel)
+!define SageMakerModel(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, SageMakerModel, SageMakerModel)
+!define SageMakerModel(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, SageMakerModel, SageMakerModel)
+!define SageMakerModelParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, SageMakerModel, SageMakerModel)
+!define SageMakerModelParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, SageMakerModel, SageMakerModel)
+
+sprite $SageMakerNotebook [64x64/16z] {
+vPS54iCm30HDgU_q__-METACmhHbs48sO8SL4JlHqi5En9OlGYyYafJlRxnKrQ_1I-6w_1XJ0d6zZe_7IIT6tGVb0N7NAJg4xZ-Ra4zVQA7xfPI6WkjDVZqs
+qFpjzqjNGDmAzV8XBz3F_-qNgiL9z_ErpAkVlx-z_2eCwdhxaRZTBDJlTmErSVKBsSIr_28fAeJJbq5-IDaWcVqonTbl-F8Vxjk_VmtxlmY-GUtX2x_eiVwU
+lcZcw2SliC3-OuF7FxlViEFNy7v3Zzy7wMUFtnpOuyVX-yz1u-VZz1i-Vnf__jQ9E7J-kWek
+}
+
+AWSEntityColoring(SageMakerNotebook)
+!define SageMakerNotebook(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, SageMakerNotebook, SageMakerNotebook)
+!define SageMakerNotebook(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, SageMakerNotebook, SageMakerNotebook)
+!define SageMakerNotebookParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, SageMakerNotebook, SageMakerNotebook)
+!define SageMakerNotebookParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, SageMakerNotebook, SageMakerNotebook)
+
+sprite $SageMakerTrain [64x64/16z] {
+xPDN5jqm24GDae2P_UytLUSH1RbzfjnVduj7bEElvZ_IBGBXrkLuJtFYWxUNjZe18jmyG83-AaC72My_7MaE0YyY39AkQnooF_uxYLuIFIwWu2Pi0w6F_23R
+FbKywntis650V-23sCzAy2H08qOnuyVu1zXkVGEawFXHKmcxzGDHTRgKRtkaTYy8BzdEqB8wJiQq1lZQTo0abr1lsp_zCQREgLTVi66EhvEswZM_agm-RQux
+N5AVON2iVjZlWFZvCKXmwXF0zxrASiaaKi_LlFMLy4_SgMTyANx1iyb3rj7GZtjVJyvCWcmxl_KLaBxndMJenlSoGT9sEaZepcTX-TESPgY1qEAB5WA4PVFK
+vYYpGFexn4Z0UrFHDXpWN0KZeTMljE1i1K4mvXNF1DMlD0Dd3M_pah90zIkY_HjEokUIymdfMvmoVZrwMnFK-LSy_JK19FtXfupqrmBmz6z8Fmiu8E_zB310
+VUjd0TNW-_zd0P8O-NwzeFg74Q2L-zi1Jp_HFlHuwrSoVpj5x_qR_cwVORS4BtpY5fxwWeV8yVVndwy
+}
+
+AWSEntityColoring(SageMakerTrain)
+!define SageMakerTrain(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, SageMakerTrain, SageMakerTrain)
+!define SageMakerTrain(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, SageMakerTrain, SageMakerTrain)
+!define SageMakerTrainParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, SageMakerTrain, SageMakerTrain)
+!define SageMakerTrainParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, SageMakerTrain, SageMakerTrain)
+
+sprite $TensorFlowonAWS [64x64/16z] {
+xPM7Zjum38D9oKFg-xzlfucBSxxVJZ4wYP7vGHFqfzzL__LVcH6PFyT6SyDtMMdnD73xpjBSZG3WxKaQZO3L64ZsQW3RSUO6b5l6uO37MV3rds70IGeLg2--
+x77sosEV7eYwJPxnSTN1NGdTtW9c1So0cc-VmNmmH7vDj_8wkXvFXlWzLXR07YoW68zh6qe-eEjztHgdDknw2Dv_pafOF-FNYzO0E-LLxjIGBTzYy5IvSqFu
+ca-O-07SkYU-UQxuG16Vck1rUYdU4SkservuRP2svy9Nz6Nv4wyDrlPEVDlowflw-9INIDrj-OvonfTr_G5_mU_xdsHkUVstaYEqFnClqUOyxwgZWSGwFZZz
+jcY0ZJpOtlED8wwjoXzWrzIjptmtRK9N-gi9sjstoRkFst9w-gR45OzKFYhZbGi4c5VxRb_vSJEKHBmylNoo70DiCYFVd62ECXzVym5Mu1lhDfJ9YaVXmYrt
+tazuVl39rPvD1kpBwN8VNNqhxveSvVmCwmIyN_sxEvJLYRBnxjziUGWh8giUAfND4sLETx-X_kk_lW
+}
+
+AWSEntityColoring(TensorFlowonAWS)
+!define TensorFlowonAWS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, TensorFlowonAWS, TensorFlowonAWS)
+!define TensorFlowonAWS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, TensorFlowonAWS, TensorFlowonAWS)
+!define TensorFlowonAWSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, TensorFlowonAWS, TensorFlowonAWS)
+!define TensorFlowonAWSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, TensorFlowonAWS, TensorFlowonAWS)
+
+sprite $Textract [64x64/16z] {
+xTMrWGHR44DH5PUq-SUxpFZcWpV7QRpDeF_3rTKLvulL1GfVjOxTbFEJJQGERKRaHoqLWZfIiCyGKiDvrXlrKGCX3MpFUdtf6o6j6V_X_ZbFHx0dFRxsiuKu
+x3lqoU3Hx47FgSmQVfYtSm_zTxy9cBl1alhae6zOyy4MRFG1_-uBoGa3B9U1o7ZL1tsZ6F3gBaCgOVxge5yapKQF6a6tYuu_ZO4L7qY3MhIqJ_XNpqKDvgO0
+Wr4gC5moFAg_UiSzboe25PI86kpP_ciqWKBTI6hJe_3579r_8cR2YPnP9RWFmeZYmVw9HqxSQndQNcQyobzwDP8iq8EaThaFB1Orp_QtNhETWJJJcqKtU7h_
+mmnmrDFu0nWzf9r7_D9_KTX2I-gwPvZ1YAVtNwAv4adfHWmKBNJw_3rQ11lm38SDpNZX-plmPOTx3iTiTM6lTNWlkUq8wk9UQiUZ6Eca_ufTivGE-hF_p-Kz
+l-zh_jN-pN7MOx-5dD5H_uFM4SuFgF_6rTNL7G
+}
+
+AWSEntityColoring(Textract)
+!define Textract(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Textract, Textract)
+!define Textract(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Textract, Textract)
+!define TextractParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Textract, Textract)
+!define TextractParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Textract, Textract)
+
+sprite $Transcribe [64x64/16z] {
+xTG5ikCm48JXrl1qxd_U1LL0ZsKlmrSKy6yIyFVqtt-TyLJnaCGp8tb4GCCN0F9OxnS-z02Gntek6X90ValF0F9R-dc2Gttx5DT-dk18dvZasXyvmUmxfo8R
+aAy0r7Q_qZ4c84xrKpTziozDikChLbmrjtjUxekW0rUvqtUwgPfddxb--y3Li9g_tCrlrNn7340Zgofi0DuKt0K_q3gJguw1fibTVfnBSL758nJQF2yW7-Uf
+oTVrG97T94sQz36_DXVlZP_3ICheQa6JYY8TkTlFotECW2igowvzvbPVK9RNjK-OeR8SCSPM7_2B8sJf4xhVEvBn3RtzujuHz6Uz-dwVSARbRVmiR-FdlZb-
+mZd-vNLg_WYAP2R9sS_hLpRP3-_q0ULLrRhJr5XWxLzEu1SgM6CbnTSrHh_ySI2vn-0lSu5nJytBTt6H0yfDXhWm19fDJgM0yS3bGu013FK8jm58SfT11D1Y
+AguqkAs0MN_L5Lzayu2SzNcTnJ_BV_zz1W
+}
+
+AWSEntityColoring(Transcribe)
+!define Transcribe(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Transcribe, Transcribe)
+!define Transcribe(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Transcribe, Transcribe)
+!define TranscribeParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Transcribe, Transcribe)
+!define TranscribeParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Transcribe, Transcribe)
+
+sprite $Translate [64x64/16z] {
+xTPLWYCn38JXacIBSl_xReER9gHbclzbyAiudFn3-kopC3qLkJR_qgBY7UTu6C8KQS4RHBVQFc3hJxro-VrsRAq38oTunUVXUpiFADhN-fJJW4E-rjzoFq5a
+p3w-ndFlsutOE6PlP7MFqKm4x103jEpJbzhibm7Gu3K_qjMd08DNlCdshttubC5Bde7ObZoNecbMlOEXULVPDpWuvqBEUSq7SGfyknUFo4lUe6dRjpss522l
+U45a4W-VMmf-Cs1ecHaWDsVudLTzFH3TblzRQ_V-riV0gnZcKqHnvpFV3HnFz0Rxw4540CLBtw7RY-7LEzCSOCzec6UwZNspuQyr-AlR_zhX8_RpUVtvUtZc
+-6OVaK4K6V7EjxYq-62Q0cYAuvKtNADOl330Km3BIn_oeSLFCNpSeJbyiSKFoh2grnONduBU8Ldq2iZLEm4KHQ-OaeiF0IHhNW42GmuVIY02QHIy0YPmXWmV
+3K2B400IRxsHfI22s_0fr1TYZQHm_iZPPvpEdwCetdyo_cVuew9lqE_o3lBXzPQNRXMV7MYgUdoYEn9Olay9Ks70VLxzB6iHfdTPv1_IPvzz0G
+}
+
+AWSEntityColoring(Translate)
+!define Translate(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Translate, Translate)
+!define Translate(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Translate, Translate)
+!define TranslateParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Translate, Translate)
+!define TranslateParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Translate, Translate)
+

--- a/awslib/ManagementAndGovernance/AutoScaling.puml
+++ b/awslib/ManagementAndGovernance/AutoScaling.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $AutoScaling [64x64/16z] {
+xPO5SiKm30MVP4Tq__iM77KycFfRvMR3i6QAdylDZLb9Lq1hEg0r7T1zNOW4q6qzY68t08P447a8UCStYTCFiTWY_G9r7pM_ju9Vnu_32xeGGB9hAmEz0wph
+Jk-HM0EQpUlyVe4pyWS1M6Sw97MmhmNGW9w_UWTuJPy1D118iX09lA3xm0Xz-7O0hCh0OU2Xa_dWQhGX0FtLzr5qe_0S_Ae3T34YAPzG-ZR7p_H1VABl5a3w
+GHJfp-mlbf-VlgV_IF4Fl_kRxntyOFM7djL7T5QWBhQVddgs6YKIpfOqlozY3ODcbHx86WLKubjfN1t_VvjVdp_hytTz_L1VlzJNJnc05jUFrVNhp-NcvXa
+}
+
+AWSEntityColoring(AutoScaling)
+!define AutoScaling(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, AutoScaling, AutoScaling)
+!define AutoScaling(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, AutoScaling, AutoScaling)
+!define AutoScalingParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, AutoScaling, AutoScaling)
+!define AutoScalingParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, AutoScaling, AutoScaling)

--- a/awslib/ManagementAndGovernance/CloudFormation.puml
+++ b/awslib/ManagementAndGovernance/CloudFormation.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CloudFormation [64x64/16z] {
+xTC5Zkqm38NX4rDit_tlzwbv0vrKBWs8-bqG_WhdxtWy7cwgvdcJ4GQol24O8ErT6U38omZaEJY18Y-IzQ0Cpciwsdf8WhcgHPwbr7F5CRIUDp6QTG4yIo6y
+eP4vE2-bGh9as9Z72xIzNdt2KvyDP7LlEP6vLm8uRlQ3CoZAFdImeXy4KlQEWVRwQ8Xo_3xuNf-2NlMJ6FbCOVNu5KzV_WvwHqMI0Cu5r_CFbK9F4ndZEbfK
+_Gb1q2pxU9SB9S-CDRS6phAFXZVzu_niinCxFRrRzRIcVkFzJ7wl3rv8zl5_eyU2nfwr6ttw8ZB6_n-l_-bV-SNhOYzzmjVwhIjzw9P5_fh7u_4F
+}
+
+AWSEntityColoring(CloudFormation)
+!define CloudFormation(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CloudFormation, CloudFormation)
+!define CloudFormation(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudFormation, CloudFormation)
+!define CloudFormationParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudFormation, CloudFormation)
+!define CloudFormationParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudFormation, CloudFormation)

--- a/awslib/ManagementAndGovernance/CloudFormationChangeSet.puml
+++ b/awslib/ManagementAndGovernance/CloudFormationChangeSet.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CloudFormationChangeSet [64x64/16z] {
+xPU7SkKg40KPufp-_mz-CXWNxvRGJPjtszdGX14p9S8tmfxandOzYTlg9u6U09HMFqBDJr0XtlWnF47yERwzvoUrAp_w5qkZnJ1nL2xy8jH1PJqPisS6P7i_
+YrOF6ifXaa6ZgmcWNlcoqV73Jx6JV0vGeJYAZ_cH1Nrq4HuIj1Vz1cbyVt3zWxd-16skuX7_DdvpvmNorgVaWuBoxVFBe9aviiUV_pm_3emsK3xtapH9uOQg
+XNJghpNikhwD_hzU_l_pKtDlwMM_eWFgUT6qN0-oRVqYQ0rKbgRcDkogCRggdVic57kAoi8a2xUHHmmV-IR_87MbvvyDejC7ACBJyTEIexpBlv7_g8Ie2U0X
+DCr5cLGt-J_cJpr35vr3hQ9s9LPKJlquLchUWv4_SSPs17Xh3iZEuz-4QXLg_typoBsBemuUT_dVX8IQBIqYpw6g7zHqSVwAIrx2IanFdN-pV_c_uGV4Bxda
+wMM_W0JbHJynpY_fwktDjdv3Xvb4EzFZA4j5SUCRGsom1B7CmLoKuq_auRh-f7K3MMfpVYW557U-nZ_ZMa2ZmpB0q3V-Mh_CFn6iAr3thkU_hLyp7WLGsVeH
+HeHxCEidplZtSZesVXY5tuIM5grw77zk_29QZ8xAMl_cNqqzybBR-Q49PhWc-MkmMR_3rhU6HBFNypVc75_8tzVlRw_V7z-_lxv_VtwV_m
+}
+
+AWSEntityColoring(CloudFormationChangeSet)
+!define CloudFormationChangeSet(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CloudFormationChangeSet, CloudFormationChangeSet)
+!define CloudFormationChangeSet(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudFormationChangeSet, CloudFormationChangeSet)
+!define CloudFormationChangeSetParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudFormationChangeSet, CloudFormationChangeSet)
+!define CloudFormationChangeSetParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudFormationChangeSet, CloudFormationChangeSet)

--- a/awslib/ManagementAndGovernance/CloudFormationStack.puml
+++ b/awslib/ManagementAndGovernance/CloudFormationStack.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CloudFormationStack [64x64/16z] {
+xTT5UWH134DX-PiYwVxt3GxRGwvmwj-stgePtwvE061YcWmmAerlFQkbL6xxWfJo4_hLhxuYfMvxSQHGRxt49Ca0j9xMW7bspSt3C5unWC4hjiy_ngJN_ihX
+RTzhRBpteyQwRbn_ZQyz6sA5lxzV_Uhpzy_y_Jlx_9X-VirhxgbiADqfCBz4yFwG39tY2R77InX5zrPgqZWXjN3ftv-Lhpq7JWmslmolltAbTyllxrU_-cf7
+whQt4zlUBQF_jzTUJWkNqV_ZXVi_NWBL0JRLsOJBR_SC
+}
+
+AWSEntityColoring(CloudFormationStack)
+!define CloudFormationStack(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CloudFormationStack, CloudFormationStack)
+!define CloudFormationStack(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudFormationStack, CloudFormationStack)
+!define CloudFormationStackParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudFormationStack, CloudFormationStack)
+!define CloudFormationStackParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudFormationStack, CloudFormationStack)

--- a/awslib/ManagementAndGovernance/CloudFormationTemplate.puml
+++ b/awslib/ManagementAndGovernance/CloudFormationTemplate.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CloudFormationTemplate [64x64/16z] {
+xTTLOWH120JGHK93tV--woup0yIJzr_jkdedb7INzaZocn8aW4mQ2BdECs2QO03VvNcLmByr_-OdLifxu3X1e58UOJkEgENZq6wDtv0NVpGIUOqdQ3hlkZFs
+uy_snCpydUQ_rd-Bar5R_tJoz_PlGcVy-lFNNp_pw_Ttd1_qH28lySW_yFouFxzPdoZU7_txw-Ftpt-Uv8HA-O4JBvuV9zNzDsIBxLUS7oIFEBN_yI3cnk-m
+3wjvXEy43ktdUxFjH-mLnq_iH3zs__pdk_-txl-n_t_j_v_xDW
+}
+
+AWSEntityColoring(CloudFormationTemplate)
+!define CloudFormationTemplate(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CloudFormationTemplate, CloudFormationTemplate)
+!define CloudFormationTemplate(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudFormationTemplate, CloudFormationTemplate)
+!define CloudFormationTemplateParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudFormationTemplate, CloudFormationTemplate)
+!define CloudFormationTemplateParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudFormationTemplate, CloudFormationTemplate)

--- a/awslib/ManagementAndGovernance/CloudTrail.puml
+++ b/awslib/ManagementAndGovernance/CloudTrail.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CloudTrail [64x64/16z] {
+xTC5biCm30JGaIsS-zztorm7zd6VVnW40VFdJDCqLPYgHVqpMWKNMjml1AAU6IgGs1_-A5i6EFT9WRya2-xIOQ_TI34ZjtVV-4BH6u2Mt4JV-oq1cZOWkOL8
+VMHqaex63UhpjheKRfiQI7H-Pp2kSXd6Ez1yfVaEz1XTz0wqueA-yfMoBoPmjDhmSmsb5rUKI8qkNLntrdwlJmrdbJWQLZ7uA7Cxgsn7VIL-rTx-Go-oL8Ec
+Dv-3gGPzNKG1Ii6DlT-c_AhoWimivbszXKiDmekF14UiV1Sca1pzUdPjEWD7GiCNmy-I6jIpolE6eHyy-HkcQPeE
+}
+
+AWSEntityColoring(CloudTrail)
+!define CloudTrail(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CloudTrail, CloudTrail)
+!define CloudTrail(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudTrail, CloudTrail)
+!define CloudTrailParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudTrail, CloudTrail)
+!define CloudTrailParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudTrail, CloudTrail)

--- a/awslib/ManagementAndGovernance/CloudWatch.puml
+++ b/awslib/ManagementAndGovernance/CloudWatch.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CloudWatch [64x64/16z] {
+xPP5ikH034HJ37F_-quqKvM_OUktQbAAKXtkNqvEJYepgtUInhZ0jaUYz1AggXSHsnxE8Azx7O3Krl3ta6JmDW61JDwl8i3rNOzthru68xwN0N86IDSe97ZG
+4S12gmPXy84cvNMhicPwsJzutblB5UtFY_I_pLIq49-WgB-CIxKa3l9burekwOS2KckC-w9SXTNhwMUPhau6qOOxMYyxhXvTCKYZAer0-PZYPBgor58fg6OM
+kH23xIhqEW3Bj_uCCNQ73nPUxGG0-JejWwzqby8x0GktMuMo49-GaPdbxTT4DUX_Ely2Tn5z7LVHnA8ANHElqAcz_Ui3kiJ4Hpyslv00h3xxpmxmgnvg1sNF
+20BuWLJRPIKUhmrfbouUc18UK7NXVTIrwX-mddH_L5kCcS0S1VcpDodTB600gRiohdFVBf22AyBWNG9TuHxP9HE1jRm4-f2088u8_5D47n0GKFK10L3qVbuF
+4YSd9_y1
+}
+
+AWSEntityColoring(CloudWatch)
+!define CloudWatch(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CloudWatch, CloudWatch)
+!define CloudWatch(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudWatch, CloudWatch)
+!define CloudWatchParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudWatch, CloudWatch)
+!define CloudWatchParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudWatch, CloudWatch)

--- a/awslib/ManagementAndGovernance/CloudWatchAlarm.puml
+++ b/awslib/ManagementAndGovernance/CloudWatchAlarm.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CloudWatchAlarm [64x64/16z] {
+xTP50kKW48HXsg2hxd_ViP01bisuV9idoO-jQ3-TYDp7FW0Wusu8IsAAYzn9OaJq936kyYxFrwmF822iJPAar_eE-ZcQ5AVFOpV51HZfvtZebTv1RRj45ljp
+lwFSwtM_zhy0etZ-unmFtYe6QMr9GagzWj1jDFHM4oHyZZN8R5MTP8QP3v0fhSm1WWJ88Us2H98aXhLRQgPosShnlImnxCaq4bRD1IIHEH8a4NVz5oJfzHxT
+-yWSFGouwVty_fA-ytBl81PAkIVp1QBUOpM1R-lzD-cZRwBSAuYl2AtsHY8da7RHMvlihjSswL_T_-__z_zxqwdpxKEdU7jsdUpe0rpU_Z3x3MBrnWqmRtlB
+lFW1vv2BxcJ-jNisVVxrdVWtU7PrxtlqyWtQD_i8
+}
+
+AWSEntityColoring(CloudWatchAlarm)
+!define CloudWatchAlarm(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CloudWatchAlarm, CloudWatchAlarm)
+!define CloudWatchAlarm(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudWatchAlarm, CloudWatchAlarm)
+!define CloudWatchAlarmParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudWatchAlarm, CloudWatchAlarm)
+!define CloudWatchAlarmParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudWatchAlarm, CloudWatchAlarm)

--- a/awslib/ManagementAndGovernance/CloudWatchEventEventBased.puml
+++ b/awslib/ManagementAndGovernance/CloudWatchEventEventBased.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CloudWatchEventEventBased [64x64/16z] {
+xT85ZWGn34JHDcMwwlxtNOvYhz33zCKblSPiLqngJMqxQj7Y0X8vzYxWuC5J0Uuz3od30QVvyKh-xT-UePO2MrxvFuojKu2rWsojn4gwNJlpLNYR2rA4zpsJ
+P_GzGlvImDi-6IbUHixRta6iA6rFxZCGVOzb0gTvlnCV8nLjh-MmGRlUIAnVGZl2svpiEAzpqgVsR__sRs_wr-3qCQUOdcDELdo0gUbJqwSGonjJmFUaA9j-
+Rq2zv4fpCgVKpoHrEbD-GjyU9tGEBoUqdTmd
+}
+
+AWSEntityColoring(CloudWatchEventEventBased)
+!define CloudWatchEventEventBased(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CloudWatchEventEventBased, CloudWatchEventEventBased)
+!define CloudWatchEventEventBased(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudWatchEventEventBased, CloudWatchEventEventBased)
+!define CloudWatchEventEventBasedParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudWatchEventEventBased, CloudWatchEventEventBased)
+!define CloudWatchEventEventBasedParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudWatchEventEventBased, CloudWatchEventEventBased)

--- a/awslib/ManagementAndGovernance/CloudWatchEventTimeBased.puml
+++ b/awslib/ManagementAndGovernance/CloudWatchEventTimeBased.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CloudWatchEventTimeBased [64x64/16z] {
+xT09jgGW38NX92J0lVjVS6CTEMBrPBJdVd_DfH-J_F9KzRxrXb6lTei7PcoMrjf0eaNKJX8bouU2oojh-G46QRfPszuTX6Lu8RkC570PETaolXEsUccaNUT6
+LZbv8-frxw2TlNJqwxu2klZvLyQBM2d5ENraVDjy1ycydukTFfOXh-QaYvLNAg-0TjqhsDv7XClrAkXl0q8JNa4KEMf4I2Rdic3hP9DSmM5SHTGgoAwIp04I
+8uwQIZgj8BROYznAlOxSxc4xVK_NsQEOgfeti6IvWWG9W20HURzpW21zFTSr_wf7Q8cHcm7BRGxYYFeLlnWzUxBFGEGz3XDuvlqFyL6N8kqD16Q4PNqXqVT0
+bhmVPg_SyoPxza_x3__XFtonlShfm_PYUbRRAoSVuDBqIzCl8GvVk0J8oC0bc8o0zo5djgRphoNPKbkJ7vG_I4Puq8_m-Y1vt2S
+}
+
+AWSEntityColoring(CloudWatchEventTimeBased)
+!define CloudWatchEventTimeBased(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CloudWatchEventTimeBased, CloudWatchEventTimeBased)
+!define CloudWatchEventTimeBased(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudWatchEventTimeBased, CloudWatchEventTimeBased)
+!define CloudWatchEventTimeBasedParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudWatchEventTimeBased, CloudWatchEventTimeBased)
+!define CloudWatchEventTimeBasedParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudWatchEventTimeBased, CloudWatchEventTimeBased)

--- a/awslib/ManagementAndGovernance/CloudWatchRule.puml
+++ b/awslib/ManagementAndGovernance/CloudWatchRule.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CloudWatchRule [64x64/16z] {
+nTPN5fum34HXoSQsvkv_loca2P-48qZxtk_yXMh_tJ6kcZsZNNlOitau84rF9gXRdKl3iW54aQS-3QW4I7roh990gNzkw7dlqp-N_MNleN2RKZzxdlQs8ERN
+K-GGBVNbWJD_svk0Rg_x0H1-wQTdTcU20i9_z82oUN-ogzcIZkzzGnTmDz2YcTaQwVkFgpW72hxsEmzOes9nzdtJ0bJ1sJUk53rKvMU_YUPLTlQp9ml2hQwX
+mx8bj8fIVnsemVV-jA94AFNF3RtjZ_vR_K3jD_e5wgzx3r2pL_rOrWJXzge_H0YMsxKV3xuwZFtueSZ6tO3EBxlt6TmDh6wfnyryNQM1L_Ul9fYzOdBslkcY
+wEnTczdrf6-04ZHRhxApNoCHJ7j-_whV_pDFVHvG3ItrQQ1Oa_lCIuQslYozVxpff-Plz1uWVzstW6Zsgf_T-eyRq7ZQBsa2u-tpOm3eiAqdLdQpTe2wxJqe
+usPWHBEjzxY2RM2pzxik6EtAVsgcVXieodqUg2BrIJisurVil_i8
+}
+
+AWSEntityColoring(CloudWatchRule)
+!define CloudWatchRule(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CloudWatchRule, CloudWatchRule)
+!define CloudWatchRule(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudWatchRule, CloudWatchRule)
+!define CloudWatchRuleParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudWatchRule, CloudWatchRule)
+!define CloudWatchRuleParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudWatchRule, CloudWatchRule)

--- a/awslib/ManagementAndGovernance/Config.puml
+++ b/awslib/ManagementAndGovernance/Config.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Config [64x64/16z] {
+xTP5ekGm34NH9yaMPV_xRKCn9Qv9qx-Zq0bJ_X7zz5EOxcVllU58_jOhYkubi0zUj_pSLZ_xJAUMP2-u3NBS3Uvw0p5e80SOc7uC-Y5Vay--R7BsqWRNVVBL
+5yItNWKa1D5zxyFdlMVCUDU7eWIHnuFtQD6-PypAWxSUzZsXY1I1VBd_nDkMMpnuAw3AABRl8Is6V7dz6BFwvFFe_JFE__FzD_pAzNU564FZx1VlNyPCXY-f
+4fdbk2VK7ZXRaJEZuvu6F7aH5gbj80vxK0-b6qUFLtmXWD2uGKmWuK0rubXwVYKDFT9CGOzZmPSmG9bjJ8bAjO3Zk8zeFAz59aEE-moP5y0AI_Kn5RhWquOl
+6AcxWVAptsvykC0wPmkl1204wf-y69szf00KQVES6GCyheUzzOuMvVJSlBI9bGOeGqPXw5kVDnzfjSlpdxqmwtCsVU_ZjEHelddxZakfOuPRP4Pzvq7tSVEG
+UUDvdbRdXDVU-Qce34ICnw0r7cO5iUVXAceG0QALGPx1y5p8G15XX9Ru75_WGQZddoiV0uooullYxkSn2-yhN5i10z8ld2k31rzS0GWeMz0OgBbOYAQ2jO8y
+IkVhdT-VNsVQylop-kcdNm
+}
+
+AWSEntityColoring(Config)
+!define Config(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, Config, Config)
+!define Config(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, Config, Config)
+!define ConfigParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, Config, Config)
+!define ConfigParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, Config, Config)

--- a/awslib/ManagementAndGovernance/ControlTower.puml
+++ b/awslib/ManagementAndGovernance/ControlTower.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ControlTower [64x64/16z] {
+xPO7kkGW38CbY47o_U-xnQ-NoPUGxJl_z287SCr_bpjtUhyc1_ebUMiN36oWJMovY8W8KBcA2L1pLTrbqh6u0JTiAQM8aGjCz2mKpXNazVYntiIF-tPsxyfq
+1u3kSiHsIbwgYKOsp2m3EgFlzJf4QjJRSr5WvmDalk1ZsXTlAu3GIpXlH-IruI9GH1P73Z6KTNIU9KUGWJ8momkqOZVVgQtNcv42bMIAK8wA0zj4tvE3gZTD
+6OWwltgZLZeJjmoKofNk7I3vuQbNGN1PkgRVMx-Nrry6h7dx_29KyZt_4IDl-2zG_jjdWluOFqKxb4DpteZVjF8WpW_veppEv7YVlu4ueGT6lgaV0SxJjVUb
+VcLGUORfT_tNUHezzV_XjUuxiuYr5Zw0aLAErGuyCKnQJRc6HO3Eg_F3rVdbulpq--QtYfz_bpjtlW8
+}
+
+AWSEntityColoring(ControlTower)
+!define ControlTower(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, ControlTower, ControlTower)
+!define ControlTower(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, ControlTower, ControlTower)
+!define ControlTowerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, ControlTower, ControlTower)
+!define ControlTowerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, ControlTower, ControlTower)

--- a/awslib/ManagementAndGovernance/LicenseManager.puml
+++ b/awslib/ManagementAndGovernance/LicenseManager.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $LicenseManager [64x64/16z] {
+xT85WXin44JHgWOrxFtl6tcPBIcSxBU7vmttdzHNNrM-MwrwnVlPeYVqdMJv0EHxbve0RDbdt5NzK405jkeLTurdtafWYtxuNVdCKmdOyVqJbxZcArzN6NDO
+zOftqYukUjTtydKV_aun_I-w_entodNlyax-www_7ikinzRzGwM0FYtk-Sh9HQ1pvi3x_VTEp7pR1o0qdna5Y5tl63s86USC_C0Fm28C60TUuM3EcPi47Bhd
+Io6ASJ7U0oRGsl43caHrjS8BaegnumqnPtfG87MP2zYE3p04DN3X1GaYTdmRQF2ReTNjCC8sd__KnEZP01rsyFu347S1ykpxwL3CDFh09q3eY1WA0hdhEuG4
+gm1IedVzhCemiwhk4ozIJdg9R7b4tbPatQlAsm9B_hxd7lSj-67tJTSfaZsztJTw8p88CCW-YW3S0Ppxw8vZhyoU9VNCLprD_yY--keR
+}
+
+AWSEntityColoring(LicenseManager)
+!define LicenseManager(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, LicenseManager, LicenseManager)
+!define LicenseManager(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, LicenseManager, LicenseManager)
+!define LicenseManagerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, LicenseManager, LicenseManager)
+!define LicenseManagerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, LicenseManager, LicenseManager)

--- a/awslib/ManagementAndGovernance/ManagedServices.puml
+++ b/awslib/ManagementAndGovernance/ManagedServices.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ManagedServices [64x64/16z] {
+xPNNecex24K7a12O_l_ttcAMUkk9sxTJnejrqc7fH-KNl-ZwW_vGcs7SiSZM5wa1UCm_20UYz0LwW6U_Gd4OhNTPXgz_VENOqdiaJFsB2VcctDR_H3LrPc7r
+U3j7-CjM6Kid-lMd1S2ubUVpYzA1k8BiKc6L-78OZnh4CNf_XZ4njG7k-7Rifm3yYZu0R4gzXbVxvRWEyiAl7dXQjDIzetgp-OFSPbXgASFCS-TzfYMdUdVA
+ImemWsWv8_8azsWyl1zT77SZvOGMu4Sz3bnwKs5zVL_ADEkpWIqlCq9vJS9-SmkslhuTGUyvyzHaFPeojCOrbuEX_wMpjo0aJPvZEnH0tUKmTA3nMizPKB1a
+Ldt9EHime1JS9sZWZx4kt4cZJsDaJgWT8WmhhQilLKvNwOoJwcbWuoffNQdf7Sh8_G1eQNW5yrdBTmXSFUxjI0S8gUQI3e-JdlauTX60TyEOMCzTrBKE2soz
+tpZuDAgDrYevuU2dA_nQrM7hjlkzTa6gXyF1G3lpjS-9-SZM36EeMzK9VQxyW-xh6Z8q3L-tE7LWmVnNLM9fOWwLp7Fle_vPb6wpKZBwV0lRORPU98p6zsOw
+b0waGMJjvAjLk9oiODxk3JsnnyNy3umXERK0N1c4tg3N30CmJoseMusOMa3gJVhExiaQsRebPBQ-J0BW7KnzH1BJC3xLgwG5aQtFgTQFn2z-yJi
+}
+
+AWSEntityColoring(ManagedServices)
+!define ManagedServices(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, ManagedServices, ManagedServices)
+!define ManagedServices(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, ManagedServices, ManagedServices)
+!define ManagedServicesParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, ManagedServices, ManagedServices)
+!define ManagedServicesParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, ManagedServices, ManagedServices)

--- a/awslib/ManagementAndGovernance/ManagementConsole.puml
+++ b/awslib/ManagementAndGovernance/ManagementConsole.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ManagementConsole [64x64/16z] {
+xPO5TjX030M_MDhS_xm1RJXnd-nocp73BDFw9_ZYYx8nzPdl6EEV-ven8FN8zrNriFTnZ1_xnCkG1RdegosNBF5h_iqQS7FeiunW-C-fFwiHTbn-8_nN-MLw
+ZzLLFz7a5JyuZ22P0hBWEEa77f1xBQHlO-vlNKbpDNb_2yJORzrNhMTgEH1pNy7h7GoT-_MXq1EekU-GRIdpOoa8VEfNC5eAl1HzWgDclWFKuH2ioa3j4U1J
+NpfwWxswfCpzVQF85XzBti_xqQLmtYThSRS2ti4OJVsWnyeMi3j37fi4nRpzUJk2UwJ3yZFjBy6rRzopRugHSpy-jjzVstyOKb7haOeIS8tz3e10jjkF4QZr
+kRy306mj0rxqiR_AgnIaIj0ghqlZFvgwFFzayulch-FrKxtaw9lhfoDYlJIini-j7rzA8AofzK_mnHTt
+}
+
+AWSEntityColoring(ManagementConsole)
+!define ManagementConsole(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, ManagementConsole, ManagementConsole)
+!define ManagementConsole(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, ManagementConsole, ManagementConsole)
+!define ManagementConsoleParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, ManagementConsole, ManagementConsole)
+!define ManagementConsoleParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, ManagementConsole, ManagementConsole)

--- a/awslib/ManagementAndGovernance/ManagementandGovernance.puml
+++ b/awslib/ManagementAndGovernance/ManagementandGovernance.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ManagementandGovernance [64x64/16z] {
+xTPLOiKm34JHaHDB6dV_-ssOFooNuJo66oPybN-olWewZSf0sdjzAK4yz-LNzlyzLsszOsN1dZwWGcsaoFCNjRq9PdF1vQDOPI_91fwNlY2x3JfXLS_b6qC_
+spx7UayhZ_TddzHpub1UrFKKF1FMzSZsf4TjR-M91dldctf2stkQANexOAXtN7ceBxVr7v__PEiNR5h-fy_1dhupP7T_y_BxrF4VKQnv-RKl_pkhxdlD0yqd
+sjNsIIQ0dAMgVi31jF_nfFoCu-zAaZr9mk3vSnKyVnO--vNNJ_zzPfIV-WRlroDrBP9W9Ktm6xm2
+}
+
+AWSEntityColoring(ManagementandGovernance)
+!define ManagementandGovernance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, ManagementandGovernance, ManagementandGovernance)
+!define ManagementandGovernance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, ManagementandGovernance, ManagementandGovernance)
+!define ManagementandGovernanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, ManagementandGovernance, ManagementandGovernance)
+!define ManagementandGovernanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, ManagementandGovernance, ManagementandGovernance)

--- a/awslib/ManagementAndGovernance/OpsWorks.puml
+++ b/awslib/ManagementAndGovernance/OpsWorks.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $OpsWorks [64x64/16z] {
+xPG7bjqW34NV4qX8_FtlDvPocBHVpAGdlkw6AphpJ-NYOjZ1UBSUAE9TRXzpW6R4yT9ZLnT0W3PdgnU9JRqaEwom2YMnfxSvLiVbMziAC83nuCyv598FrzRK
+yqsW6_fDAxkXi0gejzFwK29ADtUh007gEAa7WLQFCWOODOoCapvedbwRHSiuRiHfNsxLUbsTQTadik5xPFbz5ZtB3z_maMeWXVNi6mj96nWr2NnEhw4FectC
+W0whEqXKC-ouRs2GV8n6jXf4WMteZfKzOWM4R_Y4Jbz2lYdeSoj0FyvIl8EzzBq0IVyuS2Xz2nSDFRHiIgZuhzv_2-q7EdyZhNsVJ_vYFuPz3ccVC-ALRtYA
+lVRxu_Bx6TyUjzzU-Oq0kCPia00vxYJU9mWHUTle5HGXz4xY8r-EkwmiXZ7dW7sH-3FzosVDkRVnwsOTUYVnaO-4QxfzEUU9fFn7k2M-mbaHTnB_22ukFW
+}
+
+AWSEntityColoring(OpsWorks)
+!define OpsWorks(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OpsWorks, OpsWorks)
+!define OpsWorks(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OpsWorks, OpsWorks)
+!define OpsWorksParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OpsWorks, OpsWorks)
+!define OpsWorksParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OpsWorks, OpsWorks)

--- a/awslib/ManagementAndGovernance/OpsWorksApps.puml
+++ b/awslib/ManagementAndGovernance/OpsWorksApps.puml
@@ -1,0 +1,12 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $OpsWorksApps [64x64/16z] {
+xTV50GGm24JHED9_lx4IXlMTVt-t2AHu6UvoCJZPFBixfZVCsvjBWnAtwwqbg6PVx-dftJhckztx9r8nNqMsVtj3uSPZtYyLAFs-zukUdfwUdfwUFho_HUUl
+uFuQtP_ZBG
+}
+
+AWSEntityColoring(OpsWorksApps)
+!define OpsWorksApps(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OpsWorksApps, OpsWorksApps)
+!define OpsWorksApps(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OpsWorksApps, OpsWorksApps)
+!define OpsWorksAppsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OpsWorksApps, OpsWorksApps)
+!define OpsWorksAppsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OpsWorksApps, OpsWorksApps)

--- a/awslib/ManagementAndGovernance/OpsWorksDeployments.puml
+++ b/awslib/ManagementAndGovernance/OpsWorksDeployments.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $OpsWorksDeployments [64x64/16z] {
+xTS5paCn30FWlK8Q-_xt_M6j5CrZfaOm_EoCzrOlFKifopK-0_aQdyZqZdxwwQUVFfFv2bv0ebogK-DwMhgY_D8LbaQoBN7cad8vVswvNBoWVCyrnylrEKyd
+hv2ZQdkfV9GdHFds2aZ7l85rtssLi6E-mVVVw6YVvwUVVlfcuel7zwyNyQOv1jg6BuH7BSk6DyAslpLj-CxPJLm8R_5DgW731u-0xeLBmF32nnN32vS0WmVN
+08S9ru3QuC4rmD6gSFdjw3Eu18n1ElJRfLm3j5q3X6k0ykq01DyEE7uucYmVIBUqkl7y0W
+}
+
+AWSEntityColoring(OpsWorksDeployments)
+!define OpsWorksDeployments(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OpsWorksDeployments, OpsWorksDeployments)
+!define OpsWorksDeployments(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OpsWorksDeployments, OpsWorksDeployments)
+!define OpsWorksDeploymentsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OpsWorksDeployments, OpsWorksDeployments)
+!define OpsWorksDeploymentsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OpsWorksDeployments, OpsWorksDeployments)

--- a/awslib/ManagementAndGovernance/OpsWorksInstances.puml
+++ b/awslib/ManagementAndGovernance/OpsWorksInstances.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $OpsWorksInstances [64x64/16z] {
+xPS5hiGm44F3YNt_-owaggnEFy_dpHDRULteW1Byn2CsjAaDEuwqUvXXoFUqcR3V7qaIWXptanK4157lwJ176My-s8iOc7u1gy9AbEbZ5D69wQC4qNOVKM74
+xhSW2d3s-yj-D_xob--jFuukmCqdUnVavXDT32AU-mylzH_E_HVQE39Ffc58ywacR24iSZcIPbeCCqmcpBCsXDvViU-ldDyVzle1plEN9jNy5Tnyr2XK_qbX
+Klr7KV6JytVvQtvwwzVVFzx-zSwFXMz_EVUdSt__wVcv_3L_tVStx_tHUN_rtf_zN04
+}
+
+AWSEntityColoring(OpsWorksInstances)
+!define OpsWorksInstances(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OpsWorksInstances, OpsWorksInstances)
+!define OpsWorksInstances(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OpsWorksInstances, OpsWorksInstances)
+!define OpsWorksInstancesParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OpsWorksInstances, OpsWorksInstances)
+!define OpsWorksInstancesParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OpsWorksInstances, OpsWorksInstances)

--- a/awslib/ManagementAndGovernance/OpsWorksLayers.puml
+++ b/awslib/ManagementAndGovernance/OpsWorksLayers.puml
@@ -1,0 +1,9 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $OpsWorksLayers [64x64/16z] xTQt0O105CDGCjZxxqiQmIvFwb_vmzGtn_tyLDpvyjcsebuulru-jwZJ-hssAMfJuV5uFBxSN-t-BFTtUp-wY4RyV_X_y7Wy_m__pmC
+
+AWSEntityColoring(OpsWorksLayers)
+!define OpsWorksLayers(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OpsWorksLayers, OpsWorksLayers)
+!define OpsWorksLayers(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OpsWorksLayers, OpsWorksLayers)
+!define OpsWorksLayersParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OpsWorksLayers, OpsWorksLayers)
+!define OpsWorksLayersParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OpsWorksLayers, OpsWorksLayers)

--- a/awslib/ManagementAndGovernance/OpsWorksMonitoring.puml
+++ b/awslib/ManagementAndGovernance/OpsWorksMonitoring.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $OpsWorksMonitoring [64x64/16z] {
+xP9NOWD124EPObXq__kck6eBBZWze-zzMFDakJyZ8_KvNDsAvBC3CEKFTBp7Qn9l3ZG5lENKET15iWVA1EoE4hm_pXkWHms-l_HO532Hom6D95aFbgFXMdYW
+kiFgrd9U5YvjYv_s2--MfLQhbuaBiIHJ05QNopMH-02_yg27AvHDtyNs7tEQ7rvPkCB-bpHOj0GrkO85ggIxbuMx8y8Lb6h6FF_1k08D7_7iRX-kC2sM2_dc
+z25LW3UvWoTtYmfTxk7P7QSrkOEdZO94FBbByUGkpLSdoGcUt6Lu9NS9lZYvI_7Uq_pW1pzuhQdeaKSwxxpu4v6tr9vEbM_DoCWh
+}
+
+AWSEntityColoring(OpsWorksMonitoring)
+!define OpsWorksMonitoring(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OpsWorksMonitoring, OpsWorksMonitoring)
+!define OpsWorksMonitoring(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OpsWorksMonitoring, OpsWorksMonitoring)
+!define OpsWorksMonitoringParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OpsWorksMonitoring, OpsWorksMonitoring)
+!define OpsWorksMonitoringParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OpsWorksMonitoring, OpsWorksMonitoring)

--- a/awslib/ManagementAndGovernance/OpsWorksPermissions.puml
+++ b/awslib/ManagementAndGovernance/OpsWorksPermissions.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $OpsWorksPermissions [64x64/16z] {
+xPK7UeKW40PTTYd_tF--AQGd-3t4z6HUKLU6NhPlZ7da76vhjbSXIQZwSJjL11r1ImVr4AX6CajH1Of3UWRAOvbMW7oazDS5XY2cTHFobo4Nibc_3WeBg9Dw
+6YQjaERyh55AHtdERsfpuJ4cbL6yI3RNVCNEb4f_mNVmLV_V__VJic-TWB01MRXrTdHN1q03dkA-ks_r16DTJs_pxfbJyaKAYbtVjejOzzS7A7sYdqfh9Itx
+MPsyw0VG6X1hVaFUJzwsv2V8lHMGLdm7VxekbL_wkGTfiVs4MR3G_eu34k1h_kO2K2pFFojGxCJyJ_JGel_lk-HdV8km4txdx_Zdpm-tY_YkdyKK--Vd9B6D
+YJn5rxyBrm
+}
+
+AWSEntityColoring(OpsWorksPermissions)
+!define OpsWorksPermissions(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OpsWorksPermissions, OpsWorksPermissions)
+!define OpsWorksPermissions(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OpsWorksPermissions, OpsWorksPermissions)
+!define OpsWorksPermissionsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OpsWorksPermissions, OpsWorksPermissions)
+!define OpsWorksPermissionsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OpsWorksPermissions, OpsWorksPermissions)

--- a/awslib/ManagementAndGovernance/OpsWorksResources.puml
+++ b/awslib/ManagementAndGovernance/OpsWorksResources.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $OpsWorksResources [64x64/16z] {
+xPS7iiCW34HDHxx_VTEZ6V3xCyllZVI45xn2Ys3xs1RZM-XGzxs6L-F5zakpyZewzGlSskMffrS8luAMjotRzM_Ygl3RXT-aXvkCXJ3ucDErB0dl2RvIXTjn
+i6ocXE4craXigEOX4ONpb0Z2jGuyPq9ArY3-ee-IkmkNChCFOGZ-5JOUB8nXhzj2g-D4v5jO5wqvyIvV2y3CDywxb_AmpNpqx9Ai6G-yP3Bl0ZocFnk0U38P
+MvDvDXbRatdN22BYj0u3ZrPYqp2F_TcQmAF9m9eQxnYuLU6zRdWT4Vaf39DmdVSVo17CSxVu_Vb__fzFQtmQUNEJ4e_Mjaprctcktx3QCCzB6-zVcEUb5NzX
+daVXwiWyT-0YnJoNDYwI4m-bLTW_Eo_idq6byu9m3iED1-7o-UNAQ-SNph9w0IapvJ3SMa-VVdxqERSQlk3yhBSp
+}
+
+AWSEntityColoring(OpsWorksResources)
+!define OpsWorksResources(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OpsWorksResources, OpsWorksResources)
+!define OpsWorksResources(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OpsWorksResources, OpsWorksResources)
+!define OpsWorksResourcesParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OpsWorksResources, OpsWorksResources)
+!define OpsWorksResourcesParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OpsWorksResources, OpsWorksResources)

--- a/awslib/ManagementAndGovernance/OpsWorksStack2.puml
+++ b/awslib/ManagementAndGovernance/OpsWorksStack2.puml
@@ -1,0 +1,9 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $OpsWorksStack2 [64x64/16z] xTSv0S0m5CFGtgtDdsyl0ac-Lsb_03JbpUL-VghS-VBPjagzS7wzV6wbJkltsgPIc_1uF1xV6HwFn-FnU7pyR-a_Xl-Q_dFU0m
+
+AWSEntityColoring(OpsWorksStack2)
+!define OpsWorksStack2(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OpsWorksStack2, OpsWorksStack2)
+!define OpsWorksStack2(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OpsWorksStack2, OpsWorksStack2)
+!define OpsWorksStack2Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OpsWorksStack2, OpsWorksStack2)
+!define OpsWorksStack2Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OpsWorksStack2, OpsWorksStack2)

--- a/awslib/ManagementAndGovernance/Organizations.puml
+++ b/awslib/ManagementAndGovernance/Organizations.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Organizations [64x64/16z] {
+xPG7biCW34Hdg59o__Dk4PWNd2fd-_gdZXxV3T3XvxApK-ipjaGWobPRCn02a7MJNWYMyUD50f3in9g082xPd2YdZo6fGnU2TPe6WkAODQpkkH2e7Zy0eOxu
+ddn-LflwiGWqE_rsrgIQsfNu_JRro-pxVPl6CN5-to3jvz_vGMPVWiVNiM78iPtKkVcHjVcQ0POjpQU--zLQqCRcHsvlWNPckuhD5B8SlfEKdlD9vxJ932ap
+Ubidxa2zvGiO9u0v4tBBLyJRzn-Xd-QhgY2gwac1d7E4ZC8A8HgCbZMmvz24E0R89R-0mUZFM82UOUELFHFbij_BOV5JosdnmnXuqT_zuygtV5pvnwj-BFaT
+BdwmNCBYCrkEb_sA1LeM3CGA7BbUyhMMZhJ2o7suZAo77y7EpYi
+}
+
+AWSEntityColoring(Organizations)
+!define Organizations(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, Organizations, Organizations)
+!define Organizations(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, Organizations, Organizations)
+!define OrganizationsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, Organizations, Organizations)
+!define OrganizationsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, Organizations, Organizations)

--- a/awslib/ManagementAndGovernance/OrganizationsAccount.puml
+++ b/awslib/ManagementAndGovernance/OrganizationsAccount.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $OrganizationsAccount [64x64/16z] {
+tPO5ZYH130IBond__-zXxLhDxTE9niiGOsSQrEaZe_PfDaVD_qGtGty2zJYT9u3DQG9PYU86wd-et0nKm_XqsGCKgc28aP971mlWvV3l0ree_KvlLgI0atyU
+eWJAFtIyejS2Abw-2r0FyEM47_ylVrn_2UXFOgPTz83_tgn0_mFp5v__1XRTlv5TV7J_KXMev-_zfuVITm6WTNy0pVS5T0dq1vH0cC05FKGnm5fEkKsJRFQI
+Kfs0wblbxUJtxrneruLsO3ol3lskj7AlNT3kh6c_Fr-_XZrBp6CDnadqPu5DmCKkPw5y1NeJxC-dUherxTQTkL9tUPVUxBWFjKPU9d2meK5x43xBfXRR_F-y
+KL-Fcfkj5_GBEw_mVkfvtunwkIb_2cO-spGDbq-vv76_TaTYU3Naw_mozylzD7d-8TtmbkgtN-vdtlBf9d_oiVbgVqexlkJJMFmtv-EtuK7daR_uTSTSnpR_
+1S_YtRVbuvQl_IfM_Txd6digsFBrW_ZqdizdV7dDetRaktZ1-xWxxxyiRtW_NultO_esybYF51MA7z10h8mDgbSJYALO87SZ65s02m_74Zvod7GRNFYdn4y
+}
+
+AWSEntityColoring(OrganizationsAccount)
+!define OrganizationsAccount(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OrganizationsAccount, OrganizationsAccount)
+!define OrganizationsAccount(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OrganizationsAccount, OrganizationsAccount)
+!define OrganizationsAccountParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OrganizationsAccount, OrganizationsAccount)
+!define OrganizationsAccountParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OrganizationsAccount, OrganizationsAccount)

--- a/awslib/ManagementAndGovernance/OrganizationsOrganizationalUnitOU.puml
+++ b/awslib/ManagementAndGovernance/OrganizationsOrganizationalUnitOU.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $OrganizationsOrganizationalUnitOU [64x64/16z] {
+xPS7UgCX34H_WOGqS_y3ho7wICF6RRjVugv7hyTZl93o078S1juDxEJp0ReFwfqGmuVSsNBuG_sNNypThTpf5oSwTBd7Lv14ZESoqxJMLAxnAyXsygJwJ42o
+HBht1PnXHlhuBa029DhMLz3c1oThVm6zY2Z8klE3E2O5FST2UdvaR7mPnYGGFOIPRGDawzk7ZuxuQ2bPRlK_XXWsVfRuGuWVHoLjqJXhl-536okXRvfsmKdR
+-OKCcStFyMCZ6Qs1k_xh61blKPf3oTW1Ex2ThnovMGkIgACOS0SG_IluHRy61o0uy7BwilJm7bP1-0NVkjhKaQyalqoQ8Esitq0soLqnbmBIliulMVYfenwV
+KNn9G0bR-vhp_JCrPzqa64jVaFeNAbD839ILtq0zLXXXdzEh2x-0Vgm9zfYIsChFMRv6X-5W0btuWRYmKhUDdp5BSXaeTR9elvAfBcc0RFQFRDKrIfQDhs1v
+q4US0zVvvzdxrIyZ_-ZvvULJx-HPzuUxWJryVtgC5py
+}
+
+AWSEntityColoring(OrganizationsOrganizationalUnitOU)
+!define OrganizationsOrganizationalUnitOU(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OrganizationsOrganizationalUnitOU, OrganizationsOrganizationalUnitOU)
+!define OrganizationsOrganizationalUnitOU(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OrganizationsOrganizationalUnitOU, OrganizationsOrganizationalUnitOU)
+!define OrganizationsOrganizationalUnitOUParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OrganizationsOrganizationalUnitOU, OrganizationsOrganizationalUnitOU)
+!define OrganizationsOrganizationalUnitOUParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OrganizationsOrganizationalUnitOU, OrganizationsOrganizationalUnitOU)

--- a/awslib/ManagementAndGovernance/PersonalHealthDashboard.puml
+++ b/awslib/ManagementAndGovernance/PersonalHealthDashboard.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $PersonalHealthDashboard [64x64/16z] {
+xPK7pYCX38KVniRb_lVTEcE11k-6gFxbKmsIUGMF4f-ARxvn5P6XlfuD4PdEIhJZecjrLkCT81wgWmaWYryOpMVTeyO9jAXgX2vE2EJ_6kUO680PC6A2KL_G
+Spmlw3t7yu9ULVUycW1wcjHANfzNRiuA0uwsESCpROFlxVDplZMFYBueyZx0WCJAFMch2y7Opu_O8y3u_xn2OWzXYIPx_rOzh86MQZiiahhNsUyyucXLJ8u9
+zyXxvyXIvVI6CV_gcMlEPcXUBl1aam7DkgyzI9420NdA03rhoSxo6zl3u2nv4En-bbmkoI1xpF9RZ06-joKBCFCeSFEmcmOBRx1yrGQrnAlzRRYuf3c56HCZ
+DXXR2DzuH3YGBsyyOV4Q325u7CAaooDUA7MFWcgD69dL6pHUO-GQ6T8-GLvFaAv5fgENyOVOG3lfqJ9ivh0uGLClFxep1BJ-iHsHC-VTpPwFkzjrPe36CQdh
+TDpTb3jxU0k22CZZNQm1pU9zDBjxap7Yy_BDDpy1
+}
+
+AWSEntityColoring(PersonalHealthDashboard)
+!define PersonalHealthDashboard(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, PersonalHealthDashboard, PersonalHealthDashboard)
+!define PersonalHealthDashboard(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, PersonalHealthDashboard, PersonalHealthDashboard)
+!define PersonalHealthDashboardParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, PersonalHealthDashboard, PersonalHealthDashboard)
+!define PersonalHealthDashboardParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, PersonalHealthDashboard, PersonalHealthDashboard)

--- a/awslib/ManagementAndGovernance/ServiceCatalog.puml
+++ b/awslib/ManagementAndGovernance/ServiceCatalog.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ServiceCatalog [64x64/16z] {
+xLM7plCm23mm6CZxF_0lw-J6gk9qQFphkouo3ZX6UloX-C4FCgBtYFg6Ms4246AV-YWNGDIyTpS58Fw9Xou0OyvS0Ebl1s_0SxWoeBsNGWfQNfnMIBv31_my
+YZXjU-sWwZZif6V3cej3ikg-R1fB4m3LjHOEt1Io0qs1EBr9dpz40Dg0QmS5vBX5Yce1grbwunqod2TmgI5uLmC52wMp2C9oeD5pNAVll4g-GW6lSa2Xv3E2
+Nmj8A7CinfSQqeVw4iOlQbDSjx51e-k8GJwbMz5cRjf3qJRDLu3ta__yJNytSsmmVwIcAryV8jtZsA6Xrc7ev4zxedB75wbbS07DmKy5bZ4kqGszLfcQmuU9
+sE2ciZ2yQylNERZQXn4Ap8te2kbx_df5APV2Lrlt_5M_KZgBGEai0ldG7Lz1liIGRe26I2Zj5g9p2JOmnEny21TTX8y52Kx1OqrkDaY7Z1fYoAVDycwtRv6c
+SZr_ejFN3jnzHQwHQS_zZBtyUR51V57UQRlmuZxz6RhyhBolTeq8UaEVbzEMpZVQbbnnXjzNmEb8ERXFji6EMvGyvhNpTxKxMFnR1ViCEv3txEU7HMMU0Nrr
+lKUSpq1d_-YgGTwXyv-w5mEQCProxkGRuCtYLP3HFqYb2U37-qW3AaWn22Zf4rGS9xyDEHyZCRgTWZo-Wq7SXLbywG0W_KjaZpp-MFpW1xy
+}
+
+AWSEntityColoring(ServiceCatalog)
+!define ServiceCatalog(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, ServiceCatalog, ServiceCatalog)
+!define ServiceCatalog(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, ServiceCatalog, ServiceCatalog)
+!define ServiceCatalogParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, ServiceCatalog, ServiceCatalog)
+!define ServiceCatalogParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, ServiceCatalog, ServiceCatalog)

--- a/awslib/ManagementAndGovernance/SystemsManager.puml
+++ b/awslib/ManagementAndGovernance/SystemsManager.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SystemsManager [64x64/16z] {
+xTI54kiw30JGbGpIxll__tqJcfk26wS35qyP1F78rY_edt-OqIEfxqGnBAocxcC1hBJMbYoLkYaD7biKky6fMsYevrvWr1q5LMSLHJTq-4l2BaQafXYU_vYm
+PW0yT2tUT5i1r5Q0YGGDNSyIdfBwp4eMf5u4zpwwhZYeaK3zxtfsnl49wxmSN6g43g3nu-1-BC1i1kVKu9vnjRSuJ517uHKBsyCAsgWyzO9hXBi3b4Wf1qkK
+AEzATtP3IewQQSx1Y4WTxMtd1ZZFRnlwP7o5DQ3cSPQW5ZZx-_X0UmrFPUh0MDSYS-xw2RGt_qBNvFftd5SgOjiVXSEjMryo9jl1K5lBWlWmtksfVbK2PptX
+d-Q_9ZTIBOOKus282ChX9KS97B1D43YL8fVxeW7e6c1psoJXIUtrEqh6Wb8sT5tZLZrnjaRsE_6iYmAlgxmH3w_QiQTsuJONxzYtRFEak94AWD04ig8_NtyG
+bjISX2dT0VD3D3JDIbixxUU97rpyz7dQWPYDzvSTVUp9-GJvOzhPh0_AZnCil4cAWiKeVDn1-Dgomzge-XWxbz3MjqCyKbyeM55Vohu8_Mh--UT_
+}
+
+AWSEntityColoring(SystemsManager)
+!define SystemsManager(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SystemsManager, SystemsManager)
+!define SystemsManager(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SystemsManager, SystemsManager)
+!define SystemsManagerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SystemsManager, SystemsManager)
+!define SystemsManagerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SystemsManager, SystemsManager)

--- a/awslib/ManagementAndGovernance/SystemsManagerAutomation.puml
+++ b/awslib/ManagementAndGovernance/SystemsManagerAutomation.puml
@@ -1,0 +1,18 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SystemsManagerAutomation [64x64/16z] {
+pPVdmkii38Fh0RPq__VxZOGSeEuw-zMVPZqADiOqjzyaZKNz-_aEuXBXty-JUOcqx-OR8EFGFkTL7_1EVhjiyWftyenKB2VaO1_77T2NE66tctQG6qzcaoCf
+XBx2INWG9B9TrwKdIQ0rSZEek3iFXUznQikJjVxCmCzfRY3ZqGEUPt1F39mZTotisPJcyS0qAFW7AWOL_tu31U7VMTphkV6xUSXTyjbACNkFYExtoPAe2J0G
+cu6q90wHkLT3aYbr0fZxyYE9p0H1hD797FoY86qR8REf74kfWMJ86hsNMCcO9tcNJySrP0c_2PWretEDIyxNJSUJwQ3TMcaecsMGlSP7z6CWUJmTT-bVGd8o
+xgCxisw2yysnP51xRotd1K59hpBFgDk8miZUUk_olnS8a3bdZbvxET62v0XSG5vjFKYGaqcYJ4u7XqPaiV184TKvLfJadTL8SkPTLVGRlpyvkq_jFx4-EVdF
+P97wVNpLb-SrefdAO-83Fa2Io6XUTuYKXxovkypcGk9GMK9pIrR_JuC_WNwPad3laIKjQsKbG9xygCtnj96ZauhK3gLpZP4axEXFPXg4Ngi7ZpT88sFzdw1c
+jjn46p6caoa5rzKsoXh32028MqSrq2JReqpigrw9TaIQLZRtNffbRO06s2Y2hajDaUnhABLa6-b7ivTnHcOp5RMMtDjv45PvRgOM1C1HJ5nxWf2LRsK7jewJ
+PVOzsbuCogLJQkvk-cYiUuyrx7XL7QtisKV_79SWuhwws3_6avnuCP3dOC6hWIJQOmSDz88NWm1vETGzgEruDUWaI29iowy7JxKDhmPagYU99SEQ8Cam0xdY
+rM3CgmT8wboRHBTH9m_n-QO1IP-yWoxZSCUhvCttZtp-_GULK_uZts-TKp_4OzNty-AB9lxbz2y
+}
+
+AWSEntityColoring(SystemsManagerAutomation)
+!define SystemsManagerAutomation(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SystemsManagerAutomation, SystemsManagerAutomation)
+!define SystemsManagerAutomation(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SystemsManagerAutomation, SystemsManagerAutomation)
+!define SystemsManagerAutomationParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SystemsManagerAutomation, SystemsManagerAutomation)
+!define SystemsManagerAutomationParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SystemsManagerAutomation, SystemsManagerAutomation)

--- a/awslib/ManagementAndGovernance/SystemsManagerDocuments.puml
+++ b/awslib/ManagementAndGovernance/SystemsManagerDocuments.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SystemsManagerDocuments [64x64/16z] {
+xTBNOeKm38FXE34Xqlk_RtVF01LCVRhxN_E9bNAZJ1Vb3fq7_GmcFIONrR0V9T79Lvb5VQCA7lKJqjupppy1yjgZlhdAehuIgc51tqXY6SbXOU-sR9m68hwL
+PODo8Eunpt8WxeiUY7iz4FTw8ExrGDph0UrRFzLENWvexpZbJvx3dvgm6D2-ZLFjsVDqa8b--Fqxpf5ps9-oSq3KwyOFy5RVAkOTb65aVVRvF-Fx_VisH0Uy
+OnqjxbiN_TRl_-zXAK_24hu3p7XpztBCg_AUNYtb2N-_RypvKX-oX3yzHatwxXjDsF4WiHMtlM4tBvlPNkL6tGC
+}
+
+AWSEntityColoring(SystemsManagerDocuments)
+!define SystemsManagerDocuments(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SystemsManagerDocuments, SystemsManagerDocuments)
+!define SystemsManagerDocuments(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SystemsManagerDocuments, SystemsManagerDocuments)
+!define SystemsManagerDocumentsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SystemsManagerDocuments, SystemsManagerDocuments)
+!define SystemsManagerDocumentsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SystemsManagerDocuments, SystemsManagerDocuments)

--- a/awslib/ManagementAndGovernance/SystemsManagerInventory.puml
+++ b/awslib/ManagementAndGovernance/SystemsManagerInventory.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SystemsManagerInventory [64x64/16z] {
+lPQ9ikmW24G5CGZ__y7FfBrvsop0NResXkGKD45hslUAw5Euc4cTxjENPg_Hh0isStVbWl735Zs8XhdRGMdZg7lt8MdZip_v6JCkJzg96lyd6nt3hXJeAc0y
+zZ1UOZUNCHuRGtp4kyU4joUlHeq_RpLWF3269yR3Oo2ugLqEj7ZpevLqk5qy1gSp8ONnF_bfRa6vpGUycmPb_eYt8spSdl44jJlAyMGGDq4mixoxkNjlmznM
+bETLZfCNyo4pMHynWpUybwr_yDXyPotmInUF8Ck3icj-IzdwZQ6LPIZ5Vtx_1AB60jqfZlctIyl_lNyJqSZjd_Z7_ar44kDjKD_VdqbHNudD9Br_XFUGZ_8-
+LNV_k2TmhuJxXzcFyuVwPnIStuIu2GAzxrNvYVq9gDu_JuYAy-juPbJyVlrCJV2L_Lay8r_RtpDF0tpb_2pUuRzsVZi2f-BzGG9zs_ue1wKFUK_eOVqu_gW-
+f_GFNz7Dkqf9wfjtAyat_mdXdr9TxTFw1G
+}
+
+AWSEntityColoring(SystemsManagerInventory)
+!define SystemsManagerInventory(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SystemsManagerInventory, SystemsManagerInventory)
+!define SystemsManagerInventory(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SystemsManagerInventory, SystemsManagerInventory)
+!define SystemsManagerInventoryParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SystemsManagerInventory, SystemsManagerInventory)
+!define SystemsManagerInventoryParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SystemsManagerInventory, SystemsManagerInventory)

--- a/awslib/ManagementAndGovernance/SystemsManagerMaintWindows.puml
+++ b/awslib/ManagementAndGovernance/SystemsManagerMaintWindows.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SystemsManagerMaintWindows [64x64/16z] {
+jPS7hjmm34HbDNBc_WSEj113Eyponn0oAAwFwYpbl-cwgRoNu2Pvtpf8eqcyxm6eVKk9ybhgdHReFq9rzfplisOumFwv6Kh-XjRzk3uuWPhW9D5A4u2yjqy2
+Kai3ITG4ryMH96RpBsqkaB9_g5_nMGQNn60t8LmQPTuCHBoK2KhzgtqXrWzk8E9BlPKlQcjktK34WyBU3mQ-utK8Ff9HVp8We3uR7ah0j9VVfNmUgKvYt9y1
+aYfpZ2bA4kZ5DK3Qim6t0LoouDrhsusKwzvzmqqDj7TLlJUrUejQhIqYhf6GRS-bjrN9wdtQSzP82NYrbvVQI8ptNkkrcuhjYraNmvrt0-9j1NSbjX9I8c-c
+kpVsq03RjeFh2-yV6pdyzNgbXDdf9V2cRki2wWBDKUkUCxSJUUVsN2eWomX9s8fMScJysCyDYo6lpw1KHCMwNpE-sW1aCSI7Ho_1qmO-UkNI4NX0Sbw0XB-0
+cVDpCHa__kJR8mYFTtmZOPA4J_eFauR-9_DdQgERMZ9_MQJDrY_RFwPq_oJxrvJkt-pycFBpO-TNm_arXVDhlr-v_t15_u4HtMVqNwRSVzctu3zDcVyqjU2_
+NT5_y-VuuKhYHnQ_J4dyEegVf_7xD7yupLyEywV3_EqqVtoVloBahrd-hC_yMKF-dERlZFaxfONy_KtzKBr-EArVpkkdy_hjl7uyhr_Fw-Tp_G8
+}
+
+AWSEntityColoring(SystemsManagerMaintWindows)
+!define SystemsManagerMaintWindows(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SystemsManagerMaintWindows, SystemsManagerMaintWindows)
+!define SystemsManagerMaintWindows(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SystemsManagerMaintWindows, SystemsManagerMaintWindows)
+!define SystemsManagerMaintWindowsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SystemsManagerMaintWindows, SystemsManagerMaintWindows)
+!define SystemsManagerMaintWindowsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SystemsManagerMaintWindows, SystemsManagerMaintWindows)

--- a/awslib/ManagementAndGovernance/SystemsManagerParameterStore.puml
+++ b/awslib/ManagementAndGovernance/SystemsManagerParameterStore.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SystemsManagerParameterStore [64x64/16z] {
+rTS5agqm44RXTFm_-z_lSoYiIU3Pp2aP_IfzSSAVoxpcU9DRdE1LE1hwc2Ve-Re6TSHDk5DQXpJm3Oe_cv3TyWmj-1LeTpoE5cYGWr-7FB5vlEfu0oVHRtOT
+9TzN1CMV7ZG8m9pnDLTtVB2vmbygrTecgkxs4ve9SppguuJhrSAuej_p-JFuc4yzyXBQXT83R-BeUUPLRLj-x4lO5l-SBo9EUSk_Ad7hOwqsvQEMokBNKcsr
+n5cV3pvr98bgTpxOKjZx9904wlPy-uKegFPpYdRZhIwbrUzlaHtIu-rdegsJgFdU-bBU-hGTHNfp_AqxhaZsmfld_VbzFxlzV3-__rBEkQqtwVNxEFdv8v80
+jZTZeJxf4zTfwDElzSbsgkd2exvDYq_XLBtonz3EnwPUV1zoRVjg3Hjl4gWvtctrLNH1VEkxUaWel_LDoWtIMvy0wE6j3rdGuz7JivyvTv6jHtvfv_E5hxeh
+3jSFTbSuh2_R-d6hN_iVlfLJdLcV13h5jBUkosgOxU-z47m5
+}
+
+AWSEntityColoring(SystemsManagerParameterStore)
+!define SystemsManagerParameterStore(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SystemsManagerParameterStore, SystemsManagerParameterStore)
+!define SystemsManagerParameterStore(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SystemsManagerParameterStore, SystemsManagerParameterStore)
+!define SystemsManagerParameterStoreParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SystemsManagerParameterStore, SystemsManagerParameterStore)
+!define SystemsManagerParameterStoreParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SystemsManagerParameterStore, SystemsManagerParameterStore)

--- a/awslib/ManagementAndGovernance/SystemsManagerPatchManager.puml
+++ b/awslib/ManagementAndGovernance/SystemsManagerPatchManager.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SystemsManagerPatchManager [64x64/16z] {
+jTTbaiCm38PXWz3tl--IYbBhxbTu_sQUS9Hn-snpliRTvqjyBPylyTCEXl0JdFcu0_RLSTxQSGVaZddwuwSTmBxH7p_ie7WWNcxXMQNjabBim4TuTTlnxhbr
+sD32ozutjPIsg7YWTtjrQJMnNB_ZxQOtpmt8i-JwngFjVSzXdZqt8I_5K_NiwvuVb1lL3vgjUAoTdpPUyTFTE-Rhh7kSdZnDZ4TzzF2qVA8y2XypCN70nmuI
+1_nf1pYF-N7QmScBQmCg9m3Djd83K5yVG7YSnmueV1yTuz6aqxkjA8-GRxkx5uxuDgpmTywMIQFb1kNwFT-NS_6R6LjyRCDcVFN8FwPwgBqVaYF8a-S4yjDo
+VDjhyM1lzzroyb_Vsq_3S_R8Q_ZnzmvtoV7UYt9uyvZAUE4lVWjCJ_Zp3dWjWdrPlo1-EPVr4nBBgEktzwyVyVKhtiGutZS
+}
+
+AWSEntityColoring(SystemsManagerPatchManager)
+!define SystemsManagerPatchManager(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SystemsManagerPatchManager, SystemsManagerPatchManager)
+!define SystemsManagerPatchManager(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SystemsManagerPatchManager, SystemsManagerPatchManager)
+!define SystemsManagerPatchManagerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SystemsManagerPatchManager, SystemsManagerPatchManager)
+!define SystemsManagerPatchManagerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SystemsManagerPatchManager, SystemsManagerPatchManager)

--- a/awslib/ManagementAndGovernance/SystemsManagerRunCommand.puml
+++ b/awslib/ManagementAndGovernance/SystemsManagerRunCommand.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SystemsManagerRunCommand [64x64/16z] {
+xTO5Tkr030FGmTZI_lVxmOMWgpBVnwY1s2Vb4_hrgsebrvqIhARX8A4GLX8JjAaucGt0W29Di9LhdWpjaI4Lc2MbGpevYj9u4pBye9T9GYFxpJ8SZ68a9Duk
+VxU3La0i4kWFpKn2kdmZPfRH8GjGIqg7EBoaT4W5bdYqHDs5jBarOcOZHWZYZC0QSh7_yRiM8oJz16JyhiKXUXkpWNLc3iyFxK6soqvr_xjApAHevVBb6sHm
+iKSnmYoX0hODoTjAFdrHuGRewSVZUVqsRMMGevuuVHDot3_CDNVXDJiMtyHgYPd5iWF4bN4ilZPNFMOMqvY9-312hjdBYYzc9XbUrBlgotlNU67lQc_Okr8w
+9DgA88jFYEBxV2SEUlbqI0LzAaRCV6Y4GY9Tuxg0alSNdhT-5hz-_GK
+}
+
+AWSEntityColoring(SystemsManagerRunCommand)
+!define SystemsManagerRunCommand(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SystemsManagerRunCommand, SystemsManagerRunCommand)
+!define SystemsManagerRunCommand(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SystemsManagerRunCommand, SystemsManagerRunCommand)
+!define SystemsManagerRunCommandParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SystemsManagerRunCommand, SystemsManagerRunCommand)
+!define SystemsManagerRunCommandParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SystemsManagerRunCommand, SystemsManagerRunCommand)

--- a/awslib/ManagementAndGovernance/SystemsManagerStateManager.puml
+++ b/awslib/ManagementAndGovernance/SystemsManagerStateManager.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SystemsManagerStateManager [64x64/16z] {
+xPU7RZGX30R1cFBD-p_mlmXbVqA8zaXHpLoplCpH9Jdy5F68HRRIT4GhDka57KEvzIgeEVlBv5n1zQrtqImSOWsL4K6BuPZOmCRePI_jpnAQnWpwpoDMfUQX
+avhKqkYu_vcK-oAqJqczBn3ANGS9hcIMufiV0MsX3wz2BG8BGL0AQFAzVzFA5b5wczfxbWU3VAbWmMU_VszfwdxVAqCv9F3GlzFgvxYbTRMXPBLB4PfPGt7n
+qHwe8RW0rCPf0rJ2ud_6E6QvHos-NHPwRlP3yayPfyKzzTyHMbZyKtxP__DzuT1teGdaPtxclKy-xLyMRqpoOp-6c_W3VYmBySp_kAA7FhG9EFNNpC_vVtvS
+EFHD2tRckq0t83_siz_aG__rrkO-iAqVpUBYcyr-amPjvsU1yZlV99jzw3Ri_Aw3ykmtQBEl6Y-gDduKFK3n_pC7yDaluQBi_0JU3Un-5eM4ujp_YL_07Sgs
+_-Vn6oWbWKtzfukgbzQlmg3UFWnUshygwAXkCy_dnv9T9Dja7ixlwVbdlJzh1dUjcTlFk_lxdCbZH59DMZ1xpgGgtVN3X_8iFcNk-i767JccWNspVlfc_VRD
+-l7RzUltw-Vlymy
+}
+
+AWSEntityColoring(SystemsManagerStateManager)
+!define SystemsManagerStateManager(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SystemsManagerStateManager, SystemsManagerStateManager)
+!define SystemsManagerStateManager(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SystemsManagerStateManager, SystemsManagerStateManager)
+!define SystemsManagerStateManagerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SystemsManagerStateManager, SystemsManagerStateManager)
+!define SystemsManagerStateManagerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SystemsManagerStateManager, SystemsManagerStateManager)

--- a/awslib/ManagementAndGovernance/TrustedAdvisor.puml
+++ b/awslib/ManagementAndGovernance/TrustedAdvisor.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $TrustedAdvisor [64x64/16z] {
+xPM5ZYin3037YRd__xqFibSus99qmfrof4aCZTo_ni51kTVxSao06VMEdIeWPWAY-Qfi0z3egWu5XkNpzefxUdKgQ7RvMeWdzHA6LPSD5kSVKa_wZ7CC8HBd
+imSl-0PYsItIdIPWh_cAT_Vo_-FegtxU-lcyV_Y7Bs_xPyc-_d-jHPxr9vNCMt-InNZaXVR2y1RgwXVIWVP2O__SBUXWdWoz-egTpXavSyzFjXHBg19oyxVr
+Sq1hVGzbszkmaoEr-INuwNpiH7kN6jZb44NYln-2NeurHlK-AVYMvAXMaFNKox6EPDyZs29GHlPv_dHDndOwyQY7eBKsGBChixfCcDLT-bXVAOpeRXUGgJe7
+Mqmnpi4_2W1czgdyEZzEdHEUcI094GE6PtTLPbRtsch4W-9tHNmqO1qjq_mVDWKOlfe_AtR7UGY0tapWC-VfMsjDOcziga5U5p8CySZwr5xTAKEWsqM_eRvS
+bdM9zASkBlKvt_2Todi8SSyF99oT6-Zdybt9hnrJ0D_hlLbyxyYN9RFi9qcmrP4tSMnLwttVjxStISHTo7uN0x1-drpL_YqE3lu2
+}
+
+AWSEntityColoring(TrustedAdvisor)
+!define TrustedAdvisor(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, TrustedAdvisor, TrustedAdvisor)
+!define TrustedAdvisor(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, TrustedAdvisor, TrustedAdvisor)
+!define TrustedAdvisorParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, TrustedAdvisor, TrustedAdvisor)
+!define TrustedAdvisorParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, TrustedAdvisor, TrustedAdvisor)

--- a/awslib/ManagementAndGovernance/TrustedAdvisorCheckCost.puml
+++ b/awslib/ManagementAndGovernance/TrustedAdvisorCheckCost.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $TrustedAdvisorCheckCost [64x64/16z] {
+nTO7Zkum20HWmBWmzx_lgoCbqSPBbhmogd_vY0j8aVVH9zdp6K_ITbm1f1hHjpumFKb7-Dw7InADfxwzynvJNtWBXDMzBi2bvBk9o0I6bFo8CEd0af_nQ-o1
+1yA1K7vpoSYz3FmCRszTVN_WVwsWtm_Ki_FlCT_rdxxlt__lkxxo8vQ-y0v4tNFyAbwdYmZ7h-1NH9C1JFaPQvTexXs80IpE3yvvD3yE066ozJqvFyUnUMjs
+IbCHCqsy-1fI2Fqctlr8-xBtG1o1VzLtuCG1pxnEkpu_J9Ln83pnCyAkNiNd6ihTm3_rdHruzWuW9iSBy7l_wm6DutVn2x40snIWjzL5D13jw9z6ZpM09hi2
+d1zqcK0_zw_zyYF0PTqLe6y1B63AHwyJN1OB8Fo3byQddEQNwpyt_yqjq8lTl6FHCviLq8jDbzHVLv3txttFyn1ptu2aG3Q_QG7wUW4DhB5BbytKyVli_NVj
+fkxq_LZx395FLw2IPhk20QojoGzn0akbN82yKA30MQ3EUGjrpbkeSwwWphc2EkSXafSBaDVYvELua5UpqULy1m
+}
+
+AWSEntityColoring(TrustedAdvisorCheckCost)
+!define TrustedAdvisorCheckCost(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, TrustedAdvisorCheckCost, TrustedAdvisorCheckCost)
+!define TrustedAdvisorCheckCost(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, TrustedAdvisorCheckCost, TrustedAdvisorCheckCost)
+!define TrustedAdvisorCheckCostParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, TrustedAdvisorCheckCost, TrustedAdvisorCheckCost)
+!define TrustedAdvisorCheckCostParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, TrustedAdvisorCheckCost, TrustedAdvisorCheckCost)

--- a/awslib/ManagementAndGovernance/TrustedAdvisorCheckFaultTolerant.puml
+++ b/awslib/ManagementAndGovernance/TrustedAdvisorCheckFaultTolerant.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $TrustedAdvisorCheckFaultTolerant [64x64/16z] {
+tPI9RWCX34InmU2P___WYctMBL9OqFRkqzKZ3_0m9FqufUuWCrs8DKIP-Y1ywTFcFYmjK5pjZxBoPTTNpn_o7TGF-9Miz_O_TYsatvi_e_MKYMCT6Tdm7QpY
+P7caC61hlxiuXnUCrBL_B133sqZUoLySq8_qHon_j7-_m9UF-Hds4L_03xsVHjxSl_J1ZMptvZUuf0pYPduDzAxdrp5ymDP-QkpOxVVJ5uZXQnieM_atk7oe
+Vrd-mVl97_CBcim_esNXAuZv-r70Bltu1fzs33hvNzNN3jNvZ9aas_F_LK2JaJxfFs792IVpSvz40Q7F-vzAKIDDGP-SdvqywV_nCKBwn-ofVvoWfZcLBESg
+J_ElQ1TwVaHNo3QvFqaN-7br4U7WhoXnin7XlXzZYqGGktw45_sD2CDdrGlUpgn4FMSP_4lqo4mFl-z__Xe0rtviA0zVEKGe-P8OE9AA2BU8peOVAwuPBpnk
+oYB2DOtCuUUXZcl6mfl9y1nsU3-gw7Yg3OoqjoHGtpTwDxoJ0lYuy7vu7V4p_sM4YvXs8tGYomnVHcWaCOVqHNDnxMFHOh45ENsO5m
+}
+
+AWSEntityColoring(TrustedAdvisorCheckFaultTolerant)
+!define TrustedAdvisorCheckFaultTolerant(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, TrustedAdvisorCheckFaultTolerant, TrustedAdvisorCheckFaultTolerant)
+!define TrustedAdvisorCheckFaultTolerant(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, TrustedAdvisorCheckFaultTolerant, TrustedAdvisorCheckFaultTolerant)
+!define TrustedAdvisorCheckFaultTolerantParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, TrustedAdvisorCheckFaultTolerant, TrustedAdvisorCheckFaultTolerant)
+!define TrustedAdvisorCheckFaultTolerantParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, TrustedAdvisorCheckFaultTolerant, TrustedAdvisorCheckFaultTolerant)

--- a/awslib/ManagementAndGovernance/TrustedAdvisorCheckPerformance.puml
+++ b/awslib/ManagementAndGovernance/TrustedAdvisorCheckPerformance.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $TrustedAdvisorCheckPerformance [64x64/16z] {
+rTO7ZiCw38HXaghpt_--hpX6R6EXjPJjarw-5644sZuUdycODyqaZRW3jngLeHSjtwIWFFRATXFNh4yVyrdDF-13A5xttY7RIxw4cJMezfAlKbY1_bY5QsB2
+WpB8zsSkgVVUAW39jlIhBnFUAaT7_PgvzIzg7-kVVxI_ly4N_v2lwlu1dq4VyCVsM_NUifaTss_LTobPXKU58btYzpw3AlHz_t3ErFx900fxrLlc-FEHufJa
+CzvohpQAe_AH_bgfyH5_PDtxEtdZlSNAT6vFVxmxfgSpu5TVeCrFvuQUVlih2UHpgnFPBUlfenSp5qf7VuRDyTg5-jbtKQn1EVexRcuW03_v9EZGRCPRxm3f
+v2s9uy_7tSxD0ihPMqXAi-tg8BMBjsZP9ds6KcegXrzgj-lnJ_EYTt-sBDkwp_jT5zsMlJU07cODqiNJwo3vwRD00cg6PbwhR_xz7LPtxmreuPKjOKbAkxVQ
+XoaFdyL-09mwg9a5nCFVPFDLj7YkOlTLRtrlQDYMPRybGNhDUwc--stbLtsIqkwt-wi-uF0GVyrRXDcRwta_oC2lpOz1fkVN8DFpSyi7vlT7yoy
+}
+
+AWSEntityColoring(TrustedAdvisorCheckPerformance)
+!define TrustedAdvisorCheckPerformance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, TrustedAdvisorCheckPerformance, TrustedAdvisorCheckPerformance)
+!define TrustedAdvisorCheckPerformance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, TrustedAdvisorCheckPerformance, TrustedAdvisorCheckPerformance)
+!define TrustedAdvisorCheckPerformanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, TrustedAdvisorCheckPerformance, TrustedAdvisorCheckPerformance)
+!define TrustedAdvisorCheckPerformanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, TrustedAdvisorCheckPerformance, TrustedAdvisorCheckPerformance)

--- a/awslib/ManagementAndGovernance/TrustedAdvisorCheckSecurity.puml
+++ b/awslib/ManagementAndGovernance/TrustedAdvisorCheckSecurity.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $TrustedAdvisorCheckSecurity [64x64/16z] {
+xTS54XmX44RXRgpvt_tl6v-LAbZOcNZoIbU-SG6xdkyqvw6Tyemxe5Mepdo2A8igAdElOejysuztC-twel0BFWcbyzuxP3lbMpApW6QdV4Z9AdJxN7akhNq3
+LP1_ErjFjPtj1uwTTprND_pNBHZVKBRZhIfit9utjslUVWTV_P9lwdx15z0PlxZzrjxxvzyx53lbkvIj7RTVoa_vsXTGEsu_5uzjtJy5E7RUUTzRuRxpAQU7
+ikzuAxqkhpylhRMQJrw_NeK-HS_l-sgf2oG1rFUyIyKxzEAVG1NKiVT8Dgc9E8WW3Nr8QROBT3lA42DV8MnS4Tbk1V8dxzyMAvzk_kDF1TAZJwfcBiZ3w-TJ
+eMxtCkJd-uTg0NLu_GvzUlHPq8-TTxtjBGkGs_Z-NNjByp6MjuWGYdiTUaJKkxSKnSPL8G6w1qY0xro_5VeeGThoae-_l-RBT_BqzY9V-DNuDosyjVuoN_Xb
+lzZ_z_yzhGuAjhr60RxZisR5nGcsNUyZ
+}
+
+AWSEntityColoring(TrustedAdvisorCheckSecurity)
+!define TrustedAdvisorCheckSecurity(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, TrustedAdvisorCheckSecurity, TrustedAdvisorCheckSecurity)
+!define TrustedAdvisorCheckSecurity(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, TrustedAdvisorCheckSecurity, TrustedAdvisorCheckSecurity)
+!define TrustedAdvisorCheckSecurityParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, TrustedAdvisorCheckSecurity, TrustedAdvisorCheckSecurity)
+!define TrustedAdvisorCheckSecurityParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, TrustedAdvisorCheckSecurity, TrustedAdvisorCheckSecurity)

--- a/awslib/ManagementAndGovernance/TrustedAdvisorChecklist.puml
+++ b/awslib/ManagementAndGovernance/TrustedAdvisorChecklist.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $TrustedAdvisorChecklist [64x64/16z] {
+xPTNTlOm20KDQjpP_tx_agglESSYFRdlS-m1DRPNYXtC6HqwcB2PBu8ZDAZCl4El1zB1ptZV3iHVudjByHNr1Ez2dk03wih_suCyz9NwkTgzFB5K_n1jab_u
+FZIRvUrATlnT49DyqMLYh_ukPlcgAx6z_haqoNkzalt-Uo_PzV_r-L--bXJleYLu2oW9Va3c_6qGA_MpKH_aPOldLzqsqoH_YA-WEiaVzg-2CScNkCpOgry5
+aAsVNvLPtlkLxFUlHllTlx-yUuetgMJuWLg2Rp0I_ryWR8NlVY-FVAN-GtTSG5lgNmFvrc4idZyDr21izVnf0FBrywS1DRD-ctfk_TjNsR_P-IqxF-Rdr_py
+dCzV
+}
+
+AWSEntityColoring(TrustedAdvisorChecklist)
+!define TrustedAdvisorChecklist(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, TrustedAdvisorChecklist, TrustedAdvisorChecklist)
+!define TrustedAdvisorChecklist(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, TrustedAdvisorChecklist, TrustedAdvisorChecklist)
+!define TrustedAdvisorChecklistParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, TrustedAdvisorChecklist, TrustedAdvisorChecklist)
+!define TrustedAdvisorChecklistParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, TrustedAdvisorChecklist, TrustedAdvisorChecklist)

--- a/awslib/ManagementAndGovernance/WellArchitectedTool.puml
+++ b/awslib/ManagementAndGovernance/WellArchitectedTool.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $WellArchitectedTool [64x64/16z] {
+xPPNOkOW30O7IJJd_lTTAyQ6RH2IfvJvU_c46iB7L-A77sfvgE-H1nx2EmmeQWt1jkMPS4VWhfHTlP1BYo2KX6xANH6k21HnQxl9A_6EMaa5sT97OeMMzKAe
+HjoG5uZQ5H6rhHec0Ac_jqBQMDzEob1CEzbUlsTJhlLJU92oYD-4DCIlK2iy-aKzZ5W9l-K_-PT7VUMrfc-j_uiHC-9c3clUPxUvw3-taQE32jbxCBS8ODaG
+Gawe0gv6MqVdbX1RxIdtM378Wa7f4Jc1vPvIL115bH2Jrw10xTPB8CzhwEG0K8wA4mVhiAXXSQuPuXLLLHiAf2VpZgxvuJGZNhRQqnDER2eNEla8X80E_I4m
+rKSaDWpnZDK-XRo0K6VB-y_tzFTkLN96tZnHZFYS0Cd_xmyb5a-7NbzDgnUU4m1gn5u6Y-k9Ae-tpruu7xL6ytma_suzllDlUy6_p3Vpxl-zsP_S2m-hsbaT
+ysCaJqY9dJgFlfGnm8nk745j_HPXFu7grl4rP3Xldu2FOhIsWvBSndnQpVklzlwRDFki_uMBOLhlfF3t_RTBGgoXoB6Fq2aVlNxyslpmmoy
+}
+
+AWSEntityColoring(WellArchitectedTool)
+!define WellArchitectedTool(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, WellArchitectedTool, WellArchitectedTool)
+!define WellArchitectedTool(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, WellArchitectedTool, WellArchitectedTool)
+!define WellArchitectedToolParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, WellArchitectedTool, WellArchitectedTool)
+!define WellArchitectedToolParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, WellArchitectedTool, WellArchitectedTool)

--- a/awslib/ManagementAndGovernance/all.puml
+++ b/awslib/ManagementAndGovernance/all.puml
@@ -1,0 +1,621 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $AutoScaling [64x64/16z] {
+xPO5SiKm30MVP4Tq__iM77KycFfRvMR3i6QAdylDZLb9Lq1hEg0r7T1zNOW4q6qzY68t08P447a8UCStYTCFiTWY_G9r7pM_ju9Vnu_32xeGGB9hAmEz0wph
+Jk-HM0EQpUlyVe4pyWS1M6Sw97MmhmNGW9w_UWTuJPy1D118iX09lA3xm0Xz-7O0hCh0OU2Xa_dWQhGX0FtLzr5qe_0S_Ae3T34YAPzG-ZR7p_H1VABl5a3w
+GHJfp-mlbf-VlgV_IF4Fl_kRxntyOFM7djL7T5QWBhQVddgs6YKIpfOqlozY3ODcbHx86WLKubjfN1t_VvjVdp_hytTz_L1VlzJNJnc05jUFrVNhp-NcvXa
+}
+
+AWSEntityColoring(AutoScaling)
+!define AutoScaling(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, AutoScaling, AutoScaling)
+!define AutoScaling(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, AutoScaling, AutoScaling)
+!define AutoScalingParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, AutoScaling, AutoScaling)
+!define AutoScalingParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, AutoScaling, AutoScaling)
+
+sprite $CloudFormation [64x64/16z] {
+xTC5Zkqm38NX4rDit_tlzwbv0vrKBWs8-bqG_WhdxtWy7cwgvdcJ4GQol24O8ErT6U38omZaEJY18Y-IzQ0Cpciwsdf8WhcgHPwbr7F5CRIUDp6QTG4yIo6y
+eP4vE2-bGh9as9Z72xIzNdt2KvyDP7LlEP6vLm8uRlQ3CoZAFdImeXy4KlQEWVRwQ8Xo_3xuNf-2NlMJ6FbCOVNu5KzV_WvwHqMI0Cu5r_CFbK9F4ndZEbfK
+_Gb1q2pxU9SB9S-CDRS6phAFXZVzu_niinCxFRrRzRIcVkFzJ7wl3rv8zl5_eyU2nfwr6ttw8ZB6_n-l_-bV-SNhOYzzmjVwhIjzw9P5_fh7u_4F
+}
+
+AWSEntityColoring(CloudFormation)
+!define CloudFormation(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CloudFormation, CloudFormation)
+!define CloudFormation(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudFormation, CloudFormation)
+!define CloudFormationParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudFormation, CloudFormation)
+!define CloudFormationParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudFormation, CloudFormation)
+
+sprite $CloudFormationChangeSet [64x64/16z] {
+xPU7SkKg40KPufp-_mz-CXWNxvRGJPjtszdGX14p9S8tmfxandOzYTlg9u6U09HMFqBDJr0XtlWnF47yERwzvoUrAp_w5qkZnJ1nL2xy8jH1PJqPisS6P7i_
+YrOF6ifXaa6ZgmcWNlcoqV73Jx6JV0vGeJYAZ_cH1Nrq4HuIj1Vz1cbyVt3zWxd-16skuX7_DdvpvmNorgVaWuBoxVFBe9aviiUV_pm_3emsK3xtapH9uOQg
+XNJghpNikhwD_hzU_l_pKtDlwMM_eWFgUT6qN0-oRVqYQ0rKbgRcDkogCRggdVic57kAoi8a2xUHHmmV-IR_87MbvvyDejC7ACBJyTEIexpBlv7_g8Ie2U0X
+DCr5cLGt-J_cJpr35vr3hQ9s9LPKJlquLchUWv4_SSPs17Xh3iZEuz-4QXLg_typoBsBemuUT_dVX8IQBIqYpw6g7zHqSVwAIrx2IanFdN-pV_c_uGV4Bxda
+wMM_W0JbHJynpY_fwktDjdv3Xvb4EzFZA4j5SUCRGsom1B7CmLoKuq_auRh-f7K3MMfpVYW557U-nZ_ZMa2ZmpB0q3V-Mh_CFn6iAr3thkU_hLyp7WLGsVeH
+HeHxCEidplZtSZesVXY5tuIM5grw77zk_29QZ8xAMl_cNqqzybBR-Q49PhWc-MkmMR_3rhU6HBFNypVc75_8tzVlRw_V7z-_lxv_VtwV_m
+}
+
+AWSEntityColoring(CloudFormationChangeSet)
+!define CloudFormationChangeSet(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CloudFormationChangeSet, CloudFormationChangeSet)
+!define CloudFormationChangeSet(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudFormationChangeSet, CloudFormationChangeSet)
+!define CloudFormationChangeSetParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudFormationChangeSet, CloudFormationChangeSet)
+!define CloudFormationChangeSetParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudFormationChangeSet, CloudFormationChangeSet)
+
+sprite $CloudFormationStack [64x64/16z] {
+xTT5UWH134DX-PiYwVxt3GxRGwvmwj-stgePtwvE061YcWmmAerlFQkbL6xxWfJo4_hLhxuYfMvxSQHGRxt49Ca0j9xMW7bspSt3C5unWC4hjiy_ngJN_ihX
+RTzhRBpteyQwRbn_ZQyz6sA5lxzV_Uhpzy_y_Jlx_9X-VirhxgbiADqfCBz4yFwG39tY2R77InX5zrPgqZWXjN3ftv-Lhpq7JWmslmolltAbTyllxrU_-cf7
+whQt4zlUBQF_jzTUJWkNqV_ZXVi_NWBL0JRLsOJBR_SC
+}
+
+AWSEntityColoring(CloudFormationStack)
+!define CloudFormationStack(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CloudFormationStack, CloudFormationStack)
+!define CloudFormationStack(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudFormationStack, CloudFormationStack)
+!define CloudFormationStackParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudFormationStack, CloudFormationStack)
+!define CloudFormationStackParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudFormationStack, CloudFormationStack)
+
+sprite $CloudFormationTemplate [64x64/16z] {
+xTTLOWH120JGHK93tV--woup0yIJzr_jkdedb7INzaZocn8aW4mQ2BdECs2QO03VvNcLmByr_-OdLifxu3X1e58UOJkEgENZq6wDtv0NVpGIUOqdQ3hlkZFs
+uy_snCpydUQ_rd-Bar5R_tJoz_PlGcVy-lFNNp_pw_Ttd1_qH28lySW_yFouFxzPdoZU7_txw-Ftpt-Uv8HA-O4JBvuV9zNzDsIBxLUS7oIFEBN_yI3cnk-m
+3wjvXEy43ktdUxFjH-mLnq_iH3zs__pdk_-txl-n_t_j_v_xDW
+}
+
+AWSEntityColoring(CloudFormationTemplate)
+!define CloudFormationTemplate(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CloudFormationTemplate, CloudFormationTemplate)
+!define CloudFormationTemplate(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudFormationTemplate, CloudFormationTemplate)
+!define CloudFormationTemplateParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudFormationTemplate, CloudFormationTemplate)
+!define CloudFormationTemplateParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudFormationTemplate, CloudFormationTemplate)
+
+sprite $CloudTrail [64x64/16z] {
+xTC5biCm30JGaIsS-zztorm7zd6VVnW40VFdJDCqLPYgHVqpMWKNMjml1AAU6IgGs1_-A5i6EFT9WRya2-xIOQ_TI34ZjtVV-4BH6u2Mt4JV-oq1cZOWkOL8
+VMHqaex63UhpjheKRfiQI7H-Pp2kSXd6Ez1yfVaEz1XTz0wqueA-yfMoBoPmjDhmSmsb5rUKI8qkNLntrdwlJmrdbJWQLZ7uA7Cxgsn7VIL-rTx-Go-oL8Ec
+Dv-3gGPzNKG1Ii6DlT-c_AhoWimivbszXKiDmekF14UiV1Sca1pzUdPjEWD7GiCNmy-I6jIpolE6eHyy-HkcQPeE
+}
+
+AWSEntityColoring(CloudTrail)
+!define CloudTrail(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CloudTrail, CloudTrail)
+!define CloudTrail(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudTrail, CloudTrail)
+!define CloudTrailParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudTrail, CloudTrail)
+!define CloudTrailParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudTrail, CloudTrail)
+
+sprite $CloudWatch [64x64/16z] {
+xPP5ikH034HJ37F_-quqKvM_OUktQbAAKXtkNqvEJYepgtUInhZ0jaUYz1AggXSHsnxE8Azx7O3Krl3ta6JmDW61JDwl8i3rNOzthru68xwN0N86IDSe97ZG
+4S12gmPXy84cvNMhicPwsJzutblB5UtFY_I_pLIq49-WgB-CIxKa3l9burekwOS2KckC-w9SXTNhwMUPhau6qOOxMYyxhXvTCKYZAer0-PZYPBgor58fg6OM
+kH23xIhqEW3Bj_uCCNQ73nPUxGG0-JejWwzqby8x0GktMuMo49-GaPdbxTT4DUX_Ely2Tn5z7LVHnA8ANHElqAcz_Ui3kiJ4Hpyslv00h3xxpmxmgnvg1sNF
+20BuWLJRPIKUhmrfbouUc18UK7NXVTIrwX-mddH_L5kCcS0S1VcpDodTB600gRiohdFVBf22AyBWNG9TuHxP9HE1jRm4-f2088u8_5D47n0GKFK10L3qVbuF
+4YSd9_y1
+}
+
+AWSEntityColoring(CloudWatch)
+!define CloudWatch(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CloudWatch, CloudWatch)
+!define CloudWatch(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudWatch, CloudWatch)
+!define CloudWatchParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudWatch, CloudWatch)
+!define CloudWatchParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudWatch, CloudWatch)
+
+sprite $CloudWatchAlarm [64x64/16z] {
+xTP50kKW48HXsg2hxd_ViP01bisuV9idoO-jQ3-TYDp7FW0Wusu8IsAAYzn9OaJq936kyYxFrwmF822iJPAar_eE-ZcQ5AVFOpV51HZfvtZebTv1RRj45ljp
+lwFSwtM_zhy0etZ-unmFtYe6QMr9GagzWj1jDFHM4oHyZZN8R5MTP8QP3v0fhSm1WWJ88Us2H98aXhLRQgPosShnlImnxCaq4bRD1IIHEH8a4NVz5oJfzHxT
+-yWSFGouwVty_fA-ytBl81PAkIVp1QBUOpM1R-lzD-cZRwBSAuYl2AtsHY8da7RHMvlihjSswL_T_-__z_zxqwdpxKEdU7jsdUpe0rpU_Z3x3MBrnWqmRtlB
+lFW1vv2BxcJ-jNisVVxrdVWtU7PrxtlqyWtQD_i8
+}
+
+AWSEntityColoring(CloudWatchAlarm)
+!define CloudWatchAlarm(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CloudWatchAlarm, CloudWatchAlarm)
+!define CloudWatchAlarm(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudWatchAlarm, CloudWatchAlarm)
+!define CloudWatchAlarmParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudWatchAlarm, CloudWatchAlarm)
+!define CloudWatchAlarmParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudWatchAlarm, CloudWatchAlarm)
+
+sprite $CloudWatchEventEventBased [64x64/16z] {
+xT85ZWGn34JHDcMwwlxtNOvYhz33zCKblSPiLqngJMqxQj7Y0X8vzYxWuC5J0Uuz3od30QVvyKh-xT-UePO2MrxvFuojKu2rWsojn4gwNJlpLNYR2rA4zpsJ
+P_GzGlvImDi-6IbUHixRta6iA6rFxZCGVOzb0gTvlnCV8nLjh-MmGRlUIAnVGZl2svpiEAzpqgVsR__sRs_wr-3qCQUOdcDELdo0gUbJqwSGonjJmFUaA9j-
+Rq2zv4fpCgVKpoHrEbD-GjyU9tGEBoUqdTmd
+}
+
+AWSEntityColoring(CloudWatchEventEventBased)
+!define CloudWatchEventEventBased(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CloudWatchEventEventBased, CloudWatchEventEventBased)
+!define CloudWatchEventEventBased(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudWatchEventEventBased, CloudWatchEventEventBased)
+!define CloudWatchEventEventBasedParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudWatchEventEventBased, CloudWatchEventEventBased)
+!define CloudWatchEventEventBasedParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudWatchEventEventBased, CloudWatchEventEventBased)
+
+sprite $CloudWatchEventTimeBased [64x64/16z] {
+xT09jgGW38NX92J0lVjVS6CTEMBrPBJdVd_DfH-J_F9KzRxrXb6lTei7PcoMrjf0eaNKJX8bouU2oojh-G46QRfPszuTX6Lu8RkC570PETaolXEsUccaNUT6
+LZbv8-frxw2TlNJqwxu2klZvLyQBM2d5ENraVDjy1ycydukTFfOXh-QaYvLNAg-0TjqhsDv7XClrAkXl0q8JNa4KEMf4I2Rdic3hP9DSmM5SHTGgoAwIp04I
+8uwQIZgj8BROYznAlOxSxc4xVK_NsQEOgfeti6IvWWG9W20HURzpW21zFTSr_wf7Q8cHcm7BRGxYYFeLlnWzUxBFGEGz3XDuvlqFyL6N8kqD16Q4PNqXqVT0
+bhmVPg_SyoPxza_x3__XFtonlShfm_PYUbRRAoSVuDBqIzCl8GvVk0J8oC0bc8o0zo5djgRphoNPKbkJ7vG_I4Puq8_m-Y1vt2S
+}
+
+AWSEntityColoring(CloudWatchEventTimeBased)
+!define CloudWatchEventTimeBased(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CloudWatchEventTimeBased, CloudWatchEventTimeBased)
+!define CloudWatchEventTimeBased(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudWatchEventTimeBased, CloudWatchEventTimeBased)
+!define CloudWatchEventTimeBasedParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudWatchEventTimeBased, CloudWatchEventTimeBased)
+!define CloudWatchEventTimeBasedParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudWatchEventTimeBased, CloudWatchEventTimeBased)
+
+sprite $CloudWatchRule [64x64/16z] {
+nTPN5fum34HXoSQsvkv_loca2P-48qZxtk_yXMh_tJ6kcZsZNNlOitau84rF9gXRdKl3iW54aQS-3QW4I7roh990gNzkw7dlqp-N_MNleN2RKZzxdlQs8ERN
+K-GGBVNbWJD_svk0Rg_x0H1-wQTdTcU20i9_z82oUN-ogzcIZkzzGnTmDz2YcTaQwVkFgpW72hxsEmzOes9nzdtJ0bJ1sJUk53rKvMU_YUPLTlQp9ml2hQwX
+mx8bj8fIVnsemVV-jA94AFNF3RtjZ_vR_K3jD_e5wgzx3r2pL_rOrWJXzge_H0YMsxKV3xuwZFtueSZ6tO3EBxlt6TmDh6wfnyryNQM1L_Ul9fYzOdBslkcY
+wEnTczdrf6-04ZHRhxApNoCHJ7j-_whV_pDFVHvG3ItrQQ1Oa_lCIuQslYozVxpff-Plz1uWVzstW6Zsgf_T-eyRq7ZQBsa2u-tpOm3eiAqdLdQpTe2wxJqe
+usPWHBEjzxY2RM2pzxik6EtAVsgcVXieodqUg2BrIJisurVil_i8
+}
+
+AWSEntityColoring(CloudWatchRule)
+!define CloudWatchRule(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CloudWatchRule, CloudWatchRule)
+!define CloudWatchRule(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudWatchRule, CloudWatchRule)
+!define CloudWatchRuleParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudWatchRule, CloudWatchRule)
+!define CloudWatchRuleParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudWatchRule, CloudWatchRule)
+
+sprite $Config [64x64/16z] {
+xTP5ekGm34NH9yaMPV_xRKCn9Qv9qx-Zq0bJ_X7zz5EOxcVllU58_jOhYkubi0zUj_pSLZ_xJAUMP2-u3NBS3Uvw0p5e80SOc7uC-Y5Vay--R7BsqWRNVVBL
+5yItNWKa1D5zxyFdlMVCUDU7eWIHnuFtQD6-PypAWxSUzZsXY1I1VBd_nDkMMpnuAw3AABRl8Is6V7dz6BFwvFFe_JFE__FzD_pAzNU564FZx1VlNyPCXY-f
+4fdbk2VK7ZXRaJEZuvu6F7aH5gbj80vxK0-b6qUFLtmXWD2uGKmWuK0rubXwVYKDFT9CGOzZmPSmG9bjJ8bAjO3Zk8zeFAz59aEE-moP5y0AI_Kn5RhWquOl
+6AcxWVAptsvykC0wPmkl1204wf-y69szf00KQVES6GCyheUzzOuMvVJSlBI9bGOeGqPXw5kVDnzfjSlpdxqmwtCsVU_ZjEHelddxZakfOuPRP4Pzvq7tSVEG
+UUDvdbRdXDVU-Qce34ICnw0r7cO5iUVXAceG0QALGPx1y5p8G15XX9Ru75_WGQZddoiV0uooullYxkSn2-yhN5i10z8ld2k31rzS0GWeMz0OgBbOYAQ2jO8y
+IkVhdT-VNsVQylop-kcdNm
+}
+
+AWSEntityColoring(Config)
+!define Config(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, Config, Config)
+!define Config(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, Config, Config)
+!define ConfigParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, Config, Config)
+!define ConfigParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, Config, Config)
+
+sprite $ControlTower [64x64/16z] {
+xPO7kkGW38CbY47o_U-xnQ-NoPUGxJl_z287SCr_bpjtUhyc1_ebUMiN36oWJMovY8W8KBcA2L1pLTrbqh6u0JTiAQM8aGjCz2mKpXNazVYntiIF-tPsxyfq
+1u3kSiHsIbwgYKOsp2m3EgFlzJf4QjJRSr5WvmDalk1ZsXTlAu3GIpXlH-IruI9GH1P73Z6KTNIU9KUGWJ8momkqOZVVgQtNcv42bMIAK8wA0zj4tvE3gZTD
+6OWwltgZLZeJjmoKofNk7I3vuQbNGN1PkgRVMx-Nrry6h7dx_29KyZt_4IDl-2zG_jjdWluOFqKxb4DpteZVjF8WpW_veppEv7YVlu4ueGT6lgaV0SxJjVUb
+VcLGUORfT_tNUHezzV_XjUuxiuYr5Zw0aLAErGuyCKnQJRc6HO3Eg_F3rVdbulpq--QtYfz_bpjtlW8
+}
+
+AWSEntityColoring(ControlTower)
+!define ControlTower(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, ControlTower, ControlTower)
+!define ControlTower(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, ControlTower, ControlTower)
+!define ControlTowerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, ControlTower, ControlTower)
+!define ControlTowerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, ControlTower, ControlTower)
+
+sprite $LicenseManager [64x64/16z] {
+xT85WXin44JHgWOrxFtl6tcPBIcSxBU7vmttdzHNNrM-MwrwnVlPeYVqdMJv0EHxbve0RDbdt5NzK405jkeLTurdtafWYtxuNVdCKmdOyVqJbxZcArzN6NDO
+zOftqYukUjTtydKV_aun_I-w_entodNlyax-www_7ikinzRzGwM0FYtk-Sh9HQ1pvi3x_VTEp7pR1o0qdna5Y5tl63s86USC_C0Fm28C60TUuM3EcPi47Bhd
+Io6ASJ7U0oRGsl43caHrjS8BaegnumqnPtfG87MP2zYE3p04DN3X1GaYTdmRQF2ReTNjCC8sd__KnEZP01rsyFu347S1ykpxwL3CDFh09q3eY1WA0hdhEuG4
+gm1IedVzhCemiwhk4ozIJdg9R7b4tbPatQlAsm9B_hxd7lSj-67tJTSfaZsztJTw8p88CCW-YW3S0Ppxw8vZhyoU9VNCLprD_yY--keR
+}
+
+AWSEntityColoring(LicenseManager)
+!define LicenseManager(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, LicenseManager, LicenseManager)
+!define LicenseManager(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, LicenseManager, LicenseManager)
+!define LicenseManagerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, LicenseManager, LicenseManager)
+!define LicenseManagerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, LicenseManager, LicenseManager)
+
+sprite $ManagedServices [64x64/16z] {
+xPNNecex24K7a12O_l_ttcAMUkk9sxTJnejrqc7fH-KNl-ZwW_vGcs7SiSZM5wa1UCm_20UYz0LwW6U_Gd4OhNTPXgz_VENOqdiaJFsB2VcctDR_H3LrPc7r
+U3j7-CjM6Kid-lMd1S2ubUVpYzA1k8BiKc6L-78OZnh4CNf_XZ4njG7k-7Rifm3yYZu0R4gzXbVxvRWEyiAl7dXQjDIzetgp-OFSPbXgASFCS-TzfYMdUdVA
+ImemWsWv8_8azsWyl1zT77SZvOGMu4Sz3bnwKs5zVL_ADEkpWIqlCq9vJS9-SmkslhuTGUyvyzHaFPeojCOrbuEX_wMpjo0aJPvZEnH0tUKmTA3nMizPKB1a
+Ldt9EHime1JS9sZWZx4kt4cZJsDaJgWT8WmhhQilLKvNwOoJwcbWuoffNQdf7Sh8_G1eQNW5yrdBTmXSFUxjI0S8gUQI3e-JdlauTX60TyEOMCzTrBKE2soz
+tpZuDAgDrYevuU2dA_nQrM7hjlkzTa6gXyF1G3lpjS-9-SZM36EeMzK9VQxyW-xh6Z8q3L-tE7LWmVnNLM9fOWwLp7Fle_vPb6wpKZBwV0lRORPU98p6zsOw
+b0waGMJjvAjLk9oiODxk3JsnnyNy3umXERK0N1c4tg3N30CmJoseMusOMa3gJVhExiaQsRebPBQ-J0BW7KnzH1BJC3xLgwG5aQtFgTQFn2z-yJi
+}
+
+AWSEntityColoring(ManagedServices)
+!define ManagedServices(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, ManagedServices, ManagedServices)
+!define ManagedServices(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, ManagedServices, ManagedServices)
+!define ManagedServicesParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, ManagedServices, ManagedServices)
+!define ManagedServicesParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, ManagedServices, ManagedServices)
+
+sprite $ManagementConsole [64x64/16z] {
+xPO5TjX030M_MDhS_xm1RJXnd-nocp73BDFw9_ZYYx8nzPdl6EEV-ven8FN8zrNriFTnZ1_xnCkG1RdegosNBF5h_iqQS7FeiunW-C-fFwiHTbn-8_nN-MLw
+ZzLLFz7a5JyuZ22P0hBWEEa77f1xBQHlO-vlNKbpDNb_2yJORzrNhMTgEH1pNy7h7GoT-_MXq1EekU-GRIdpOoa8VEfNC5eAl1HzWgDclWFKuH2ioa3j4U1J
+NpfwWxswfCpzVQF85XzBti_xqQLmtYThSRS2ti4OJVsWnyeMi3j37fi4nRpzUJk2UwJ3yZFjBy6rRzopRugHSpy-jjzVstyOKb7haOeIS8tz3e10jjkF4QZr
+kRy306mj0rxqiR_AgnIaIj0ghqlZFvgwFFzayulch-FrKxtaw9lhfoDYlJIini-j7rzA8AofzK_mnHTt
+}
+
+AWSEntityColoring(ManagementConsole)
+!define ManagementConsole(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, ManagementConsole, ManagementConsole)
+!define ManagementConsole(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, ManagementConsole, ManagementConsole)
+!define ManagementConsoleParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, ManagementConsole, ManagementConsole)
+!define ManagementConsoleParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, ManagementConsole, ManagementConsole)
+
+sprite $ManagementandGovernance [64x64/16z] {
+xTPLOiKm34JHaHDB6dV_-ssOFooNuJo66oPybN-olWewZSf0sdjzAK4yz-LNzlyzLsszOsN1dZwWGcsaoFCNjRq9PdF1vQDOPI_91fwNlY2x3JfXLS_b6qC_
+spx7UayhZ_TddzHpub1UrFKKF1FMzSZsf4TjR-M91dldctf2stkQANexOAXtN7ceBxVr7v__PEiNR5h-fy_1dhupP7T_y_BxrF4VKQnv-RKl_pkhxdlD0yqd
+sjNsIIQ0dAMgVi31jF_nfFoCu-zAaZr9mk3vSnKyVnO--vNNJ_zzPfIV-WRlroDrBP9W9Ktm6xm2
+}
+
+AWSEntityColoring(ManagementandGovernance)
+!define ManagementandGovernance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, ManagementandGovernance, ManagementandGovernance)
+!define ManagementandGovernance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, ManagementandGovernance, ManagementandGovernance)
+!define ManagementandGovernanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, ManagementandGovernance, ManagementandGovernance)
+!define ManagementandGovernanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, ManagementandGovernance, ManagementandGovernance)
+
+sprite $OpsWorks [64x64/16z] {
+xPG7bjqW34NV4qX8_FtlDvPocBHVpAGdlkw6AphpJ-NYOjZ1UBSUAE9TRXzpW6R4yT9ZLnT0W3PdgnU9JRqaEwom2YMnfxSvLiVbMziAC83nuCyv598FrzRK
+yqsW6_fDAxkXi0gejzFwK29ADtUh007gEAa7WLQFCWOODOoCapvedbwRHSiuRiHfNsxLUbsTQTadik5xPFbz5ZtB3z_maMeWXVNi6mj96nWr2NnEhw4FectC
+W0whEqXKC-ouRs2GV8n6jXf4WMteZfKzOWM4R_Y4Jbz2lYdeSoj0FyvIl8EzzBq0IVyuS2Xz2nSDFRHiIgZuhzv_2-q7EdyZhNsVJ_vYFuPz3ccVC-ALRtYA
+lVRxu_Bx6TyUjzzU-Oq0kCPia00vxYJU9mWHUTle5HGXz4xY8r-EkwmiXZ7dW7sH-3FzosVDkRVnwsOTUYVnaO-4QxfzEUU9fFn7k2M-mbaHTnB_22ukFW
+}
+
+AWSEntityColoring(OpsWorks)
+!define OpsWorks(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OpsWorks, OpsWorks)
+!define OpsWorks(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OpsWorks, OpsWorks)
+!define OpsWorksParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OpsWorks, OpsWorks)
+!define OpsWorksParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OpsWorks, OpsWorks)
+
+sprite $OpsWorksApps [64x64/16z] {
+xTV50GGm24JHED9_lx4IXlMTVt-t2AHu6UvoCJZPFBixfZVCsvjBWnAtwwqbg6PVx-dftJhckztx9r8nNqMsVtj3uSPZtYyLAFs-zukUdfwUdfwUFho_HUUl
+uFuQtP_ZBG
+}
+
+AWSEntityColoring(OpsWorksApps)
+!define OpsWorksApps(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OpsWorksApps, OpsWorksApps)
+!define OpsWorksApps(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OpsWorksApps, OpsWorksApps)
+!define OpsWorksAppsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OpsWorksApps, OpsWorksApps)
+!define OpsWorksAppsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OpsWorksApps, OpsWorksApps)
+
+sprite $OpsWorksDeployments [64x64/16z] {
+xTS5paCn30FWlK8Q-_xt_M6j5CrZfaOm_EoCzrOlFKifopK-0_aQdyZqZdxwwQUVFfFv2bv0ebogK-DwMhgY_D8LbaQoBN7cad8vVswvNBoWVCyrnylrEKyd
+hv2ZQdkfV9GdHFds2aZ7l85rtssLi6E-mVVVw6YVvwUVVlfcuel7zwyNyQOv1jg6BuH7BSk6DyAslpLj-CxPJLm8R_5DgW731u-0xeLBmF32nnN32vS0WmVN
+08S9ru3QuC4rmD6gSFdjw3Eu18n1ElJRfLm3j5q3X6k0ykq01DyEE7uucYmVIBUqkl7y0W
+}
+
+AWSEntityColoring(OpsWorksDeployments)
+!define OpsWorksDeployments(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OpsWorksDeployments, OpsWorksDeployments)
+!define OpsWorksDeployments(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OpsWorksDeployments, OpsWorksDeployments)
+!define OpsWorksDeploymentsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OpsWorksDeployments, OpsWorksDeployments)
+!define OpsWorksDeploymentsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OpsWorksDeployments, OpsWorksDeployments)
+
+sprite $OpsWorksInstances [64x64/16z] {
+xPS5hiGm44F3YNt_-owaggnEFy_dpHDRULteW1Byn2CsjAaDEuwqUvXXoFUqcR3V7qaIWXptanK4157lwJ176My-s8iOc7u1gy9AbEbZ5D69wQC4qNOVKM74
+xhSW2d3s-yj-D_xob--jFuukmCqdUnVavXDT32AU-mylzH_E_HVQE39Ffc58ywacR24iSZcIPbeCCqmcpBCsXDvViU-ldDyVzle1plEN9jNy5Tnyr2XK_qbX
+Klr7KV6JytVvQtvwwzVVFzx-zSwFXMz_EVUdSt__wVcv_3L_tVStx_tHUN_rtf_zN04
+}
+
+AWSEntityColoring(OpsWorksInstances)
+!define OpsWorksInstances(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OpsWorksInstances, OpsWorksInstances)
+!define OpsWorksInstances(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OpsWorksInstances, OpsWorksInstances)
+!define OpsWorksInstancesParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OpsWorksInstances, OpsWorksInstances)
+!define OpsWorksInstancesParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OpsWorksInstances, OpsWorksInstances)
+
+sprite $OpsWorksLayers [64x64/16z] xTQt0O105CDGCjZxxqiQmIvFwb_vmzGtn_tyLDpvyjcsebuulru-jwZJ-hssAMfJuV5uFBxSN-t-BFTtUp-wY4RyV_X_y7Wy_m__pmC
+
+AWSEntityColoring(OpsWorksLayers)
+!define OpsWorksLayers(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OpsWorksLayers, OpsWorksLayers)
+!define OpsWorksLayers(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OpsWorksLayers, OpsWorksLayers)
+!define OpsWorksLayersParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OpsWorksLayers, OpsWorksLayers)
+!define OpsWorksLayersParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OpsWorksLayers, OpsWorksLayers)
+
+sprite $OpsWorksMonitoring [64x64/16z] {
+xP9NOWD124EPObXq__kck6eBBZWze-zzMFDakJyZ8_KvNDsAvBC3CEKFTBp7Qn9l3ZG5lENKET15iWVA1EoE4hm_pXkWHms-l_HO532Hom6D95aFbgFXMdYW
+kiFgrd9U5YvjYv_s2--MfLQhbuaBiIHJ05QNopMH-02_yg27AvHDtyNs7tEQ7rvPkCB-bpHOj0GrkO85ggIxbuMx8y8Lb6h6FF_1k08D7_7iRX-kC2sM2_dc
+z25LW3UvWoTtYmfTxk7P7QSrkOEdZO94FBbByUGkpLSdoGcUt6Lu9NS9lZYvI_7Uq_pW1pzuhQdeaKSwxxpu4v6tr9vEbM_DoCWh
+}
+
+AWSEntityColoring(OpsWorksMonitoring)
+!define OpsWorksMonitoring(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OpsWorksMonitoring, OpsWorksMonitoring)
+!define OpsWorksMonitoring(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OpsWorksMonitoring, OpsWorksMonitoring)
+!define OpsWorksMonitoringParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OpsWorksMonitoring, OpsWorksMonitoring)
+!define OpsWorksMonitoringParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OpsWorksMonitoring, OpsWorksMonitoring)
+
+sprite $OpsWorksPermissions [64x64/16z] {
+xPK7UeKW40PTTYd_tF--AQGd-3t4z6HUKLU6NhPlZ7da76vhjbSXIQZwSJjL11r1ImVr4AX6CajH1Of3UWRAOvbMW7oazDS5XY2cTHFobo4Nibc_3WeBg9Dw
+6YQjaERyh55AHtdERsfpuJ4cbL6yI3RNVCNEb4f_mNVmLV_V__VJic-TWB01MRXrTdHN1q03dkA-ks_r16DTJs_pxfbJyaKAYbtVjejOzzS7A7sYdqfh9Itx
+MPsyw0VG6X1hVaFUJzwsv2V8lHMGLdm7VxekbL_wkGTfiVs4MR3G_eu34k1h_kO2K2pFFojGxCJyJ_JGel_lk-HdV8km4txdx_Zdpm-tY_YkdyKK--Vd9B6D
+YJn5rxyBrm
+}
+
+AWSEntityColoring(OpsWorksPermissions)
+!define OpsWorksPermissions(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OpsWorksPermissions, OpsWorksPermissions)
+!define OpsWorksPermissions(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OpsWorksPermissions, OpsWorksPermissions)
+!define OpsWorksPermissionsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OpsWorksPermissions, OpsWorksPermissions)
+!define OpsWorksPermissionsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OpsWorksPermissions, OpsWorksPermissions)
+
+sprite $OpsWorksResources [64x64/16z] {
+xPS7iiCW34HDHxx_VTEZ6V3xCyllZVI45xn2Ys3xs1RZM-XGzxs6L-F5zakpyZewzGlSskMffrS8luAMjotRzM_Ygl3RXT-aXvkCXJ3ucDErB0dl2RvIXTjn
+i6ocXE4craXigEOX4ONpb0Z2jGuyPq9ArY3-ee-IkmkNChCFOGZ-5JOUB8nXhzj2g-D4v5jO5wqvyIvV2y3CDywxb_AmpNpqx9Ai6G-yP3Bl0ZocFnk0U38P
+MvDvDXbRatdN22BYj0u3ZrPYqp2F_TcQmAF9m9eQxnYuLU6zRdWT4Vaf39DmdVSVo17CSxVu_Vb__fzFQtmQUNEJ4e_Mjaprctcktx3QCCzB6-zVcEUb5NzX
+daVXwiWyT-0YnJoNDYwI4m-bLTW_Eo_idq6byu9m3iED1-7o-UNAQ-SNph9w0IapvJ3SMa-VVdxqERSQlk3yhBSp
+}
+
+AWSEntityColoring(OpsWorksResources)
+!define OpsWorksResources(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OpsWorksResources, OpsWorksResources)
+!define OpsWorksResources(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OpsWorksResources, OpsWorksResources)
+!define OpsWorksResourcesParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OpsWorksResources, OpsWorksResources)
+!define OpsWorksResourcesParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OpsWorksResources, OpsWorksResources)
+
+sprite $OpsWorksStack2 [64x64/16z] xTSv0S0m5CFGtgtDdsyl0ac-Lsb_03JbpUL-VghS-VBPjagzS7wzV6wbJkltsgPIc_1uF1xV6HwFn-FnU7pyR-a_Xl-Q_dFU0m
+
+AWSEntityColoring(OpsWorksStack2)
+!define OpsWorksStack2(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OpsWorksStack2, OpsWorksStack2)
+!define OpsWorksStack2(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OpsWorksStack2, OpsWorksStack2)
+!define OpsWorksStack2Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OpsWorksStack2, OpsWorksStack2)
+!define OpsWorksStack2Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OpsWorksStack2, OpsWorksStack2)
+
+sprite $Organizations [64x64/16z] {
+xPG7biCW34Hdg59o__Dk4PWNd2fd-_gdZXxV3T3XvxApK-ipjaGWobPRCn02a7MJNWYMyUD50f3in9g082xPd2YdZo6fGnU2TPe6WkAODQpkkH2e7Zy0eOxu
+ddn-LflwiGWqE_rsrgIQsfNu_JRro-pxVPl6CN5-to3jvz_vGMPVWiVNiM78iPtKkVcHjVcQ0POjpQU--zLQqCRcHsvlWNPckuhD5B8SlfEKdlD9vxJ932ap
+Ubidxa2zvGiO9u0v4tBBLyJRzn-Xd-QhgY2gwac1d7E4ZC8A8HgCbZMmvz24E0R89R-0mUZFM82UOUELFHFbij_BOV5JosdnmnXuqT_zuygtV5pvnwj-BFaT
+BdwmNCBYCrkEb_sA1LeM3CGA7BbUyhMMZhJ2o7suZAo77y7EpYi
+}
+
+AWSEntityColoring(Organizations)
+!define Organizations(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, Organizations, Organizations)
+!define Organizations(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, Organizations, Organizations)
+!define OrganizationsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, Organizations, Organizations)
+!define OrganizationsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, Organizations, Organizations)
+
+sprite $OrganizationsAccount [64x64/16z] {
+tPO5ZYH130IBond__-zXxLhDxTE9niiGOsSQrEaZe_PfDaVD_qGtGty2zJYT9u3DQG9PYU86wd-et0nKm_XqsGCKgc28aP971mlWvV3l0ree_KvlLgI0atyU
+eWJAFtIyejS2Abw-2r0FyEM47_ylVrn_2UXFOgPTz83_tgn0_mFp5v__1XRTlv5TV7J_KXMev-_zfuVITm6WTNy0pVS5T0dq1vH0cC05FKGnm5fEkKsJRFQI
+Kfs0wblbxUJtxrneruLsO3ol3lskj7AlNT3kh6c_Fr-_XZrBp6CDnadqPu5DmCKkPw5y1NeJxC-dUherxTQTkL9tUPVUxBWFjKPU9d2meK5x43xBfXRR_F-y
+KL-Fcfkj5_GBEw_mVkfvtunwkIb_2cO-spGDbq-vv76_TaTYU3Naw_mozylzD7d-8TtmbkgtN-vdtlBf9d_oiVbgVqexlkJJMFmtv-EtuK7daR_uTSTSnpR_
+1S_YtRVbuvQl_IfM_Txd6digsFBrW_ZqdizdV7dDetRaktZ1-xWxxxyiRtW_NultO_esybYF51MA7z10h8mDgbSJYALO87SZ65s02m_74Zvod7GRNFYdn4y
+}
+
+AWSEntityColoring(OrganizationsAccount)
+!define OrganizationsAccount(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OrganizationsAccount, OrganizationsAccount)
+!define OrganizationsAccount(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OrganizationsAccount, OrganizationsAccount)
+!define OrganizationsAccountParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OrganizationsAccount, OrganizationsAccount)
+!define OrganizationsAccountParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OrganizationsAccount, OrganizationsAccount)
+
+sprite $OrganizationsOrganizationalUnitOU [64x64/16z] {
+xPS7UgCX34H_WOGqS_y3ho7wICF6RRjVugv7hyTZl93o078S1juDxEJp0ReFwfqGmuVSsNBuG_sNNypThTpf5oSwTBd7Lv14ZESoqxJMLAxnAyXsygJwJ42o
+HBht1PnXHlhuBa029DhMLz3c1oThVm6zY2Z8klE3E2O5FST2UdvaR7mPnYGGFOIPRGDawzk7ZuxuQ2bPRlK_XXWsVfRuGuWVHoLjqJXhl-536okXRvfsmKdR
+-OKCcStFyMCZ6Qs1k_xh61blKPf3oTW1Ex2ThnovMGkIgACOS0SG_IluHRy61o0uy7BwilJm7bP1-0NVkjhKaQyalqoQ8Esitq0soLqnbmBIliulMVYfenwV
+KNn9G0bR-vhp_JCrPzqa64jVaFeNAbD839ILtq0zLXXXdzEh2x-0Vgm9zfYIsChFMRv6X-5W0btuWRYmKhUDdp5BSXaeTR9elvAfBcc0RFQFRDKrIfQDhs1v
+q4US0zVvvzdxrIyZ_-ZvvULJx-HPzuUxWJryVtgC5py
+}
+
+AWSEntityColoring(OrganizationsOrganizationalUnitOU)
+!define OrganizationsOrganizationalUnitOU(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, OrganizationsOrganizationalUnitOU, OrganizationsOrganizationalUnitOU)
+!define OrganizationsOrganizationalUnitOU(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, OrganizationsOrganizationalUnitOU, OrganizationsOrganizationalUnitOU)
+!define OrganizationsOrganizationalUnitOUParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, OrganizationsOrganizationalUnitOU, OrganizationsOrganizationalUnitOU)
+!define OrganizationsOrganizationalUnitOUParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, OrganizationsOrganizationalUnitOU, OrganizationsOrganizationalUnitOU)
+
+sprite $PersonalHealthDashboard [64x64/16z] {
+xPK7pYCX38KVniRb_lVTEcE11k-6gFxbKmsIUGMF4f-ARxvn5P6XlfuD4PdEIhJZecjrLkCT81wgWmaWYryOpMVTeyO9jAXgX2vE2EJ_6kUO680PC6A2KL_G
+Spmlw3t7yu9ULVUycW1wcjHANfzNRiuA0uwsESCpROFlxVDplZMFYBueyZx0WCJAFMch2y7Opu_O8y3u_xn2OWzXYIPx_rOzh86MQZiiahhNsUyyucXLJ8u9
+zyXxvyXIvVI6CV_gcMlEPcXUBl1aam7DkgyzI9420NdA03rhoSxo6zl3u2nv4En-bbmkoI1xpF9RZ06-joKBCFCeSFEmcmOBRx1yrGQrnAlzRRYuf3c56HCZ
+DXXR2DzuH3YGBsyyOV4Q325u7CAaooDUA7MFWcgD69dL6pHUO-GQ6T8-GLvFaAv5fgENyOVOG3lfqJ9ivh0uGLClFxep1BJ-iHsHC-VTpPwFkzjrPe36CQdh
+TDpTb3jxU0k22CZZNQm1pU9zDBjxap7Yy_BDDpy1
+}
+
+AWSEntityColoring(PersonalHealthDashboard)
+!define PersonalHealthDashboard(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, PersonalHealthDashboard, PersonalHealthDashboard)
+!define PersonalHealthDashboard(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, PersonalHealthDashboard, PersonalHealthDashboard)
+!define PersonalHealthDashboardParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, PersonalHealthDashboard, PersonalHealthDashboard)
+!define PersonalHealthDashboardParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, PersonalHealthDashboard, PersonalHealthDashboard)
+
+sprite $ServiceCatalog [64x64/16z] {
+xLM7plCm23mm6CZxF_0lw-J6gk9qQFphkouo3ZX6UloX-C4FCgBtYFg6Ms4246AV-YWNGDIyTpS58Fw9Xou0OyvS0Ebl1s_0SxWoeBsNGWfQNfnMIBv31_my
+YZXjU-sWwZZif6V3cej3ikg-R1fB4m3LjHOEt1Io0qs1EBr9dpz40Dg0QmS5vBX5Yce1grbwunqod2TmgI5uLmC52wMp2C9oeD5pNAVll4g-GW6lSa2Xv3E2
+Nmj8A7CinfSQqeVw4iOlQbDSjx51e-k8GJwbMz5cRjf3qJRDLu3ta__yJNytSsmmVwIcAryV8jtZsA6Xrc7ev4zxedB75wbbS07DmKy5bZ4kqGszLfcQmuU9
+sE2ciZ2yQylNERZQXn4Ap8te2kbx_df5APV2Lrlt_5M_KZgBGEai0ldG7Lz1liIGRe26I2Zj5g9p2JOmnEny21TTX8y52Kx1OqrkDaY7Z1fYoAVDycwtRv6c
+SZr_ejFN3jnzHQwHQS_zZBtyUR51V57UQRlmuZxz6RhyhBolTeq8UaEVbzEMpZVQbbnnXjzNmEb8ERXFji6EMvGyvhNpTxKxMFnR1ViCEv3txEU7HMMU0Nrr
+lKUSpq1d_-YgGTwXyv-w5mEQCProxkGRuCtYLP3HFqYb2U37-qW3AaWn22Zf4rGS9xyDEHyZCRgTWZo-Wq7SXLbywG0W_KjaZpp-MFpW1xy
+}
+
+AWSEntityColoring(ServiceCatalog)
+!define ServiceCatalog(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, ServiceCatalog, ServiceCatalog)
+!define ServiceCatalog(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, ServiceCatalog, ServiceCatalog)
+!define ServiceCatalogParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, ServiceCatalog, ServiceCatalog)
+!define ServiceCatalogParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, ServiceCatalog, ServiceCatalog)
+
+sprite $SystemsManager [64x64/16z] {
+xTI54kiw30JGbGpIxll__tqJcfk26wS35qyP1F78rY_edt-OqIEfxqGnBAocxcC1hBJMbYoLkYaD7biKky6fMsYevrvWr1q5LMSLHJTq-4l2BaQafXYU_vYm
+PW0yT2tUT5i1r5Q0YGGDNSyIdfBwp4eMf5u4zpwwhZYeaK3zxtfsnl49wxmSN6g43g3nu-1-BC1i1kVKu9vnjRSuJ517uHKBsyCAsgWyzO9hXBi3b4Wf1qkK
+AEzATtP3IewQQSx1Y4WTxMtd1ZZFRnlwP7o5DQ3cSPQW5ZZx-_X0UmrFPUh0MDSYS-xw2RGt_qBNvFftd5SgOjiVXSEjMryo9jl1K5lBWlWmtksfVbK2PptX
+d-Q_9ZTIBOOKus282ChX9KS97B1D43YL8fVxeW7e6c1psoJXIUtrEqh6Wb8sT5tZLZrnjaRsE_6iYmAlgxmH3w_QiQTsuJONxzYtRFEak94AWD04ig8_NtyG
+bjISX2dT0VD3D3JDIbixxUU97rpyz7dQWPYDzvSTVUp9-GJvOzhPh0_AZnCil4cAWiKeVDn1-Dgomzge-XWxbz3MjqCyKbyeM55Vohu8_Mh--UT_
+}
+
+AWSEntityColoring(SystemsManager)
+!define SystemsManager(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SystemsManager, SystemsManager)
+!define SystemsManager(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SystemsManager, SystemsManager)
+!define SystemsManagerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SystemsManager, SystemsManager)
+!define SystemsManagerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SystemsManager, SystemsManager)
+
+sprite $SystemsManagerAutomation [64x64/16z] {
+pPVdmkii38Fh0RPq__VxZOGSeEuw-zMVPZqADiOqjzyaZKNz-_aEuXBXty-JUOcqx-OR8EFGFkTL7_1EVhjiyWftyenKB2VaO1_77T2NE66tctQG6qzcaoCf
+XBx2INWG9B9TrwKdIQ0rSZEek3iFXUznQikJjVxCmCzfRY3ZqGEUPt1F39mZTotisPJcyS0qAFW7AWOL_tu31U7VMTphkV6xUSXTyjbACNkFYExtoPAe2J0G
+cu6q90wHkLT3aYbr0fZxyYE9p0H1hD797FoY86qR8REf74kfWMJ86hsNMCcO9tcNJySrP0c_2PWretEDIyxNJSUJwQ3TMcaecsMGlSP7z6CWUJmTT-bVGd8o
+xgCxisw2yysnP51xRotd1K59hpBFgDk8miZUUk_olnS8a3bdZbvxET62v0XSG5vjFKYGaqcYJ4u7XqPaiV184TKvLfJadTL8SkPTLVGRlpyvkq_jFx4-EVdF
+P97wVNpLb-SrefdAO-83Fa2Io6XUTuYKXxovkypcGk9GMK9pIrR_JuC_WNwPad3laIKjQsKbG9xygCtnj96ZauhK3gLpZP4axEXFPXg4Ngi7ZpT88sFzdw1c
+jjn46p6caoa5rzKsoXh32028MqSrq2JReqpigrw9TaIQLZRtNffbRO06s2Y2hajDaUnhABLa6-b7ivTnHcOp5RMMtDjv45PvRgOM1C1HJ5nxWf2LRsK7jewJ
+PVOzsbuCogLJQkvk-cYiUuyrx7XL7QtisKV_79SWuhwws3_6avnuCP3dOC6hWIJQOmSDz88NWm1vETGzgEruDUWaI29iowy7JxKDhmPagYU99SEQ8Cam0xdY
+rM3CgmT8wboRHBTH9m_n-QO1IP-yWoxZSCUhvCttZtp-_GULK_uZts-TKp_4OzNty-AB9lxbz2y
+}
+
+AWSEntityColoring(SystemsManagerAutomation)
+!define SystemsManagerAutomation(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SystemsManagerAutomation, SystemsManagerAutomation)
+!define SystemsManagerAutomation(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SystemsManagerAutomation, SystemsManagerAutomation)
+!define SystemsManagerAutomationParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SystemsManagerAutomation, SystemsManagerAutomation)
+!define SystemsManagerAutomationParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SystemsManagerAutomation, SystemsManagerAutomation)
+
+sprite $SystemsManagerDocuments [64x64/16z] {
+xTBNOeKm38FXE34Xqlk_RtVF01LCVRhxN_E9bNAZJ1Vb3fq7_GmcFIONrR0V9T79Lvb5VQCA7lKJqjupppy1yjgZlhdAehuIgc51tqXY6SbXOU-sR9m68hwL
+PODo8Eunpt8WxeiUY7iz4FTw8ExrGDph0UrRFzLENWvexpZbJvx3dvgm6D2-ZLFjsVDqa8b--Fqxpf5ps9-oSq3KwyOFy5RVAkOTb65aVVRvF-Fx_VisH0Uy
+OnqjxbiN_TRl_-zXAK_24hu3p7XpztBCg_AUNYtb2N-_RypvKX-oX3yzHatwxXjDsF4WiHMtlM4tBvlPNkL6tGC
+}
+
+AWSEntityColoring(SystemsManagerDocuments)
+!define SystemsManagerDocuments(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SystemsManagerDocuments, SystemsManagerDocuments)
+!define SystemsManagerDocuments(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SystemsManagerDocuments, SystemsManagerDocuments)
+!define SystemsManagerDocumentsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SystemsManagerDocuments, SystemsManagerDocuments)
+!define SystemsManagerDocumentsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SystemsManagerDocuments, SystemsManagerDocuments)
+
+sprite $SystemsManagerInventory [64x64/16z] {
+lPQ9ikmW24G5CGZ__y7FfBrvsop0NResXkGKD45hslUAw5Euc4cTxjENPg_Hh0isStVbWl735Zs8XhdRGMdZg7lt8MdZip_v6JCkJzg96lyd6nt3hXJeAc0y
+zZ1UOZUNCHuRGtp4kyU4joUlHeq_RpLWF3269yR3Oo2ugLqEj7ZpevLqk5qy1gSp8ONnF_bfRa6vpGUycmPb_eYt8spSdl44jJlAyMGGDq4mixoxkNjlmznM
+bETLZfCNyo4pMHynWpUybwr_yDXyPotmInUF8Ck3icj-IzdwZQ6LPIZ5Vtx_1AB60jqfZlctIyl_lNyJqSZjd_Z7_ar44kDjKD_VdqbHNudD9Br_XFUGZ_8-
+LNV_k2TmhuJxXzcFyuVwPnIStuIu2GAzxrNvYVq9gDu_JuYAy-juPbJyVlrCJV2L_Lay8r_RtpDF0tpb_2pUuRzsVZi2f-BzGG9zs_ue1wKFUK_eOVqu_gW-
+f_GFNz7Dkqf9wfjtAyat_mdXdr9TxTFw1G
+}
+
+AWSEntityColoring(SystemsManagerInventory)
+!define SystemsManagerInventory(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SystemsManagerInventory, SystemsManagerInventory)
+!define SystemsManagerInventory(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SystemsManagerInventory, SystemsManagerInventory)
+!define SystemsManagerInventoryParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SystemsManagerInventory, SystemsManagerInventory)
+!define SystemsManagerInventoryParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SystemsManagerInventory, SystemsManagerInventory)
+
+sprite $SystemsManagerMaintWindows [64x64/16z] {
+jPS7hjmm34HbDNBc_WSEj113Eyponn0oAAwFwYpbl-cwgRoNu2Pvtpf8eqcyxm6eVKk9ybhgdHReFq9rzfplisOumFwv6Kh-XjRzk3uuWPhW9D5A4u2yjqy2
+Kai3ITG4ryMH96RpBsqkaB9_g5_nMGQNn60t8LmQPTuCHBoK2KhzgtqXrWzk8E9BlPKlQcjktK34WyBU3mQ-utK8Ff9HVp8We3uR7ah0j9VVfNmUgKvYt9y1
+aYfpZ2bA4kZ5DK3Qim6t0LoouDrhsusKwzvzmqqDj7TLlJUrUejQhIqYhf6GRS-bjrN9wdtQSzP82NYrbvVQI8ptNkkrcuhjYraNmvrt0-9j1NSbjX9I8c-c
+kpVsq03RjeFh2-yV6pdyzNgbXDdf9V2cRki2wWBDKUkUCxSJUUVsN2eWomX9s8fMScJysCyDYo6lpw1KHCMwNpE-sW1aCSI7Ho_1qmO-UkNI4NX0Sbw0XB-0
+cVDpCHa__kJR8mYFTtmZOPA4J_eFauR-9_DdQgERMZ9_MQJDrY_RFwPq_oJxrvJkt-pycFBpO-TNm_arXVDhlr-v_t15_u4HtMVqNwRSVzctu3zDcVyqjU2_
+NT5_y-VuuKhYHnQ_J4dyEegVf_7xD7yupLyEywV3_EqqVtoVloBahrd-hC_yMKF-dERlZFaxfONy_KtzKBr-EArVpkkdy_hjl7uyhr_Fw-Tp_G8
+}
+
+AWSEntityColoring(SystemsManagerMaintWindows)
+!define SystemsManagerMaintWindows(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SystemsManagerMaintWindows, SystemsManagerMaintWindows)
+!define SystemsManagerMaintWindows(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SystemsManagerMaintWindows, SystemsManagerMaintWindows)
+!define SystemsManagerMaintWindowsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SystemsManagerMaintWindows, SystemsManagerMaintWindows)
+!define SystemsManagerMaintWindowsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SystemsManagerMaintWindows, SystemsManagerMaintWindows)
+
+sprite $SystemsManagerParameterStore [64x64/16z] {
+rTS5agqm44RXTFm_-z_lSoYiIU3Pp2aP_IfzSSAVoxpcU9DRdE1LE1hwc2Ve-Re6TSHDk5DQXpJm3Oe_cv3TyWmj-1LeTpoE5cYGWr-7FB5vlEfu0oVHRtOT
+9TzN1CMV7ZG8m9pnDLTtVB2vmbygrTecgkxs4ve9SppguuJhrSAuej_p-JFuc4yzyXBQXT83R-BeUUPLRLj-x4lO5l-SBo9EUSk_Ad7hOwqsvQEMokBNKcsr
+n5cV3pvr98bgTpxOKjZx9904wlPy-uKegFPpYdRZhIwbrUzlaHtIu-rdegsJgFdU-bBU-hGTHNfp_AqxhaZsmfld_VbzFxlzV3-__rBEkQqtwVNxEFdv8v80
+jZTZeJxf4zTfwDElzSbsgkd2exvDYq_XLBtonz3EnwPUV1zoRVjg3Hjl4gWvtctrLNH1VEkxUaWel_LDoWtIMvy0wE6j3rdGuz7JivyvTv6jHtvfv_E5hxeh
+3jSFTbSuh2_R-d6hN_iVlfLJdLcV13h5jBUkosgOxU-z47m5
+}
+
+AWSEntityColoring(SystemsManagerParameterStore)
+!define SystemsManagerParameterStore(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SystemsManagerParameterStore, SystemsManagerParameterStore)
+!define SystemsManagerParameterStore(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SystemsManagerParameterStore, SystemsManagerParameterStore)
+!define SystemsManagerParameterStoreParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SystemsManagerParameterStore, SystemsManagerParameterStore)
+!define SystemsManagerParameterStoreParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SystemsManagerParameterStore, SystemsManagerParameterStore)
+
+sprite $SystemsManagerPatchManager [64x64/16z] {
+jTTbaiCm38PXWz3tl--IYbBhxbTu_sQUS9Hn-snpliRTvqjyBPylyTCEXl0JdFcu0_RLSTxQSGVaZddwuwSTmBxH7p_ie7WWNcxXMQNjabBim4TuTTlnxhbr
+sD32ozutjPIsg7YWTtjrQJMnNB_ZxQOtpmt8i-JwngFjVSzXdZqt8I_5K_NiwvuVb1lL3vgjUAoTdpPUyTFTE-Rhh7kSdZnDZ4TzzF2qVA8y2XypCN70nmuI
+1_nf1pYF-N7QmScBQmCg9m3Djd83K5yVG7YSnmueV1yTuz6aqxkjA8-GRxkx5uxuDgpmTywMIQFb1kNwFT-NS_6R6LjyRCDcVFN8FwPwgBqVaYF8a-S4yjDo
+VDjhyM1lzzroyb_Vsq_3S_R8Q_ZnzmvtoV7UYt9uyvZAUE4lVWjCJ_Zp3dWjWdrPlo1-EPVr4nBBgEktzwyVyVKhtiGutZS
+}
+
+AWSEntityColoring(SystemsManagerPatchManager)
+!define SystemsManagerPatchManager(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SystemsManagerPatchManager, SystemsManagerPatchManager)
+!define SystemsManagerPatchManager(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SystemsManagerPatchManager, SystemsManagerPatchManager)
+!define SystemsManagerPatchManagerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SystemsManagerPatchManager, SystemsManagerPatchManager)
+!define SystemsManagerPatchManagerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SystemsManagerPatchManager, SystemsManagerPatchManager)
+
+sprite $SystemsManagerRunCommand [64x64/16z] {
+xTO5Tkr030FGmTZI_lVxmOMWgpBVnwY1s2Vb4_hrgsebrvqIhARX8A4GLX8JjAaucGt0W29Di9LhdWpjaI4Lc2MbGpevYj9u4pBye9T9GYFxpJ8SZ68a9Duk
+VxU3La0i4kWFpKn2kdmZPfRH8GjGIqg7EBoaT4W5bdYqHDs5jBarOcOZHWZYZC0QSh7_yRiM8oJz16JyhiKXUXkpWNLc3iyFxK6soqvr_xjApAHevVBb6sHm
+iKSnmYoX0hODoTjAFdrHuGRewSVZUVqsRMMGevuuVHDot3_CDNVXDJiMtyHgYPd5iWF4bN4ilZPNFMOMqvY9-312hjdBYYzc9XbUrBlgotlNU67lQc_Okr8w
+9DgA88jFYEBxV2SEUlbqI0LzAaRCV6Y4GY9Tuxg0alSNdhT-5hz-_GK
+}
+
+AWSEntityColoring(SystemsManagerRunCommand)
+!define SystemsManagerRunCommand(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SystemsManagerRunCommand, SystemsManagerRunCommand)
+!define SystemsManagerRunCommand(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SystemsManagerRunCommand, SystemsManagerRunCommand)
+!define SystemsManagerRunCommandParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SystemsManagerRunCommand, SystemsManagerRunCommand)
+!define SystemsManagerRunCommandParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SystemsManagerRunCommand, SystemsManagerRunCommand)
+
+sprite $SystemsManagerStateManager [64x64/16z] {
+xPU7RZGX30R1cFBD-p_mlmXbVqA8zaXHpLoplCpH9Jdy5F68HRRIT4GhDka57KEvzIgeEVlBv5n1zQrtqImSOWsL4K6BuPZOmCRePI_jpnAQnWpwpoDMfUQX
+avhKqkYu_vcK-oAqJqczBn3ANGS9hcIMufiV0MsX3wz2BG8BGL0AQFAzVzFA5b5wczfxbWU3VAbWmMU_VszfwdxVAqCv9F3GlzFgvxYbTRMXPBLB4PfPGt7n
+qHwe8RW0rCPf0rJ2ud_6E6QvHos-NHPwRlP3yayPfyKzzTyHMbZyKtxP__DzuT1teGdaPtxclKy-xLyMRqpoOp-6c_W3VYmBySp_kAA7FhG9EFNNpC_vVtvS
+EFHD2tRckq0t83_siz_aG__rrkO-iAqVpUBYcyr-amPjvsU1yZlV99jzw3Ri_Aw3ykmtQBEl6Y-gDduKFK3n_pC7yDaluQBi_0JU3Un-5eM4ujp_YL_07Sgs
+_-Vn6oWbWKtzfukgbzQlmg3UFWnUshygwAXkCy_dnv9T9Dja7ixlwVbdlJzh1dUjcTlFk_lxdCbZH59DMZ1xpgGgtVN3X_8iFcNk-i767JccWNspVlfc_VRD
+-l7RzUltw-Vlymy
+}
+
+AWSEntityColoring(SystemsManagerStateManager)
+!define SystemsManagerStateManager(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, SystemsManagerStateManager, SystemsManagerStateManager)
+!define SystemsManagerStateManager(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, SystemsManagerStateManager, SystemsManagerStateManager)
+!define SystemsManagerStateManagerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, SystemsManagerStateManager, SystemsManagerStateManager)
+!define SystemsManagerStateManagerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, SystemsManagerStateManager, SystemsManagerStateManager)
+
+sprite $TrustedAdvisor [64x64/16z] {
+xPM5ZYin3037YRd__xqFibSus99qmfrof4aCZTo_ni51kTVxSao06VMEdIeWPWAY-Qfi0z3egWu5XkNpzefxUdKgQ7RvMeWdzHA6LPSD5kSVKa_wZ7CC8HBd
+imSl-0PYsItIdIPWh_cAT_Vo_-FegtxU-lcyV_Y7Bs_xPyc-_d-jHPxr9vNCMt-InNZaXVR2y1RgwXVIWVP2O__SBUXWdWoz-egTpXavSyzFjXHBg19oyxVr
+Sq1hVGzbszkmaoEr-INuwNpiH7kN6jZb44NYln-2NeurHlK-AVYMvAXMaFNKox6EPDyZs29GHlPv_dHDndOwyQY7eBKsGBChixfCcDLT-bXVAOpeRXUGgJe7
+Mqmnpi4_2W1czgdyEZzEdHEUcI094GE6PtTLPbRtsch4W-9tHNmqO1qjq_mVDWKOlfe_AtR7UGY0tapWC-VfMsjDOcziga5U5p8CySZwr5xTAKEWsqM_eRvS
+bdM9zASkBlKvt_2Todi8SSyF99oT6-Zdybt9hnrJ0D_hlLbyxyYN9RFi9qcmrP4tSMnLwttVjxStISHTo7uN0x1-drpL_YqE3lu2
+}
+
+AWSEntityColoring(TrustedAdvisor)
+!define TrustedAdvisor(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, TrustedAdvisor, TrustedAdvisor)
+!define TrustedAdvisor(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, TrustedAdvisor, TrustedAdvisor)
+!define TrustedAdvisorParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, TrustedAdvisor, TrustedAdvisor)
+!define TrustedAdvisorParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, TrustedAdvisor, TrustedAdvisor)
+
+sprite $TrustedAdvisorCheckCost [64x64/16z] {
+nTO7Zkum20HWmBWmzx_lgoCbqSPBbhmogd_vY0j8aVVH9zdp6K_ITbm1f1hHjpumFKb7-Dw7InADfxwzynvJNtWBXDMzBi2bvBk9o0I6bFo8CEd0af_nQ-o1
+1yA1K7vpoSYz3FmCRszTVN_WVwsWtm_Ki_FlCT_rdxxlt__lkxxo8vQ-y0v4tNFyAbwdYmZ7h-1NH9C1JFaPQvTexXs80IpE3yvvD3yE066ozJqvFyUnUMjs
+IbCHCqsy-1fI2Fqctlr8-xBtG1o1VzLtuCG1pxnEkpu_J9Ln83pnCyAkNiNd6ihTm3_rdHruzWuW9iSBy7l_wm6DutVn2x40snIWjzL5D13jw9z6ZpM09hi2
+d1zqcK0_zw_zyYF0PTqLe6y1B63AHwyJN1OB8Fo3byQddEQNwpyt_yqjq8lTl6FHCviLq8jDbzHVLv3txttFyn1ptu2aG3Q_QG7wUW4DhB5BbytKyVli_NVj
+fkxq_LZx395FLw2IPhk20QojoGzn0akbN82yKA30MQ3EUGjrpbkeSwwWphc2EkSXafSBaDVYvELua5UpqULy1m
+}
+
+AWSEntityColoring(TrustedAdvisorCheckCost)
+!define TrustedAdvisorCheckCost(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, TrustedAdvisorCheckCost, TrustedAdvisorCheckCost)
+!define TrustedAdvisorCheckCost(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, TrustedAdvisorCheckCost, TrustedAdvisorCheckCost)
+!define TrustedAdvisorCheckCostParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, TrustedAdvisorCheckCost, TrustedAdvisorCheckCost)
+!define TrustedAdvisorCheckCostParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, TrustedAdvisorCheckCost, TrustedAdvisorCheckCost)
+
+sprite $TrustedAdvisorCheckFaultTolerant [64x64/16z] {
+tPI9RWCX34InmU2P___WYctMBL9OqFRkqzKZ3_0m9FqufUuWCrs8DKIP-Y1ywTFcFYmjK5pjZxBoPTTNpn_o7TGF-9Miz_O_TYsatvi_e_MKYMCT6Tdm7QpY
+P7caC61hlxiuXnUCrBL_B133sqZUoLySq8_qHon_j7-_m9UF-Hds4L_03xsVHjxSl_J1ZMptvZUuf0pYPduDzAxdrp5ymDP-QkpOxVVJ5uZXQnieM_atk7oe
+Vrd-mVl97_CBcim_esNXAuZv-r70Bltu1fzs33hvNzNN3jNvZ9aas_F_LK2JaJxfFs792IVpSvz40Q7F-vzAKIDDGP-SdvqywV_nCKBwn-ofVvoWfZcLBESg
+J_ElQ1TwVaHNo3QvFqaN-7br4U7WhoXnin7XlXzZYqGGktw45_sD2CDdrGlUpgn4FMSP_4lqo4mFl-z__Xe0rtviA0zVEKGe-P8OE9AA2BU8peOVAwuPBpnk
+oYB2DOtCuUUXZcl6mfl9y1nsU3-gw7Yg3OoqjoHGtpTwDxoJ0lYuy7vu7V4p_sM4YvXs8tGYomnVHcWaCOVqHNDnxMFHOh45ENsO5m
+}
+
+AWSEntityColoring(TrustedAdvisorCheckFaultTolerant)
+!define TrustedAdvisorCheckFaultTolerant(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, TrustedAdvisorCheckFaultTolerant, TrustedAdvisorCheckFaultTolerant)
+!define TrustedAdvisorCheckFaultTolerant(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, TrustedAdvisorCheckFaultTolerant, TrustedAdvisorCheckFaultTolerant)
+!define TrustedAdvisorCheckFaultTolerantParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, TrustedAdvisorCheckFaultTolerant, TrustedAdvisorCheckFaultTolerant)
+!define TrustedAdvisorCheckFaultTolerantParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, TrustedAdvisorCheckFaultTolerant, TrustedAdvisorCheckFaultTolerant)
+
+sprite $TrustedAdvisorCheckPerformance [64x64/16z] {
+rTO7ZiCw38HXaghpt_--hpX6R6EXjPJjarw-5644sZuUdycODyqaZRW3jngLeHSjtwIWFFRATXFNh4yVyrdDF-13A5xttY7RIxw4cJMezfAlKbY1_bY5QsB2
+WpB8zsSkgVVUAW39jlIhBnFUAaT7_PgvzIzg7-kVVxI_ly4N_v2lwlu1dq4VyCVsM_NUifaTss_LTobPXKU58btYzpw3AlHz_t3ErFx900fxrLlc-FEHufJa
+CzvohpQAe_AH_bgfyH5_PDtxEtdZlSNAT6vFVxmxfgSpu5TVeCrFvuQUVlih2UHpgnFPBUlfenSp5qf7VuRDyTg5-jbtKQn1EVexRcuW03_v9EZGRCPRxm3f
+v2s9uy_7tSxD0ihPMqXAi-tg8BMBjsZP9ds6KcegXrzgj-lnJ_EYTt-sBDkwp_jT5zsMlJU07cODqiNJwo3vwRD00cg6PbwhR_xz7LPtxmreuPKjOKbAkxVQ
+XoaFdyL-09mwg9a5nCFVPFDLj7YkOlTLRtrlQDYMPRybGNhDUwc--stbLtsIqkwt-wi-uF0GVyrRXDcRwta_oC2lpOz1fkVN8DFpSyi7vlT7yoy
+}
+
+AWSEntityColoring(TrustedAdvisorCheckPerformance)
+!define TrustedAdvisorCheckPerformance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, TrustedAdvisorCheckPerformance, TrustedAdvisorCheckPerformance)
+!define TrustedAdvisorCheckPerformance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, TrustedAdvisorCheckPerformance, TrustedAdvisorCheckPerformance)
+!define TrustedAdvisorCheckPerformanceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, TrustedAdvisorCheckPerformance, TrustedAdvisorCheckPerformance)
+!define TrustedAdvisorCheckPerformanceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, TrustedAdvisorCheckPerformance, TrustedAdvisorCheckPerformance)
+
+sprite $TrustedAdvisorCheckSecurity [64x64/16z] {
+xTS54XmX44RXRgpvt_tl6v-LAbZOcNZoIbU-SG6xdkyqvw6Tyemxe5Mepdo2A8igAdElOejysuztC-twel0BFWcbyzuxP3lbMpApW6QdV4Z9AdJxN7akhNq3
+LP1_ErjFjPtj1uwTTprND_pNBHZVKBRZhIfit9utjslUVWTV_P9lwdx15z0PlxZzrjxxvzyx53lbkvIj7RTVoa_vsXTGEsu_5uzjtJy5E7RUUTzRuRxpAQU7
+ikzuAxqkhpylhRMQJrw_NeK-HS_l-sgf2oG1rFUyIyKxzEAVG1NKiVT8Dgc9E8WW3Nr8QROBT3lA42DV8MnS4Tbk1V8dxzyMAvzk_kDF1TAZJwfcBiZ3w-TJ
+eMxtCkJd-uTg0NLu_GvzUlHPq8-TTxtjBGkGs_Z-NNjByp6MjuWGYdiTUaJKkxSKnSPL8G6w1qY0xro_5VeeGThoae-_l-RBT_BqzY9V-DNuDosyjVuoN_Xb
+lzZ_z_yzhGuAjhr60RxZisR5nGcsNUyZ
+}
+
+AWSEntityColoring(TrustedAdvisorCheckSecurity)
+!define TrustedAdvisorCheckSecurity(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, TrustedAdvisorCheckSecurity, TrustedAdvisorCheckSecurity)
+!define TrustedAdvisorCheckSecurity(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, TrustedAdvisorCheckSecurity, TrustedAdvisorCheckSecurity)
+!define TrustedAdvisorCheckSecurityParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, TrustedAdvisorCheckSecurity, TrustedAdvisorCheckSecurity)
+!define TrustedAdvisorCheckSecurityParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, TrustedAdvisorCheckSecurity, TrustedAdvisorCheckSecurity)
+
+sprite $TrustedAdvisorChecklist [64x64/16z] {
+xPTNTlOm20KDQjpP_tx_agglESSYFRdlS-m1DRPNYXtC6HqwcB2PBu8ZDAZCl4El1zB1ptZV3iHVudjByHNr1Ez2dk03wih_suCyz9NwkTgzFB5K_n1jab_u
+FZIRvUrATlnT49DyqMLYh_ukPlcgAx6z_haqoNkzalt-Uo_PzV_r-L--bXJleYLu2oW9Va3c_6qGA_MpKH_aPOldLzqsqoH_YA-WEiaVzg-2CScNkCpOgry5
+aAsVNvLPtlkLxFUlHllTlx-yUuetgMJuWLg2Rp0I_ryWR8NlVY-FVAN-GtTSG5lgNmFvrc4idZyDr21izVnf0FBrywS1DRD-ctfk_TjNsR_P-IqxF-Rdr_py
+dCzV
+}
+
+AWSEntityColoring(TrustedAdvisorChecklist)
+!define TrustedAdvisorChecklist(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, TrustedAdvisorChecklist, TrustedAdvisorChecklist)
+!define TrustedAdvisorChecklist(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, TrustedAdvisorChecklist, TrustedAdvisorChecklist)
+!define TrustedAdvisorChecklistParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, TrustedAdvisorChecklist, TrustedAdvisorChecklist)
+!define TrustedAdvisorChecklistParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, TrustedAdvisorChecklist, TrustedAdvisorChecklist)
+
+sprite $WellArchitectedTool [64x64/16z] {
+xPPNOkOW30O7IJJd_lTTAyQ6RH2IfvJvU_c46iB7L-A77sfvgE-H1nx2EmmeQWt1jkMPS4VWhfHTlP1BYo2KX6xANH6k21HnQxl9A_6EMaa5sT97OeMMzKAe
+HjoG5uZQ5H6rhHec0Ac_jqBQMDzEob1CEzbUlsTJhlLJU92oYD-4DCIlK2iy-aKzZ5W9l-K_-PT7VUMrfc-j_uiHC-9c3clUPxUvw3-taQE32jbxCBS8ODaG
+Gawe0gv6MqVdbX1RxIdtM378Wa7f4Jc1vPvIL115bH2Jrw10xTPB8CzhwEG0K8wA4mVhiAXXSQuPuXLLLHiAf2VpZgxvuJGZNhRQqnDER2eNEla8X80E_I4m
+rKSaDWpnZDK-XRo0K6VB-y_tzFTkLN96tZnHZFYS0Cd_xmyb5a-7NbzDgnUU4m1gn5u6Y-k9Ae-tpruu7xL6ytma_suzllDlUy6_p3Vpxl-zsP_S2m-hsbaT
+ysCaJqY9dJgFlfGnm8nk745j_HPXFu7grl4rP3Xldu2FOhIsWvBSndnQpVklzlwRDFki_uMBOLhlfF3t_RTBGgoXoB6Fq2aVlNxyslpmmoy
+}
+
+AWSEntityColoring(WellArchitectedTool)
+!define WellArchitectedTool(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, WellArchitectedTool, WellArchitectedTool)
+!define WellArchitectedTool(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, WellArchitectedTool, WellArchitectedTool)
+!define WellArchitectedToolParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, WellArchitectedTool, WellArchitectedTool)
+!define WellArchitectedToolParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, WellArchitectedTool, WellArchitectedTool)
+

--- a/awslib/MediaServices/ElasticTranscoder.puml
+++ b/awslib/MediaServices/ElasticTranscoder.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ElasticTranscoder [64x64/16z] {
+xPO7Zgmm44HVn-B-5_u1Mnh1hba6XHzBOUBhHBNbxJVKV_rNLrNh8Qmq02mUHMW3pqe7wW4EqRCEo7Tn6I-ctwyWY6CnKfLkuy8EVquC8ExoIPxYGOJT3k3q
+AQ3rFfI-nnldNlVFTRE01Yt6ScE82h3F-Jjcag-pgBysK-AwQ2qWTO4BjAQTNSkLkfvnWLTt6gPr-NNnM58Q4pQzppkv1Q7nTbbZhfVY9xZFhx5baNuLsGcm
+bBDie9Ty_UGbXup5AkY3NhOS-Jl0sZ_dPPpaBz_Wet-hfKiQ_A1zJYe7mkZDX_rouP8-Vu-DWznIMs7gr4ZJQpv3htui01__Zh5PIgXjoSjU1jTCFHM06GE_
+uY4r-T9X_MR0IzwKCuAmypzg1BpaHu_M7_Wq0Ayl-QqCwiJBmICCufhVQUzJ__Bv8Cg8AnuVz9n_z2mUtz9xVDrNFDw7vszZbcYRaGjV-oTUyn4stUkrdspE
+S8UXc_xTlqu3nlwf36gnlut5GTWif8Ev_tsn_-8iFvxCFcQxgd_hitIy53XOBKwvEvUI71jerFkyREvbE_7qJXUP3gxjYHG0M6vFfHvNsjz6__LVtm4
+}
+
+AWSEntityColoring(ElasticTranscoder)
+!define ElasticTranscoder(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ElasticTranscoder, ElasticTranscoder)
+!define ElasticTranscoder(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ElasticTranscoder, ElasticTranscoder)
+!define ElasticTranscoderParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ElasticTranscoder, ElasticTranscoder)
+!define ElasticTranscoderParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ElasticTranscoder, ElasticTranscoder)

--- a/awslib/MediaServices/ElementalMediaConnect.puml
+++ b/awslib/MediaServices/ElementalMediaConnect.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ElementalMediaConnect [64x64/16z] {
+xLPNeiCm20FCoFrF_6eKkblRRoz-CiKIADb-hVtRluLgl05kJCJsMhGBKMj4ugzA7KXuYVN2aRaxgbXiWmCIBMEdiwKYD5FliEueYz3vr7qpiZq7nCODZKdE
+cf9jaZbaR3dWjHMNGywOAF5xk4Zy0JtcqlADKE1zzmcyHdf_ca98voosiBZ0vuteN4eCvmPbNkQFnhIOcfiimfcqo6JFrCTpX57hxmhHQNxpKZnqG47akC4F
+ssb_yhAM8fxX-KY4dk-lKeNb5NpfnmaVAtZOc_4h-PFZf07l8fxuejwVzczBhK7V7Dt63Sy-GfF60r2AnTJxdpKb4lIF1x2sp3IOGwqsSqx6l667qfZp1BlJ
+V5vx1IU55rIqfBqd_9866wDzXQ-KvZJOfTfN-DiduzHly7D51DJ-4HvVX6SERXGM-0jr7kjtGTmwtlpoYpfkF-z5CgMGCT3Am-czPAga3-SdLXSuD6Qxk3Em
+6wOYRbXTdE5ozdd_BxV_Jr_p_rRw_sljt_xj1G
+}
+
+AWSEntityColoring(ElementalMediaConnect)
+!define ElementalMediaConnect(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ElementalMediaConnect, ElementalMediaConnect)
+!define ElementalMediaConnect(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ElementalMediaConnect, ElementalMediaConnect)
+!define ElementalMediaConnectParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ElementalMediaConnect, ElementalMediaConnect)
+!define ElementalMediaConnectParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ElementalMediaConnect, ElementalMediaConnect)

--- a/awslib/MediaServices/ElementalMediaLive.puml
+++ b/awslib/MediaServices/ElementalMediaLive.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ElementalMediaLive [64x64/16z] {
+xPO7biGW34CbtBZ_YVSnUOdPHfXUDRryOYm3hY-hZpuArJW3DmAqKsalW0XG_2JS6hcCSb88laPkzAVop2BVYqJ_mvndjhaF0BfI1jgKPv7kgsAZOj_BxXzU
+qh_-EndW0K2tqDE_RH8A80Oy0T1x90TRlWL7F7W8jqj2D_N3H8Wnlrob-E_4BZ7iy-qvgHofaNjyaPKFyVJV9LPIIlAZA1me15K95g2FV8eF8o2nf8uMn_8j
+0bcBocjzGpxpTn9VRVNFwYIVzVDx_-ZhPxv-WUdwJPwvViXSFvpZ-qqioEYshXa-KzV-gDg-pYJkyR0wsh-g0N7c_dds_dt--J5_VW6ZysjVP3rTwV_9_GEP
+_SCf_GjvIl-INZOLlqV_bltZo-gZZxu
+}
+
+AWSEntityColoring(ElementalMediaLive)
+!define ElementalMediaLive(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ElementalMediaLive, ElementalMediaLive)
+!define ElementalMediaLive(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ElementalMediaLive, ElementalMediaLive)
+!define ElementalMediaLiveParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ElementalMediaLive, ElementalMediaLive)
+!define ElementalMediaLiveParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ElementalMediaLive, ElementalMediaLive)

--- a/awslib/MediaServices/ElementalMediaPackage.puml
+++ b/awslib/MediaServices/ElementalMediaPackage.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ElementalMediaPackage [64x64/16z] {
+xPO7aiKW28P1AU_-9zw1i99C6culZoc9vMC4zDV7ZxMdFKs9z1qu8m3oMsbfuDRaBRHs8n7DIzVvm9UL8ovHpAKX4SHqDXDu1As8cZrJIz_clnv4JlJCzR6K
+KX2hR3iPFQkAtDSi_W4uLWIWE--7rW1e-8AMtOCXoEwzMRf8ptabct75Tq_IdX-fxTTyLdh7nyWbRnF52hZFdvLFhFkEjoXvNp-sp1HuCttizuzr5lWR_QZo
+Ablz4ftY6Q7BPbSZrtaBV7NSj7kpIOcFGp2Ec_-GnjOlyDsvnOzuzKbVOwhm3MGS5ZQUyaJLUFrRV8-c5FYrKZCQBz5M0l-xrm-lT6gT_uZByhr-k7un0gul
+36FDsQr-kNxkjTwu9gcV1VqMZakWnqX5l_Sp555ttgltL_Bb-oid9hzt-_xxkng4yRcYBtc_rDzFzVVRTxmVK_z_h3tjQIy
+}
+
+AWSEntityColoring(ElementalMediaPackage)
+!define ElementalMediaPackage(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ElementalMediaPackage, ElementalMediaPackage)
+!define ElementalMediaPackage(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ElementalMediaPackage, ElementalMediaPackage)
+!define ElementalMediaPackageParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ElementalMediaPackage, ElementalMediaPackage)
+!define ElementalMediaPackageParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ElementalMediaPackage, ElementalMediaPackage)

--- a/awslib/MediaServices/ElementalMediaStore.puml
+++ b/awslib/MediaServices/ElementalMediaStore.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ElementalMediaStore [64x64/16z] {
+xPO5OiKm34Ebr93xNtYGglMmD0P_pkzp8olKVstynt-aMRu1TmBqgtGqO9g05bVe7AIov7dXwhbKd2n38PNid72qh8OS3N5S-0ZBkZsD1ylW1DtWwlEg9Oq7
+HAZQ3fS1QYX7Dl7b2eChsO9KzYtf0AoBlmzNmn8683Tu0g0NtzLGhe9RF9WDQEdYarnLn_Y7sEPx3m8iNgh304RlUxpyLfcojLJ7Xudx_1EdShLk93h8Fvzr
+AiXX_kaKSjX9NhFk5DyZdiwawJ4V4ByHaVKLp8LNGkRk36BrWiNFWhPvNOD96NBmqTpXCGgwgLz5dz-Bd-yBjFtnXodLYrXvJMJw2V-cuZLnPSH5tk5lvEqY
+tq_nwcPmuU4Bhq_axlgPznyf7Yt4xw-VkeB3A_5F5_HJMr-ISuF3N6dt8Zt6ftYjPy2vRTpBlrFxPpbXAVxq_jqB8QiYLyulv9NpIta92V_yyrkT7tzj_CT_
+t08
+}
+
+AWSEntityColoring(ElementalMediaStore)
+!define ElementalMediaStore(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ElementalMediaStore, ElementalMediaStore)
+!define ElementalMediaStore(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ElementalMediaStore, ElementalMediaStore)
+!define ElementalMediaStoreParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ElementalMediaStore, ElementalMediaStore)
+!define ElementalMediaStoreParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ElementalMediaStore, ElementalMediaStore)

--- a/awslib/MediaServices/ElementalMediaTailor.puml
+++ b/awslib/MediaServices/ElementalMediaTailor.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ElementalMediaTailor [64x64/16z] {
+xPI7SWCX44CbE5Rv_nzEmnxDff3bCir5BbUVA5fukLyzzPJqB_e0ZlCEWm30SOvM0vhc_nc-W_5n3AAVusEUn3O_Zk_yCQgqEg2ll82kQcOSt_d1KfP-hQFh
+OjXjlAQZkPk3uBWSFB0M2rpyVEwtqHe-7UrFBNWm3wG1BNURMFDv82BbRfTv4wJTghmdUhRlM4fyE6ZpqpGgV0Uw0tLSy_wQRtqEdjzI3iufwCtyiegIG-JA
+sQZYLBbrYKO60MftvsERNOwF8uljIowNUPW3Tq59AvpjMdpk-KWhit4dV_MkdVn1jsHvILJud5vEiCRdm6rOvTtTD7KbNdahjDEKrZp1I4KqHYgT8AW_LaxU
+GTrrFwsld01YSnNbryXlnclbkHUfd451VdloTjpRGCQL7nvHMJeOLpxeWTSbzz_qZioVbupVdvvwwWq
+}
+
+AWSEntityColoring(ElementalMediaTailor)
+!define ElementalMediaTailor(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ElementalMediaTailor, ElementalMediaTailor)
+!define ElementalMediaTailor(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ElementalMediaTailor, ElementalMediaTailor)
+!define ElementalMediaTailorParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ElementalMediaTailor, ElementalMediaTailor)
+!define ElementalMediaTailorParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ElementalMediaTailor, ElementalMediaTailor)

--- a/awslib/MediaServices/MediaServices.puml
+++ b/awslib/MediaServices/MediaServices.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $MediaServices [64x64/16z] {
+xTK5WiH024JH0WgA-rzutRMRzPtyyKbUNF1J7Tdjfy6Jkm5-xxDtqoFF_-4FVtZLypQy7CyBBVj4rjE8NFQ4-bdWnloVUzbdUBfxQD6hzCGJ5evSz0xBHpu1
+ji0rBp3WklU2MxIGgpwx7DJjk33j-cx2wlfFidhVj-B-q9luxa9yn9U3Soy2xB5FGsYy_HImxF7-Su3puwS3Ni-FtmONlTGBvy_W_1twpxv-pQ-Vy-lt_Fxn
+l--VXp-yTgj7Vj3dUNXCSiDjDWh_eNC
+}
+
+AWSEntityColoring(MediaServices)
+!define MediaServices(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, MediaServices, MediaServices)
+!define MediaServices(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, MediaServices, MediaServices)
+!define MediaServicesParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, MediaServices, MediaServices)
+!define MediaServicesParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, MediaServices, MediaServices)

--- a/awslib/MediaServices/all.puml
+++ b/awslib/MediaServices/all.puml
@@ -1,0 +1,96 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $ElasticTranscoder [64x64/16z] {
+xPO7Zgmm44HVn-B-5_u1Mnh1hba6XHzBOUBhHBNbxJVKV_rNLrNh8Qmq02mUHMW3pqe7wW4EqRCEo7Tn6I-ctwyWY6CnKfLkuy8EVquC8ExoIPxYGOJT3k3q
+AQ3rFfI-nnldNlVFTRE01Yt6ScE82h3F-Jjcag-pgBysK-AwQ2qWTO4BjAQTNSkLkfvnWLTt6gPr-NNnM58Q4pQzppkv1Q7nTbbZhfVY9xZFhx5baNuLsGcm
+bBDie9Ty_UGbXup5AkY3NhOS-Jl0sZ_dPPpaBz_Wet-hfKiQ_A1zJYe7mkZDX_rouP8-Vu-DWznIMs7gr4ZJQpv3htui01__Zh5PIgXjoSjU1jTCFHM06GE_
+uY4r-T9X_MR0IzwKCuAmypzg1BpaHu_M7_Wq0Ayl-QqCwiJBmICCufhVQUzJ__Bv8Cg8AnuVz9n_z2mUtz9xVDrNFDw7vszZbcYRaGjV-oTUyn4stUkrdspE
+S8UXc_xTlqu3nlwf36gnlut5GTWif8Ev_tsn_-8iFvxCFcQxgd_hitIy53XOBKwvEvUI71jerFkyREvbE_7qJXUP3gxjYHG0M6vFfHvNsjz6__LVtm4
+}
+
+AWSEntityColoring(ElasticTranscoder)
+!define ElasticTranscoder(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ElasticTranscoder, ElasticTranscoder)
+!define ElasticTranscoder(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ElasticTranscoder, ElasticTranscoder)
+!define ElasticTranscoderParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ElasticTranscoder, ElasticTranscoder)
+!define ElasticTranscoderParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ElasticTranscoder, ElasticTranscoder)
+
+sprite $ElementalMediaConnect [64x64/16z] {
+xLPNeiCm20FCoFrF_6eKkblRRoz-CiKIADb-hVtRluLgl05kJCJsMhGBKMj4ugzA7KXuYVN2aRaxgbXiWmCIBMEdiwKYD5FliEueYz3vr7qpiZq7nCODZKdE
+cf9jaZbaR3dWjHMNGywOAF5xk4Zy0JtcqlADKE1zzmcyHdf_ca98voosiBZ0vuteN4eCvmPbNkQFnhIOcfiimfcqo6JFrCTpX57hxmhHQNxpKZnqG47akC4F
+ssb_yhAM8fxX-KY4dk-lKeNb5NpfnmaVAtZOc_4h-PFZf07l8fxuejwVzczBhK7V7Dt63Sy-GfF60r2AnTJxdpKb4lIF1x2sp3IOGwqsSqx6l667qfZp1BlJ
+V5vx1IU55rIqfBqd_9866wDzXQ-KvZJOfTfN-DiduzHly7D51DJ-4HvVX6SERXGM-0jr7kjtGTmwtlpoYpfkF-z5CgMGCT3Am-czPAga3-SdLXSuD6Qxk3Em
+6wOYRbXTdE5ozdd_BxV_Jr_p_rRw_sljt_xj1G
+}
+
+AWSEntityColoring(ElementalMediaConnect)
+!define ElementalMediaConnect(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ElementalMediaConnect, ElementalMediaConnect)
+!define ElementalMediaConnect(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ElementalMediaConnect, ElementalMediaConnect)
+!define ElementalMediaConnectParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ElementalMediaConnect, ElementalMediaConnect)
+!define ElementalMediaConnectParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ElementalMediaConnect, ElementalMediaConnect)
+
+sprite $ElementalMediaLive [64x64/16z] {
+xPO7biGW34CbtBZ_YVSnUOdPHfXUDRryOYm3hY-hZpuArJW3DmAqKsalW0XG_2JS6hcCSb88laPkzAVop2BVYqJ_mvndjhaF0BfI1jgKPv7kgsAZOj_BxXzU
+qh_-EndW0K2tqDE_RH8A80Oy0T1x90TRlWL7F7W8jqj2D_N3H8Wnlrob-E_4BZ7iy-qvgHofaNjyaPKFyVJV9LPIIlAZA1me15K95g2FV8eF8o2nf8uMn_8j
+0bcBocjzGpxpTn9VRVNFwYIVzVDx_-ZhPxv-WUdwJPwvViXSFvpZ-qqioEYshXa-KzV-gDg-pYJkyR0wsh-g0N7c_dds_dt--J5_VW6ZysjVP3rTwV_9_GEP
+_SCf_GjvIl-INZOLlqV_bltZo-gZZxu
+}
+
+AWSEntityColoring(ElementalMediaLive)
+!define ElementalMediaLive(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ElementalMediaLive, ElementalMediaLive)
+!define ElementalMediaLive(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ElementalMediaLive, ElementalMediaLive)
+!define ElementalMediaLiveParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ElementalMediaLive, ElementalMediaLive)
+!define ElementalMediaLiveParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ElementalMediaLive, ElementalMediaLive)
+
+sprite $ElementalMediaPackage [64x64/16z] {
+xPO7aiKW28P1AU_-9zw1i99C6culZoc9vMC4zDV7ZxMdFKs9z1qu8m3oMsbfuDRaBRHs8n7DIzVvm9UL8ovHpAKX4SHqDXDu1As8cZrJIz_clnv4JlJCzR6K
+KX2hR3iPFQkAtDSi_W4uLWIWE--7rW1e-8AMtOCXoEwzMRf8ptabct75Tq_IdX-fxTTyLdh7nyWbRnF52hZFdvLFhFkEjoXvNp-sp1HuCttizuzr5lWR_QZo
+Ablz4ftY6Q7BPbSZrtaBV7NSj7kpIOcFGp2Ec_-GnjOlyDsvnOzuzKbVOwhm3MGS5ZQUyaJLUFrRV8-c5FYrKZCQBz5M0l-xrm-lT6gT_uZByhr-k7un0gul
+36FDsQr-kNxkjTwu9gcV1VqMZakWnqX5l_Sp555ttgltL_Bb-oid9hzt-_xxkng4yRcYBtc_rDzFzVVRTxmVK_z_h3tjQIy
+}
+
+AWSEntityColoring(ElementalMediaPackage)
+!define ElementalMediaPackage(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ElementalMediaPackage, ElementalMediaPackage)
+!define ElementalMediaPackage(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ElementalMediaPackage, ElementalMediaPackage)
+!define ElementalMediaPackageParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ElementalMediaPackage, ElementalMediaPackage)
+!define ElementalMediaPackageParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ElementalMediaPackage, ElementalMediaPackage)
+
+sprite $ElementalMediaStore [64x64/16z] {
+xPO5OiKm34Ebr93xNtYGglMmD0P_pkzp8olKVstynt-aMRu1TmBqgtGqO9g05bVe7AIov7dXwhbKd2n38PNid72qh8OS3N5S-0ZBkZsD1ylW1DtWwlEg9Oq7
+HAZQ3fS1QYX7Dl7b2eChsO9KzYtf0AoBlmzNmn8683Tu0g0NtzLGhe9RF9WDQEdYarnLn_Y7sEPx3m8iNgh304RlUxpyLfcojLJ7Xudx_1EdShLk93h8Fvzr
+AiXX_kaKSjX9NhFk5DyZdiwawJ4V4ByHaVKLp8LNGkRk36BrWiNFWhPvNOD96NBmqTpXCGgwgLz5dz-Bd-yBjFtnXodLYrXvJMJw2V-cuZLnPSH5tk5lvEqY
+tq_nwcPmuU4Bhq_axlgPznyf7Yt4xw-VkeB3A_5F5_HJMr-ISuF3N6dt8Zt6ftYjPy2vRTpBlrFxPpbXAVxq_jqB8QiYLyulv9NpIta92V_yyrkT7tzj_CT_
+t08
+}
+
+AWSEntityColoring(ElementalMediaStore)
+!define ElementalMediaStore(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ElementalMediaStore, ElementalMediaStore)
+!define ElementalMediaStore(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ElementalMediaStore, ElementalMediaStore)
+!define ElementalMediaStoreParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ElementalMediaStore, ElementalMediaStore)
+!define ElementalMediaStoreParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ElementalMediaStore, ElementalMediaStore)
+
+sprite $ElementalMediaTailor [64x64/16z] {
+xPI7SWCX44CbE5Rv_nzEmnxDff3bCir5BbUVA5fukLyzzPJqB_e0ZlCEWm30SOvM0vhc_nc-W_5n3AAVusEUn3O_Zk_yCQgqEg2ll82kQcOSt_d1KfP-hQFh
+OjXjlAQZkPk3uBWSFB0M2rpyVEwtqHe-7UrFBNWm3wG1BNURMFDv82BbRfTv4wJTghmdUhRlM4fyE6ZpqpGgV0Uw0tLSy_wQRtqEdjzI3iufwCtyiegIG-JA
+sQZYLBbrYKO60MftvsERNOwF8uljIowNUPW3Tq59AvpjMdpk-KWhit4dV_MkdVn1jsHvILJud5vEiCRdm6rOvTtTD7KbNdahjDEKrZp1I4KqHYgT8AW_LaxU
+GTrrFwsld01YSnNbryXlnclbkHUfd451VdloTjpRGCQL7nvHMJeOLpxeWTSbzz_qZioVbupVdvvwwWq
+}
+
+AWSEntityColoring(ElementalMediaTailor)
+!define ElementalMediaTailor(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ElementalMediaTailor, ElementalMediaTailor)
+!define ElementalMediaTailor(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ElementalMediaTailor, ElementalMediaTailor)
+!define ElementalMediaTailorParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ElementalMediaTailor, ElementalMediaTailor)
+!define ElementalMediaTailorParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ElementalMediaTailor, ElementalMediaTailor)
+
+sprite $MediaServices [64x64/16z] {
+xTK5WiH024JH0WgA-rzutRMRzPtyyKbUNF1J7Tdjfy6Jkm5-xxDtqoFF_-4FVtZLypQy7CyBBVj4rjE8NFQ4-bdWnloVUzbdUBfxQD6hzCGJ5evSz0xBHpu1
+ji0rBp3WklU2MxIGgpwx7DJjk33j-cx2wlfFidhVj-B-q9luxa9yn9U3Soy2xB5FGsYy_HImxF7-Su3puwS3Ni-FtmONlTGBvy_W_1twpxv-pQ-Vy-lt_Fxn
+l--VXp-yTgj7Vj3dUNXCSiDjDWh_eNC
+}
+
+AWSEntityColoring(MediaServices)
+!define MediaServices(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, MediaServices, MediaServices)
+!define MediaServices(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, MediaServices, MediaServices)
+!define MediaServicesParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, MediaServices, MediaServices)
+!define MediaServicesParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, MediaServices, MediaServices)
+

--- a/awslib/MigrationAndTransfer/ApplicationDiscoveryService.puml
+++ b/awslib/MigrationAndTransfer/ApplicationDiscoveryService.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ApplicationDiscoveryService [64x64/16z] {
+xLLNTXmX4AocwNZ_0_j1QymemlZ7IVKbxMx52UIVXszy8znKrJn-YMnCA13hOmaTvDP5fBSX8OyKl05DOqK1cZqm__dpY2X11lG1NQPjRqJKkiNwy8okrm8W
+NEtjKC0dFHXWzOXm7Urz2fniq8QDqtqmvqbLK1oaRvb1w7c709x9-mP1mwcXP_X2fA15-Zw0eLK6mmtyujst5v6XbK5uOMWw4AM-YV_-Lp7_xwKSculNwfUy
+OCMtQc6R-ZpMSyU25Z_6UB8PG24pPFX253z7TeKSy2dUzn-nplck2_x0tz2daMtwR_VNXJZTVrr_tbp_xVtd-NR_0ABYVGaTtW9EUzE_ZsNwxW4ixsYGD7w1
+1-byzYl31b8FozqeF1Mm4_iixv6UVNtM0SqXmaVlFwiJe5wyuHqWcryS2LJM4090ZGQhntmbYjE9WDGBF9HfdNuAz25ocA3Qnq0jK8kU28Ic4S2ZVM4i0F8i
+0VJTW5BjYKLLPROGFXO8j6gF2qqYyrWWhePXAY9QFSu5YhyG6u4Td-5vBl2UtzP3qsy2_eJ_Ji2WJ_Zl1EASpuk_1FIh_AHtKF5l0XOA_cA_joZ-4W30aP_2
+z3NixGskwlcdu1lV-04
+}
+
+AWSEntityColoring(ApplicationDiscoveryService)
+!define ApplicationDiscoveryService(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, ApplicationDiscoveryService, ApplicationDiscoveryService)
+!define ApplicationDiscoveryService(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, ApplicationDiscoveryService, ApplicationDiscoveryService)
+!define ApplicationDiscoveryServiceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, ApplicationDiscoveryService, ApplicationDiscoveryService)
+!define ApplicationDiscoveryServiceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, ApplicationDiscoveryService, ApplicationDiscoveryService)

--- a/awslib/MigrationAndTransfer/DataSync.puml
+++ b/awslib/MigrationAndTransfer/DataSync.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DataSync [64x64/16z] {
+xTC7Zjqm40DGQlhm_lVTNknezI4dg5a_m6XM9IZ-ZswtMxcAg1V_IWe-IF8w0pIgkq81QrwaXrrBeCrBx3IZ5SOh4j8yQ86eDtS9YYSr1e3WdeBo3zqTsmlu
+pmCBepV3hqMgkTCw0Pe_oOqYE81Xgrm0BJwY6D5S2HCWDdgp5a1ofI2zqIskw4x0wq4znbQvRRztsVCkqDN-KNFbQfulNEaF_FWIGAnEENEyqnh8mYi1d2S1
+vqB8Es-HB7cLDQ0zFUwr39wrda9m61_m-V7K8OEsXu-u5K3MGJC0wtgJFY35fHfGmOax46nyikPI0Cwq0mNUBj_sBlhnrNE-kZOtsLos5kU-jwjMl695ilnJ
+Sqi0BdX5ms3YKt9F3G0HaM_xTtvgRce5cl_2ZR_3xNPx1W
+}
+
+AWSEntityColoring(DataSync)
+!define DataSync(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, DataSync, DataSync)
+!define DataSync(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, DataSync, DataSync)
+!define DataSyncParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, DataSync, DataSync)
+!define DataSyncParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, DataSync, DataSync)

--- a/awslib/MigrationAndTransfer/DataSyncAgent.puml
+++ b/awslib/MigrationAndTransfer/DataSyncAgent.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DataSyncAgent [64x64/16z] {
+xPS7hgqm34J7IUnuPl_xVGLGlb10w16LtuxAhOVY9emlIgH-J4R1ZbCIVyQc-AO7fGp_8P4IOpyxArvGAJeAHSChZ689gU8bLGegyPeKfS1hOcJX7Su_n__l
+MxGbtwbOyHl5Rak-b6N1Pqfirtxp4mPylpIW-44NBIJvfPyyKM4YAQ3nG99jGGYxyFlaasH--uD-ZAqiim_R031UznVO0DzOKgotyIk69xh4TkCxQNZ2kMcp
+RvrImHE5Oh_mIr9F_WZXx5TAbEn1TqannU_uladXTzJZ5jam-RP7jLAy1oWZUoT_V6_9MqGxUd3oJz_Vu6GVvN_oHqYU-vSDinyZ90_-bhRPJohnY9DXkF9B
+IbaMvkUMrBeolsFqL0mCzltYG8s9Ul972Yf_KVPF2GGdukn_cs8_rP-X75F7EJ7txnP5bygR-n_Tl-03iUZ35trKflqfpm___V_-wlwmkh-ixa-h-zlY_hYu
+lwxlpwlx-oS
+}
+
+AWSEntityColoring(DataSyncAgent)
+!define DataSyncAgent(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, DataSyncAgent, DataSyncAgent)
+!define DataSyncAgent(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, DataSyncAgent, DataSyncAgent)
+!define DataSyncAgentParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, DataSyncAgent, DataSyncAgent)
+!define DataSyncAgentParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, DataSyncAgent, DataSyncAgent)

--- a/awslib/MigrationAndTransfer/DatabaseMigrationService2.puml
+++ b/awslib/MigrationAndTransfer/DatabaseMigrationService2.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DatabaseMigrationService2 [64x64/16z] {
+xTO5eYD124NHXqFjVxznrw97ljwud2Wjuz_qsszLkQkMu3GX72Anx6ddBMFHJS84W7rU5mFYvyzTwG9mpNEv-xmfu4aVaF4WGSnvXuq7ANpMFtgceU71djV_
+9gFXJG2mcCSctq-2shoF_HkUOyiHyzxt_tguRVBOJu9t_5rVojjuaCtxHvCQrF2Gg75HXNJcHnaWiOZS5hi1OktCJsp9EPBepa-bcyecDS_wMVFpUFqrxn-l
+F-SzFLf_Dxm_sdvump_QVhNyhifTLL_h_u-7cyean9XBGLRZgZA2ZjaCW5XaxSem0M2jlG_2DjgqlzBT0wbq5Tvw5ZtFOhTQ0brot9NYirwHn_S-NoQqwOLg
+nqcMUSRUWvTvENff-h2wzsKn6jtvVfddot_IRx-j0G
+}
+
+AWSEntityColoring(DatabaseMigrationService2)
+!define DatabaseMigrationService2(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, DatabaseMigrationService2, DatabaseMigrationService2)
+!define DatabaseMigrationService2(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, DatabaseMigrationService2, DatabaseMigrationService2)
+!define DatabaseMigrationService2Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, DatabaseMigrationService2, DatabaseMigrationService2)
+!define DatabaseMigrationService2Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, DatabaseMigrationService2, DatabaseMigrationService2)

--- a/awslib/MigrationAndTransfer/MigrationHub.puml
+++ b/awslib/MigrationAndTransfer/MigrationHub.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $MigrationHub [64x64/16z] {
+xPK7pkWu28G731Zc_lVTOYTQvozfAllQfuQCPd27FoH_-4DbBS5JoW0OIOxWiKE3cC186q7ZCn9QB44Lf5YAv2Cwd6H3vYZjw7n4GFbVVIhYyUQfAuni8xYv
+XTMJP0Wa6e1MP8rW397CVcRZ03GKy29pU74BohSK_6JHi54jkLF5dHmfm_TRCKx9OCinYYHtPYgX_9g2p9DRvC1YC4zHKEVrOv6xBmQnrpzTlzGY9nU3ahd-
+y_tFW_nWaEVxJoOQ3_BU3mPiI9vGQ0Tv074mQAXh_IfV3ExgLtdlYy5zlUvoSZVGH_LZb-y6SQj-XyxyBZVR3GQbfn-90P2-o1lG5eCk0Epa-eZRl7-voLKt
+WvptprpW_0P1aZxpFkLLqy39BPMGY_Td70mvEGmcTld-Hj5OvQj1pBNezxkFffkAFeDfu7kW3ISd40AqJPLMt2ZBBMY0n4NFx4qq-8dUrF96B-s0uFCP1G2W
+yueI15EGF510BuVoYcE_-zmFh_NAzHDTlqxgjPuAIz-tUJsOk3L_fW20pO-qUg_vRRQR-qUMcoUp0Hu2I3ZGajtKaWy80M26iPOtb2B8W1RVeIYoe7o9pVvb
+V4a2hG79jtG5jFCzbLdyOVd37_u6
+}
+
+AWSEntityColoring(MigrationHub)
+!define MigrationHub(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, MigrationHub, MigrationHub)
+!define MigrationHub(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, MigrationHub, MigrationHub)
+!define MigrationHubParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, MigrationHub, MigrationHub)
+!define MigrationHubParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, MigrationHub, MigrationHub)

--- a/awslib/MigrationAndTransfer/MigrationandTransfer.puml
+++ b/awslib/MigrationAndTransfer/MigrationandTransfer.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $MigrationandTransfer [64x64/16z] {
+xTO50jD048NXDpuJxdzVgcnz1OVyTVdYXj_L7brV2UAp6S3D-vTjihhtsm_skzzzcAf5BVeW41D0lkGLadNuMmfamLlxoc7JFc-D8MUzqFrVIMB6r_qaknh3
+9tmYdfTdZlj0FS-lZVeqVlORwPWl1OazyIAmrO0NU6qlSXDGT7qWjdSL8tjUU7jVaRpnxnQpNC0be-fvlr_hqBk5W9ePlyCFzpU-F_y9VTZmbFhBlqqBSHsU
+cQeXxVbDltsGyvWJqhQDUkTR2ZO_f8Zh9AaVCqACRFyXX4DjIThbVvAZ-t_LUQhRdDIXYUDVCIBZFF-H0Mvuo0TErO7ZLCpvoaEEF7hFGpNiMt7sRQcj-LZt
+zPrUpNJT9zCXxip_VlsoUwlPyiulzECyM5RYDbfQ2lz2Nm4
+}
+
+AWSEntityColoring(MigrationandTransfer)
+!define MigrationandTransfer(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, MigrationandTransfer, MigrationandTransfer)
+!define MigrationandTransfer(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, MigrationandTransfer, MigrationandTransfer)
+!define MigrationandTransferParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, MigrationandTransfer, MigrationandTransfer)
+!define MigrationandTransferParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, MigrationandTransfer, MigrationandTransfer)

--- a/awslib/MigrationAndTransfer/ServerMigrationService.puml
+++ b/awslib/MigrationAndTransfer/ServerMigrationService.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ServerMigrationService [64x64/16z] {
+xTK5ejim48JXMH3CzlxdBNh39Adj8t_XsByPudtOxLezrsD8nmLXZ6YmUcgyzsznGiRxEC6PlhV4cEa5gKprjQGM8j5huyBwHm5WRQ3dmU--LrV0-7Alr-lV
+5CfNUzTKimywb4lxt-3HQkspFGK20CPdlLkgf_k_0bQBG3cu_JRq5X4qb9Vt7xC_GSZQ-QCeVQLt0CxvdZqtud2VQD2vFXdgKj-XItqekDGx-ch_bilVrhOV
+5Mskpzpdxryi0ejxlRYTmA6ljb40vUNxjyR6aBJqk8lz31aRCl-A0Rt_VkFsRKnkVmKZ3Fr_ztiVxh7rrHWpib_GAkFTskr-
+}
+
+AWSEntityColoring(ServerMigrationService)
+!define ServerMigrationService(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, ServerMigrationService, ServerMigrationService)
+!define ServerMigrationService(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, ServerMigrationService, ServerMigrationService)
+!define ServerMigrationServiceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, ServerMigrationService, ServerMigrationService)
+!define ServerMigrationServiceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, ServerMigrationService, ServerMigrationService)

--- a/awslib/MigrationAndTransfer/Snowball.puml
+++ b/awslib/MigrationAndTransfer/Snowball.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Snowball [64x64/16z] {
+xTP5OWGn34HHoQYg-zytr12I4aqO_3Op3RztjeKVObaM9Y0sQi90f4fA3VCoxLMp11ymKH3pO80z-7S0eM9m3EcSAYTZt_vqcfnqiilm-y4YjM-gTCxjxsH_
+SBjmX3r4mOr9mVuVA6BSG0Klz5fmAA8dUN1Ra_tG1qQ-Z-Lxkj9zRwwUxIMGxdKwDDyNuXcM2teulgvVFHqNzDeTckvLN9hjRReiryS-lnS50udzyzY_OyV-
+dJW_0iVv4PzViVZyUl_v-VxpEpy_n9Y07s9Pbci
+}
+
+AWSEntityColoring(Snowball)
+!define Snowball(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Snowball, Snowball)
+!define Snowball(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Snowball, Snowball)
+!define SnowballParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Snowball, Snowball)
+!define SnowballParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Snowball, Snowball)

--- a/awslib/MigrationAndTransfer/SnowballEdge.puml
+++ b/awslib/MigrationAndTransfer/SnowballEdge.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SnowballEdge [64x64/16z] {
+xTG55k8038JXYMTo_mFlmcjnQTU53y_Znmd_51yVytttwN3pryoZ-KG9jf3YGmrulUT0yn57p7GjccHVNplecO3p4G7fEF4XZeHpCGusv74lB8YxVUK68TsE
+dnWfi6KiAChJFf2pCDIi2ZQBHBpkkKY8hkGytjnJSQRStxFFkA-V9pRs7VvGzAP-0a_arjuhxvHjxsjuPs9xd_pqTxhwktfsasnk-lxErgNRigu-lEaT7XT8
+LbGRL64pfFkktszFhdzYWRd6yCt_9w-mW529NZTylkd9kS09n933Wwm2-br_hM0y6qEzsvzd9EbmacLgXx0XVDOd9AuLMu4c0mVngWTfkE5Zq3fKo2v1aSV1
+0uOSLbvhAhXyXijv6vGF593DEu8Ynv73AVWy_m46xla446J2E3GaoOJoeNAzTKo5f49TZw41mHr6KMGR0EtZmoMtEtzXNNNwcFSeAC-MN_CU1bK9akmiskwU
+2W0s4pZGvbxLBSW4tCIutxfKOlZDqZtuFOP_ce-FBm
+}
+
+AWSEntityColoring(SnowballEdge)
+!define SnowballEdge(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, SnowballEdge, SnowballEdge)
+!define SnowballEdge(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, SnowballEdge, SnowballEdge)
+!define SnowballEdgeParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, SnowballEdge, SnowballEdge)
+!define SnowballEdgeParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, SnowballEdge, SnowballEdge)

--- a/awslib/MigrationAndTransfer/Snowmobile.puml
+++ b/awslib/MigrationAndTransfer/Snowmobile.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Snowmobile [64x64/16z] {
+x9H7Ojmm30078Fh__viYTrlYhdD9yvosQD08iVzSllXYVl2hQbU6ctbazUU3f2dFgDSdRGNK8d_WHoIhkRloMh3YgUgPBXUmUts7bU-74OBaNIKO4cVZD8Wx
+0YpqlDM9Um8OUZcNb5i1nj7DlmcrzHFPFJ21RdtbnemDtppWhDvJikl0f7hFE3QRy7qJaVtYoocQJmKOSL6Q8HrmflCojhoSaUlgmFk4O6LctMnW0f_JdmzM
+7GjUU_yylxi9KZr6dazETVMbxpFJXlKuSTuYoCu_UgSdplsk7zpmPr6NViyFZWTd7hv-gF_m_S9FTpyUBBFeJhDyxPTRzAAkvZS6T109O0uGByUo15YBcglp
+gypim8L81SaGwjLmlHPGc_qv-eSran0pnil-eZC5ijdVBgjKGNiSR7eXJoXI4zZc_JcsRBeDKKHGVPt94OMQxVe_D6oWLOktXPgWkRy_9bWlrqZL-_Pktb_V
+Hq7vINdvJNdzGNdzHRZ-fB3-fh3zG57xXTBs4_tQRvZjHzgtN-aFHi4e
+}
+
+AWSEntityColoring(Snowmobile)
+!define Snowmobile(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Snowmobile, Snowmobile)
+!define Snowmobile(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Snowmobile, Snowmobile)
+!define SnowmobileParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Snowmobile, Snowmobile)
+!define SnowmobileParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Snowmobile, Snowmobile)

--- a/awslib/MigrationAndTransfer/TransferforSFTP.puml
+++ b/awslib/MigrationAndTransfer/TransferforSFTP.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $TransferforSFTP [64x64/16z] {
+xTG7hjim44NHDyFfV__x3IWJLW4YWtHwVDtBKIVhh-ZJfyYtkA6znm5PvmuuGzxXbGHTum5OVo7OWXvkUG6vgo3uD6UmMVHtveBf1IXwRPn3W2TzcfbkNY5c
+5lNTJ9_PUHbZ_LwtCVPaoNlu8uPuBqvUtUFM7u_wbhXczxnv07phSr-0Rdb3x5xqfSzHZPu-I-5bVklBw9pAy4O4W4XUU10Vsptt2FpAUntx6dwmdF8g8lJm
+92AQSpxHezo6O2_cV1bW4TkYmW6jILy6ojfAxdpMbu9oSAa5NmBk2sXejU370WPVyjtsPIpxQXXyokzZA7dm2HyCW6oWh4cV16O6eaQJFiPyPSjUCdFP9-CH
+-P9luBO5oWMVHFlazvQNQQ_mhrhr3MfDD0xUzHpQZG-Y5C0E-s-un7LJHhXxCffiWT8lHRqkQ3__IsKyolgJ-_Jf6m
+}
+
+AWSEntityColoring(TransferforSFTP)
+!define TransferforSFTP(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, TransferforSFTP, TransferforSFTP)
+!define TransferforSFTP(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, TransferforSFTP, TransferforSFTP)
+!define TransferforSFTPParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, TransferforSFTP, TransferforSFTP)
+!define TransferforSFTPParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, TransferforSFTP, TransferforSFTP)

--- a/awslib/MigrationAndTransfer/all.puml
+++ b/awslib/MigrationAndTransfer/all.puml
@@ -1,0 +1,151 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $ApplicationDiscoveryService [64x64/16z] {
+xLLNTXmX4AocwNZ_0_j1QymemlZ7IVKbxMx52UIVXszy8znKrJn-YMnCA13hOmaTvDP5fBSX8OyKl05DOqK1cZqm__dpY2X11lG1NQPjRqJKkiNwy8okrm8W
+NEtjKC0dFHXWzOXm7Urz2fniq8QDqtqmvqbLK1oaRvb1w7c709x9-mP1mwcXP_X2fA15-Zw0eLK6mmtyujst5v6XbK5uOMWw4AM-YV_-Lp7_xwKSculNwfUy
+OCMtQc6R-ZpMSyU25Z_6UB8PG24pPFX253z7TeKSy2dUzn-nplck2_x0tz2daMtwR_VNXJZTVrr_tbp_xVtd-NR_0ABYVGaTtW9EUzE_ZsNwxW4ixsYGD7w1
+1-byzYl31b8FozqeF1Mm4_iixv6UVNtM0SqXmaVlFwiJe5wyuHqWcryS2LJM4090ZGQhntmbYjE9WDGBF9HfdNuAz25ocA3Qnq0jK8kU28Ic4S2ZVM4i0F8i
+0VJTW5BjYKLLPROGFXO8j6gF2qqYyrWWhePXAY9QFSu5YhyG6u4Td-5vBl2UtzP3qsy2_eJ_Ji2WJ_Zl1EASpuk_1FIh_AHtKF5l0XOA_cA_joZ-4W30aP_2
+z3NixGskwlcdu1lV-04
+}
+
+AWSEntityColoring(ApplicationDiscoveryService)
+!define ApplicationDiscoveryService(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, ApplicationDiscoveryService, ApplicationDiscoveryService)
+!define ApplicationDiscoveryService(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, ApplicationDiscoveryService, ApplicationDiscoveryService)
+!define ApplicationDiscoveryServiceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, ApplicationDiscoveryService, ApplicationDiscoveryService)
+!define ApplicationDiscoveryServiceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, ApplicationDiscoveryService, ApplicationDiscoveryService)
+
+sprite $DataSync [64x64/16z] {
+xTC7Zjqm40DGQlhm_lVTNknezI4dg5a_m6XM9IZ-ZswtMxcAg1V_IWe-IF8w0pIgkq81QrwaXrrBeCrBx3IZ5SOh4j8yQ86eDtS9YYSr1e3WdeBo3zqTsmlu
+pmCBepV3hqMgkTCw0Pe_oOqYE81Xgrm0BJwY6D5S2HCWDdgp5a1ofI2zqIskw4x0wq4znbQvRRztsVCkqDN-KNFbQfulNEaF_FWIGAnEENEyqnh8mYi1d2S1
+vqB8Es-HB7cLDQ0zFUwr39wrda9m61_m-V7K8OEsXu-u5K3MGJC0wtgJFY35fHfGmOax46nyikPI0Cwq0mNUBj_sBlhnrNE-kZOtsLos5kU-jwjMl695ilnJ
+Sqi0BdX5ms3YKt9F3G0HaM_xTtvgRce5cl_2ZR_3xNPx1W
+}
+
+AWSEntityColoring(DataSync)
+!define DataSync(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, DataSync, DataSync)
+!define DataSync(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, DataSync, DataSync)
+!define DataSyncParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, DataSync, DataSync)
+!define DataSyncParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, DataSync, DataSync)
+
+sprite $DataSyncAgent [64x64/16z] {
+xPS7hgqm34J7IUnuPl_xVGLGlb10w16LtuxAhOVY9emlIgH-J4R1ZbCIVyQc-AO7fGp_8P4IOpyxArvGAJeAHSChZ689gU8bLGegyPeKfS1hOcJX7Su_n__l
+MxGbtwbOyHl5Rak-b6N1Pqfirtxp4mPylpIW-44NBIJvfPyyKM4YAQ3nG99jGGYxyFlaasH--uD-ZAqiim_R031UznVO0DzOKgotyIk69xh4TkCxQNZ2kMcp
+RvrImHE5Oh_mIr9F_WZXx5TAbEn1TqannU_uladXTzJZ5jam-RP7jLAy1oWZUoT_V6_9MqGxUd3oJz_Vu6GVvN_oHqYU-vSDinyZ90_-bhRPJohnY9DXkF9B
+IbaMvkUMrBeolsFqL0mCzltYG8s9Ul972Yf_KVPF2GGdukn_cs8_rP-X75F7EJ7txnP5bygR-n_Tl-03iUZ35trKflqfpm___V_-wlwmkh-ixa-h-zlY_hYu
+lwxlpwlx-oS
+}
+
+AWSEntityColoring(DataSyncAgent)
+!define DataSyncAgent(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, DataSyncAgent, DataSyncAgent)
+!define DataSyncAgent(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, DataSyncAgent, DataSyncAgent)
+!define DataSyncAgentParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, DataSyncAgent, DataSyncAgent)
+!define DataSyncAgentParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, DataSyncAgent, DataSyncAgent)
+
+sprite $DatabaseMigrationService2 [64x64/16z] {
+xTO5eYD124NHXqFjVxznrw97ljwud2Wjuz_qsszLkQkMu3GX72Anx6ddBMFHJS84W7rU5mFYvyzTwG9mpNEv-xmfu4aVaF4WGSnvXuq7ANpMFtgceU71djV_
+9gFXJG2mcCSctq-2shoF_HkUOyiHyzxt_tguRVBOJu9t_5rVojjuaCtxHvCQrF2Gg75HXNJcHnaWiOZS5hi1OktCJsp9EPBepa-bcyecDS_wMVFpUFqrxn-l
+F-SzFLf_Dxm_sdvump_QVhNyhifTLL_h_u-7cyean9XBGLRZgZA2ZjaCW5XaxSem0M2jlG_2DjgqlzBT0wbq5Tvw5ZtFOhTQ0brot9NYirwHn_S-NoQqwOLg
+nqcMUSRUWvTvENff-h2wzsKn6jtvVfddot_IRx-j0G
+}
+
+AWSEntityColoring(DatabaseMigrationService2)
+!define DatabaseMigrationService2(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, DatabaseMigrationService2, DatabaseMigrationService2)
+!define DatabaseMigrationService2(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, DatabaseMigrationService2, DatabaseMigrationService2)
+!define DatabaseMigrationService2Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, DatabaseMigrationService2, DatabaseMigrationService2)
+!define DatabaseMigrationService2Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, DatabaseMigrationService2, DatabaseMigrationService2)
+
+sprite $MigrationHub [64x64/16z] {
+xPK7pkWu28G731Zc_lVTOYTQvozfAllQfuQCPd27FoH_-4DbBS5JoW0OIOxWiKE3cC186q7ZCn9QB44Lf5YAv2Cwd6H3vYZjw7n4GFbVVIhYyUQfAuni8xYv
+XTMJP0Wa6e1MP8rW397CVcRZ03GKy29pU74BohSK_6JHi54jkLF5dHmfm_TRCKx9OCinYYHtPYgX_9g2p9DRvC1YC4zHKEVrOv6xBmQnrpzTlzGY9nU3ahd-
+y_tFW_nWaEVxJoOQ3_BU3mPiI9vGQ0Tv074mQAXh_IfV3ExgLtdlYy5zlUvoSZVGH_LZb-y6SQj-XyxyBZVR3GQbfn-90P2-o1lG5eCk0Epa-eZRl7-voLKt
+WvptprpW_0P1aZxpFkLLqy39BPMGY_Td70mvEGmcTld-Hj5OvQj1pBNezxkFffkAFeDfu7kW3ISd40AqJPLMt2ZBBMY0n4NFx4qq-8dUrF96B-s0uFCP1G2W
+yueI15EGF510BuVoYcE_-zmFh_NAzHDTlqxgjPuAIz-tUJsOk3L_fW20pO-qUg_vRRQR-qUMcoUp0Hu2I3ZGajtKaWy80M26iPOtb2B8W1RVeIYoe7o9pVvb
+V4a2hG79jtG5jFCzbLdyOVd37_u6
+}
+
+AWSEntityColoring(MigrationHub)
+!define MigrationHub(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, MigrationHub, MigrationHub)
+!define MigrationHub(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, MigrationHub, MigrationHub)
+!define MigrationHubParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, MigrationHub, MigrationHub)
+!define MigrationHubParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, MigrationHub, MigrationHub)
+
+sprite $MigrationandTransfer [64x64/16z] {
+xTO50jD048NXDpuJxdzVgcnz1OVyTVdYXj_L7brV2UAp6S3D-vTjihhtsm_skzzzcAf5BVeW41D0lkGLadNuMmfamLlxoc7JFc-D8MUzqFrVIMB6r_qaknh3
+9tmYdfTdZlj0FS-lZVeqVlORwPWl1OazyIAmrO0NU6qlSXDGT7qWjdSL8tjUU7jVaRpnxnQpNC0be-fvlr_hqBk5W9ePlyCFzpU-F_y9VTZmbFhBlqqBSHsU
+cQeXxVbDltsGyvWJqhQDUkTR2ZO_f8Zh9AaVCqACRFyXX4DjIThbVvAZ-t_LUQhRdDIXYUDVCIBZFF-H0Mvuo0TErO7ZLCpvoaEEF7hFGpNiMt7sRQcj-LZt
+zPrUpNJT9zCXxip_VlsoUwlPyiulzECyM5RYDbfQ2lz2Nm4
+}
+
+AWSEntityColoring(MigrationandTransfer)
+!define MigrationandTransfer(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, MigrationandTransfer, MigrationandTransfer)
+!define MigrationandTransfer(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, MigrationandTransfer, MigrationandTransfer)
+!define MigrationandTransferParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, MigrationandTransfer, MigrationandTransfer)
+!define MigrationandTransferParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, MigrationandTransfer, MigrationandTransfer)
+
+sprite $ServerMigrationService [64x64/16z] {
+xTK5ejim48JXMH3CzlxdBNh39Adj8t_XsByPudtOxLezrsD8nmLXZ6YmUcgyzsznGiRxEC6PlhV4cEa5gKprjQGM8j5huyBwHm5WRQ3dmU--LrV0-7Alr-lV
+5CfNUzTKimywb4lxt-3HQkspFGK20CPdlLkgf_k_0bQBG3cu_JRq5X4qb9Vt7xC_GSZQ-QCeVQLt0CxvdZqtud2VQD2vFXdgKj-XItqekDGx-ch_bilVrhOV
+5Mskpzpdxryi0ejxlRYTmA6ljb40vUNxjyR6aBJqk8lz31aRCl-A0Rt_VkFsRKnkVmKZ3Fr_ztiVxh7rrHWpib_GAkFTskr-
+}
+
+AWSEntityColoring(ServerMigrationService)
+!define ServerMigrationService(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, ServerMigrationService, ServerMigrationService)
+!define ServerMigrationService(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, ServerMigrationService, ServerMigrationService)
+!define ServerMigrationServiceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, ServerMigrationService, ServerMigrationService)
+!define ServerMigrationServiceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, ServerMigrationService, ServerMigrationService)
+
+sprite $Snowball [64x64/16z] {
+xTP5OWGn34HHoQYg-zytr12I4aqO_3Op3RztjeKVObaM9Y0sQi90f4fA3VCoxLMp11ymKH3pO80z-7S0eM9m3EcSAYTZt_vqcfnqiilm-y4YjM-gTCxjxsH_
+SBjmX3r4mOr9mVuVA6BSG0Klz5fmAA8dUN1Ra_tG1qQ-Z-Lxkj9zRwwUxIMGxdKwDDyNuXcM2teulgvVFHqNzDeTckvLN9hjRReiryS-lnS50udzyzY_OyV-
+dJW_0iVv4PzViVZyUl_v-VxpEpy_n9Y07s9Pbci
+}
+
+AWSEntityColoring(Snowball)
+!define Snowball(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Snowball, Snowball)
+!define Snowball(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Snowball, Snowball)
+!define SnowballParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Snowball, Snowball)
+!define SnowballParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Snowball, Snowball)
+
+sprite $SnowballEdge [64x64/16z] {
+xTG55k8038JXYMTo_mFlmcjnQTU53y_Znmd_51yVytttwN3pryoZ-KG9jf3YGmrulUT0yn57p7GjccHVNplecO3p4G7fEF4XZeHpCGusv74lB8YxVUK68TsE
+dnWfi6KiAChJFf2pCDIi2ZQBHBpkkKY8hkGytjnJSQRStxFFkA-V9pRs7VvGzAP-0a_arjuhxvHjxsjuPs9xd_pqTxhwktfsasnk-lxErgNRigu-lEaT7XT8
+LbGRL64pfFkktszFhdzYWRd6yCt_9w-mW529NZTylkd9kS09n933Wwm2-br_hM0y6qEzsvzd9EbmacLgXx0XVDOd9AuLMu4c0mVngWTfkE5Zq3fKo2v1aSV1
+0uOSLbvhAhXyXijv6vGF593DEu8Ynv73AVWy_m46xla446J2E3GaoOJoeNAzTKo5f49TZw41mHr6KMGR0EtZmoMtEtzXNNNwcFSeAC-MN_CU1bK9akmiskwU
+2W0s4pZGvbxLBSW4tCIutxfKOlZDqZtuFOP_ce-FBm
+}
+
+AWSEntityColoring(SnowballEdge)
+!define SnowballEdge(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, SnowballEdge, SnowballEdge)
+!define SnowballEdge(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, SnowballEdge, SnowballEdge)
+!define SnowballEdgeParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, SnowballEdge, SnowballEdge)
+!define SnowballEdgeParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, SnowballEdge, SnowballEdge)
+
+sprite $Snowmobile [64x64/16z] {
+x9H7Ojmm30078Fh__viYTrlYhdD9yvosQD08iVzSllXYVl2hQbU6ctbazUU3f2dFgDSdRGNK8d_WHoIhkRloMh3YgUgPBXUmUts7bU-74OBaNIKO4cVZD8Wx
+0YpqlDM9Um8OUZcNb5i1nj7DlmcrzHFPFJ21RdtbnemDtppWhDvJikl0f7hFE3QRy7qJaVtYoocQJmKOSL6Q8HrmflCojhoSaUlgmFk4O6LctMnW0f_JdmzM
+7GjUU_yylxi9KZr6dazETVMbxpFJXlKuSTuYoCu_UgSdplsk7zpmPr6NViyFZWTd7hv-gF_m_S9FTpyUBBFeJhDyxPTRzAAkvZS6T109O0uGByUo15YBcglp
+gypim8L81SaGwjLmlHPGc_qv-eSran0pnil-eZC5ijdVBgjKGNiSR7eXJoXI4zZc_JcsRBeDKKHGVPt94OMQxVe_D6oWLOktXPgWkRy_9bWlrqZL-_Pktb_V
+Hq7vINdvJNdzGNdzHRZ-fB3-fh3zG57xXTBs4_tQRvZjHzgtN-aFHi4e
+}
+
+AWSEntityColoring(Snowmobile)
+!define Snowmobile(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, Snowmobile, Snowmobile)
+!define Snowmobile(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, Snowmobile, Snowmobile)
+!define SnowmobileParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Snowmobile, Snowmobile)
+!define SnowmobileParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Snowmobile, Snowmobile)
+
+sprite $TransferforSFTP [64x64/16z] {
+xTG7hjim44NHDyFfV__x3IWJLW4YWtHwVDtBKIVhh-ZJfyYtkA6znm5PvmuuGzxXbGHTum5OVo7OWXvkUG6vgo3uD6UmMVHtveBf1IXwRPn3W2TzcfbkNY5c
+5lNTJ9_PUHbZ_LwtCVPaoNlu8uPuBqvUtUFM7u_wbhXczxnv07phSr-0Rdb3x5xqfSzHZPu-I-5bVklBw9pAy4O4W4XUU10Vsptt2FpAUntx6dwmdF8g8lJm
+92AQSpxHezo6O2_cV1bW4TkYmW6jILy6ojfAxdpMbu9oSAa5NmBk2sXejU370WPVyjtsPIpxQXXyokzZA7dm2HyCW6oWh4cV16O6eaQJFiPyPSjUCdFP9-CH
+-P9luBO5oWMVHFlazvQNQQ_mhrhr3MfDD0xUzHpQZG-Y5C0E-s-un7LJHhXxCffiWT8lHRqkQ3__IsKyolgJ-_Jf6m
+}
+
+AWSEntityColoring(TransferforSFTP)
+!define TransferforSFTP(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, TransferforSFTP, TransferforSFTP)
+!define TransferforSFTP(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, TransferforSFTP, TransferforSFTP)
+!define TransferforSFTPParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, TransferforSFTP, TransferforSFTP)
+!define TransferforSFTPParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, TransferforSFTP, TransferforSFTP)
+

--- a/awslib/Mobile/APIGateway.puml
+++ b/awslib/Mobile/APIGateway.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $APIGateway [64x64/16z] {
+xTPLOlGm30JWYMD9uz7zp_ipjjg0jzpCmjjd9dsqNBb26tgGOJoiEs1w40CwZ-hQ7oc1Ax1uL3vy0LRkQsNjKmzAA7HpIQgz97cxMK80BQHjBqK3elB-7Urx
+oU2rzsFUZ_ZKVycJldDeHFpw4zdFUO0PG2G1om7Wd5zjQDZFFqfcwylst_GWitxmFc_mdFJH9JNGOiexG16DW4_uZYM-CyjOq4zx0f5I0vK1SAP-YcWIP-fF
+6J0CdWHiQlruLyEGki_EFz7kMdyElykBe_9lxFoQFp_cpw_vy_Fjdr_pFe_ulEcRZtq_lDMU2u3LnvOVlW9Og3BilufWvVaB6tKxj0L0gtmhSLr4uGiyyNxy
+KBbovIi
+}
+
+AWSEntityColoring(APIGateway)
+!define APIGateway(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, APIGateway, APIGateway)
+!define APIGateway(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, APIGateway, APIGateway)
+!define APIGatewayParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, APIGateway, APIGateway)
+!define APIGatewayParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, APIGateway, APIGateway)

--- a/awslib/Mobile/APIGatewayEndpoint.puml
+++ b/awslib/Mobile/APIGatewayEndpoint.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $APIGatewayEndpoint [64x64/16z] {
+xTS7hWCn20HGWs4tvlxtJKNHA9aDNp-zMCqIVfCUJ7kzfRQmz4-yZrXOer_1QG3dBdGv2Q1ygKW3EAy3Qbu7S5u65BmEABbOFocQq03E5VQ0OCyvx6F2wXJR
+PII0SOkWFfm69CTg-3ZrmpCJ0YYVzhLplpyqOm3ZCaSCRSpltzMLGC0vrrKUORx9hggd0PeyjxCqwk7PPK1kxSZxY6J4mxjp3B3qSk2Hd7hu90y1WZu3lHKU
+JZ4ljPStyJ-lAasrYUg__Awk4RghN-klVFvVyldzVAzzfpuhOPKtzl_fqFakUmyyRTW_CdowvAT81Fq3-zUnHt8_G_UW3J1x9FUy_M50ziYXpFFsopjuF_Uq
+_VCRnDBzPIAS1JZtJZWFCEQDSXwWxe8rSLV6hx-_Ndz_llx-VltySFtySltyTFtyLi-FrywlhxSs
+}
+
+AWSEntityColoring(APIGatewayEndpoint)
+!define APIGatewayEndpoint(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, APIGatewayEndpoint, APIGatewayEndpoint)
+!define APIGatewayEndpoint(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, APIGatewayEndpoint, APIGatewayEndpoint)
+!define APIGatewayEndpointParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, APIGatewayEndpoint, APIGatewayEndpoint)
+!define APIGatewayEndpointParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, APIGatewayEndpoint, APIGatewayEndpoint)

--- a/awslib/Mobile/Amplify.puml
+++ b/awslib/Mobile/Amplify.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Amplify [64x64/16z] {
+xLLN5iCm3CBRIkz_tnBKFUryc-w1159utZvWOM5XeQL8f7wKdo6aetm3kbb4EyIkmGeoNI0SuWSaFlfkennf3w0rHDcmUNv4eV24kcsoCOc6j0ll24OhyoCa
+zxGBbtdPc8CQKxW5cfUD6RJgKu_e5VbIRHn6mvewXTjbXtdAF7JnIBZCgyg4zxqVAH8kytKY1Zk13aGfrnsEnq226qcaIBX6sKTZe4xwEmj9k7Ou70Dtcb4l
+QuzoCXm3dxGy-tDt9wCnqB-yipJhIKw6Ok0gE-BbKp1zfNeZCV0f9NLoDNgI4waQY8qQtQUX61IKaHXu1urBE6dqmp7mnWsXNs7ihR8gz3i6QgpdEs9boViE
+VyVWyclDDqHKpRBu3d_5uAEwZaWt_jDbX-7dfVCATi-N_DB4pnZek7e5LPFdnnZhc_MlCSZu3FA4G1D2_ZAz53yXTVCVojRy2zhP5XOM5iu
+}
+
+AWSEntityColoring(Amplify)
+!define Amplify(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, Amplify, Amplify)
+!define Amplify(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, Amplify, Amplify)
+!define AmplifyParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, Amplify, Amplify)
+!define AmplifyParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, Amplify, Amplify)

--- a/awslib/Mobile/AppSync2.puml
+++ b/awslib/Mobile/AppSync2.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $AppSync2 [64x64/16z] {
+xLP7jjmm30Ex6Dt_lXbtM--R-SviZTKKGWyWeVBdHxnuyQA5Vn3jVxWPIbX14lcGRJJHr3ym8O3ioGf1W4QUj00FN2YWEThvlNO6FslPI9VQQms65XDj__Ok
+1HqWiIeG0SepmUnSx5YGj-O9CTRRPJ0KeVS67NgHI-w4TkuDh1Vk2LUvthiV0XASeApSorMDzMxmGuzqXLVDZw4RPZWa1Nbla4f-Za76kIEPdvfx0maUf-4-
+hYbej_Q7wEdiVn1iY7k-NTCsIoN4qDJRwLzxoylNkBgAN_BxpXDul-7Vwc-cXBRxK6k3_hf_0U2GpG1sQGOlvdSCBXYUCnmS3kGnloe_sN8IqZ-oTqJlYZXg
+Ylps1fs2FlMFU0PD_PELN-Ot8Cj-OOXXPKn2JB36jjm_axZPNsFWA7G0lBZE8luVumuXMgJ4gIxtRmOhpYvM05hTg2Xsdp80bFuONb-wofJF3lSH1Tt0tznC
+2lhYNcoFhjKOIjFmv5fDuFHcoQO0-HErJW2uVh_KkBoVFBzvl_rCVl7YnLy
+}
+
+AWSEntityColoring(AppSync2)
+!define AppSync2(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, AppSync2, AppSync2)
+!define AppSync2(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, AppSync2, AppSync2)
+!define AppSync2Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, AppSync2, AppSync2)
+!define AppSync2Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, AppSync2, AppSync2)

--- a/awslib/Mobile/DeviceFarm.puml
+++ b/awslib/Mobile/DeviceFarm.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DeviceFarm [64x64/16z] {
+xPO73XmX34M_ZUkV-vytPRD8HAEDq_lRNfuO6mFcZ-C__udWDv0AQF8hgGMO0Qlu5RHz63iLiFxom0KIlCZh-VQB0_ScGzMRxL-MXbhFe1q0rldDp35QGweL
+TLpHo1bjOLsN8yyV1khCTWiY1NNEI4rpjiDiBmO0EClwg8ZcAr8WoUjXXy38CalIT-ZNyoylM72omvFChUoC9baUJJhMQx_P2i18BnwKamv0Ylrfts2f2Due
+I3XqyWMy4iORWRYewC5N91shxrE3nPRH3q20MwN4uqk1SV0P0irTAMTLrO8uHv_ierAwZwfgahFVlOi9lW1rx9Bfdltz_5ozge0uoMr-WS-2aWl1R_0lGtwj
+JuKvq5_cLt9J0Xord3Nx7zCYjwy6lvPQSoD2RbnNZdu2W3Jl_WA0cFo5Q8FV_OHsGZvd_HRixWVYkXGzZk-z47U_e3MFpm80RKQVVWTfcEDtNcNB-xb_RZy4
+ISQotFldk7yxO8_vhnVxztX-MEtwgrMydn_p-KNPzV_Y_9hFJmxdvt1-QtCXNvpVS_zW48NU-eUHtJGzyjcxbRepfw5x27n8mn3ud8OnyBb__KNzyyn__lCM
+}
+
+AWSEntityColoring(DeviceFarm)
+!define DeviceFarm(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, DeviceFarm, DeviceFarm)
+!define DeviceFarm(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, DeviceFarm, DeviceFarm)
+!define DeviceFarmParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, DeviceFarm, DeviceFarm)
+!define DeviceFarmParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, DeviceFarm, DeviceFarm)

--- a/awslib/Mobile/Mobile.puml
+++ b/awslib/Mobile/Mobile.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Mobile [64x64/16z] {
+xTO5GiKm383XU9Rq_kV5eItQ38T-p-MV6toN3UzV4TYg581wRosBOkxph_IxZwSAlICyXRxS8_bJZB7O1tZBnvf3eKyX795ahKVI4M6rrpPElDRx72c6mn6t
+odqGZAJQ6vZRzVsQ2qIrntb5rll8RlUxtttX-DFEx7_8T8yHQFX4Axq9TmJShVLTd_xMskBqQtPz-Qdwql9B0PpTz46eQtswJhYo_9zg1kQT5FhwyVzvCVgJ
+rq-xrwWwflw4Z-k1-0n2k8Udm5zm2G
+}
+
+AWSEntityColoring(Mobile)
+!define Mobile(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, Mobile, Mobile)
+!define Mobile(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, Mobile, Mobile)
+!define MobileParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, Mobile, Mobile)
+!define MobileParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, Mobile, Mobile)

--- a/awslib/Mobile/all.puml
+++ b/awslib/Mobile/all.puml
@@ -1,0 +1,82 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $APIGateway [64x64/16z] {
+xTPLOlGm30JWYMD9uz7zp_ipjjg0jzpCmjjd9dsqNBb26tgGOJoiEs1w40CwZ-hQ7oc1Ax1uL3vy0LRkQsNjKmzAA7HpIQgz97cxMK80BQHjBqK3elB-7Urx
+oU2rzsFUZ_ZKVycJldDeHFpw4zdFUO0PG2G1om7Wd5zjQDZFFqfcwylst_GWitxmFc_mdFJH9JNGOiexG16DW4_uZYM-CyjOq4zx0f5I0vK1SAP-YcWIP-fF
+6J0CdWHiQlruLyEGki_EFz7kMdyElykBe_9lxFoQFp_cpw_vy_Fjdr_pFe_ulEcRZtq_lDMU2u3LnvOVlW9Og3BilufWvVaB6tKxj0L0gtmhSLr4uGiyyNxy
+KBbovIi
+}
+
+AWSEntityColoring(APIGateway)
+!define APIGateway(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, APIGateway, APIGateway)
+!define APIGateway(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, APIGateway, APIGateway)
+!define APIGatewayParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, APIGateway, APIGateway)
+!define APIGatewayParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, APIGateway, APIGateway)
+
+sprite $APIGatewayEndpoint [64x64/16z] {
+xTS7hWCn20HGWs4tvlxtJKNHA9aDNp-zMCqIVfCUJ7kzfRQmz4-yZrXOer_1QG3dBdGv2Q1ygKW3EAy3Qbu7S5u65BmEABbOFocQq03E5VQ0OCyvx6F2wXJR
+PII0SOkWFfm69CTg-3ZrmpCJ0YYVzhLplpyqOm3ZCaSCRSpltzMLGC0vrrKUORx9hggd0PeyjxCqwk7PPK1kxSZxY6J4mxjp3B3qSk2Hd7hu90y1WZu3lHKU
+JZ4ljPStyJ-lAasrYUg__Awk4RghN-klVFvVyldzVAzzfpuhOPKtzl_fqFakUmyyRTW_CdowvAT81Fq3-zUnHt8_G_UW3J1x9FUy_M50ziYXpFFsopjuF_Uq
+_VCRnDBzPIAS1JZtJZWFCEQDSXwWxe8rSLV6hx-_Ndz_llx-VltySFtySltyTFtyLi-FrywlhxSs
+}
+
+AWSEntityColoring(APIGatewayEndpoint)
+!define APIGatewayEndpoint(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, APIGatewayEndpoint, APIGatewayEndpoint)
+!define APIGatewayEndpoint(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, APIGatewayEndpoint, APIGatewayEndpoint)
+!define APIGatewayEndpointParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, APIGatewayEndpoint, APIGatewayEndpoint)
+!define APIGatewayEndpointParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, APIGatewayEndpoint, APIGatewayEndpoint)
+
+sprite $Amplify [64x64/16z] {
+xLLN5iCm3CBRIkz_tnBKFUryc-w1159utZvWOM5XeQL8f7wKdo6aetm3kbb4EyIkmGeoNI0SuWSaFlfkennf3w0rHDcmUNv4eV24kcsoCOc6j0ll24OhyoCa
+zxGBbtdPc8CQKxW5cfUD6RJgKu_e5VbIRHn6mvewXTjbXtdAF7JnIBZCgyg4zxqVAH8kytKY1Zk13aGfrnsEnq226qcaIBX6sKTZe4xwEmj9k7Ou70Dtcb4l
+QuzoCXm3dxGy-tDt9wCnqB-yipJhIKw6Ok0gE-BbKp1zfNeZCV0f9NLoDNgI4waQY8qQtQUX61IKaHXu1urBE6dqmp7mnWsXNs7ihR8gz3i6QgpdEs9boViE
+VyVWyclDDqHKpRBu3d_5uAEwZaWt_jDbX-7dfVCATi-N_DB4pnZek7e5LPFdnnZhc_MlCSZu3FA4G1D2_ZAz53yXTVCVojRy2zhP5XOM5iu
+}
+
+AWSEntityColoring(Amplify)
+!define Amplify(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, Amplify, Amplify)
+!define Amplify(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, Amplify, Amplify)
+!define AmplifyParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, Amplify, Amplify)
+!define AmplifyParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, Amplify, Amplify)
+
+sprite $AppSync2 [64x64/16z] {
+xLP7jjmm30Ex6Dt_lXbtM--R-SviZTKKGWyWeVBdHxnuyQA5Vn3jVxWPIbX14lcGRJJHr3ym8O3ioGf1W4QUj00FN2YWEThvlNO6FslPI9VQQms65XDj__Ok
+1HqWiIeG0SepmUnSx5YGj-O9CTRRPJ0KeVS67NgHI-w4TkuDh1Vk2LUvthiV0XASeApSorMDzMxmGuzqXLVDZw4RPZWa1Nbla4f-Za76kIEPdvfx0maUf-4-
+hYbej_Q7wEdiVn1iY7k-NTCsIoN4qDJRwLzxoylNkBgAN_BxpXDul-7Vwc-cXBRxK6k3_hf_0U2GpG1sQGOlvdSCBXYUCnmS3kGnloe_sN8IqZ-oTqJlYZXg
+Ylps1fs2FlMFU0PD_PELN-Ot8Cj-OOXXPKn2JB36jjm_axZPNsFWA7G0lBZE8luVumuXMgJ4gIxtRmOhpYvM05hTg2Xsdp80bFuONb-wofJF3lSH1Tt0tznC
+2lhYNcoFhjKOIjFmv5fDuFHcoQO0-HErJW2uVh_KkBoVFBzvl_rCVl7YnLy
+}
+
+AWSEntityColoring(AppSync2)
+!define AppSync2(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, AppSync2, AppSync2)
+!define AppSync2(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, AppSync2, AppSync2)
+!define AppSync2Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, AppSync2, AppSync2)
+!define AppSync2Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, AppSync2, AppSync2)
+
+sprite $DeviceFarm [64x64/16z] {
+xPO73XmX34M_ZUkV-vytPRD8HAEDq_lRNfuO6mFcZ-C__udWDv0AQF8hgGMO0Qlu5RHz63iLiFxom0KIlCZh-VQB0_ScGzMRxL-MXbhFe1q0rldDp35QGweL
+TLpHo1bjOLsN8yyV1khCTWiY1NNEI4rpjiDiBmO0EClwg8ZcAr8WoUjXXy38CalIT-ZNyoylM72omvFChUoC9baUJJhMQx_P2i18BnwKamv0Ylrfts2f2Due
+I3XqyWMy4iORWRYewC5N91shxrE3nPRH3q20MwN4uqk1SV0P0irTAMTLrO8uHv_ierAwZwfgahFVlOi9lW1rx9Bfdltz_5ozge0uoMr-WS-2aWl1R_0lGtwj
+JuKvq5_cLt9J0Xord3Nx7zCYjwy6lvPQSoD2RbnNZdu2W3Jl_WA0cFo5Q8FV_OHsGZvd_HRixWVYkXGzZk-z47U_e3MFpm80RKQVVWTfcEDtNcNB-xb_RZy4
+ISQotFldk7yxO8_vhnVxztX-MEtwgrMydn_p-KNPzV_Y_9hFJmxdvt1-QtCXNvpVS_zW48NU-eUHtJGzyjcxbRepfw5x27n8mn3ud8OnyBb__KNzyyn__lCM
+}
+
+AWSEntityColoring(DeviceFarm)
+!define DeviceFarm(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, DeviceFarm, DeviceFarm)
+!define DeviceFarm(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, DeviceFarm, DeviceFarm)
+!define DeviceFarmParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, DeviceFarm, DeviceFarm)
+!define DeviceFarmParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, DeviceFarm, DeviceFarm)
+
+sprite $Mobile [64x64/16z] {
+xTO5GiKm383XU9Rq_kV5eItQ38T-p-MV6toN3UzV4TYg581wRosBOkxph_IxZwSAlICyXRxS8_bJZB7O1tZBnvf3eKyX795ahKVI4M6rrpPElDRx72c6mn6t
+odqGZAJQ6vZRzVsQ2qIrntb5rll8RlUxtttX-DFEx7_8T8yHQFX4Axq9TmJShVLTd_xMskBqQtPz-Qdwql9B0PpTz46eQtswJhYo_9zg1kQT5FhwyVzvCVgJ
+rq-xrwWwflw4Z-k1-0n2k8Udm5zm2G
+}
+
+AWSEntityColoring(Mobile)
+!define Mobile(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, Mobile, Mobile)
+!define Mobile(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, Mobile, Mobile)
+!define MobileParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, Mobile, Mobile)
+!define MobileParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, Mobile, Mobile)
+

--- a/awslib/NetworkingAndContentDelivery/AppMesh.puml
+++ b/awslib/NetworkingAndContentDelivery/AppMesh.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $AppMesh [64x64/16z] {
+xPPNWjim34G7XIYZ-vytFN4tbtBwwdtPaXux0V3_vU2Wcwym0ETkje88SkDEKc4E2UwY3D-Gs3TrhHvUxO3j6NoUHX9SOWpU45Py6o6GvZK6U7DAXZxuC0GO
+ET4DmAE1zi1i9GjgSDvdIvYYPlx3_KwP-dH0_MuBeO3ChuEYjtROdHTM1UNS9rbDzccjeyagic5lyp_ZqFo-SOEVMVFB03CR0dYj-QVx2vpiPNzBsC3OkE1N
+yKG3WkI9whM06S3Wag_eoxyyes7BVhzlNrxpkxdaFu_rDhl_1L44JsJmH41b6h_y_C1Jpgz3m1KrZR_mlhiS8S1q0I92WD4tVYZW4PpJ0wXhlqvnO4udcQD_
+-5daA2wXa60BYgbGBjCEg02YW1LtK0wO0vhSIK84yKVgjzFz-NyvEFW8
+}
+
+AWSEntityColoring(AppMesh)
+!define AppMesh(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, AppMesh, AppMesh)
+!define AppMesh(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, AppMesh, AppMesh)
+!define AppMeshParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, AppMesh, AppMesh)
+!define AppMeshParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, AppMesh, AppMesh)

--- a/awslib/NetworkingAndContentDelivery/ClassicLoadBalancer.puml
+++ b/awslib/NetworkingAndContentDelivery/ClassicLoadBalancer.puml
@@ -1,0 +1,18 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ClassicLoadBalancer [64x64/16z] {
+fPS9akqi24P50U7iVx__OFdUjOpftAvyFJSv60S6ousgUYH36Qwr_4RDWqtXxKjORC8PtVzJZvmkJBwWFUTmoyCoNoZzoOCba5QlbZfDFz4rWD0ximvplSKL
+o4cVfGdSFU50VvYWTC2FfiuON6wqlaA_mMlHlDFVUTUZWmuXOmvtoZyE9AuEd84N9-salZlmVULJXX_oVA9XTP2WYxKEsmCVaEiQr8yrXhi7llhYG24-XnPw
+UURBwg23VMQJyinRquIi5yX1opC_5PyP-FH4b2U-viG_zfWlOA0tV5NxJoCJI1tg7xlE5SW5MVdg2KFPsy4-mGPsuerLNQwyGHkhLw-y113MHAHg1x9T-3fM
+C8XouIKPnD3qe3i_q0f-uIMMJEAGRa3RUOUgq2wyBquT05T8sVW6wY0xtvR3BH0Q80QsyG8UPDdv3dKTeoZKagHivoE997PUHZX9dTbkZbyKTEE3XBxp2aqw
+f6eovMDF-iRtOTfv9simbURCPpgvyNxaEw7GBI5DIf4cqyPNVD37hZYqrMOWt_5XO2tc-4L-vFlr_NC9TxKaRDgkwtVOFmDf2RW6KpQF-sN_3kTdHBIerjaF
+f2V8Y9Jh-JcTtpMZZFWOtnpgzVoUuiV0blFhub0hn25-Jl4hkJXD0482sY5-Z_cZRQMAQ05-oX_d_6LB8oDggW7zdB_E-TF6e7yUd9tD8N_UvczD8BkRzGJm
+S_w-hn_YVDJROj_gnstzaZ4q6LPFzY3biNxEpkl0A_YNzNldTyYW_vRlOBVzopEl4BVzqpDV4-gvVoD-Kf9R_xRtZq_AsJ-U-zVQdwG3xpVzynUgFpJW-eph
+nD_S7rxVNzxVdzxVtzxV7z_VNz_Vdz_Ut_y5
+}
+
+AWSEntityColoring(ClassicLoadBalancer)
+!define ClassicLoadBalancer(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, ClassicLoadBalancer, ClassicLoadBalancer)
+!define ClassicLoadBalancer(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, ClassicLoadBalancer, ClassicLoadBalancer)
+!define ClassicLoadBalancerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, ClassicLoadBalancer, ClassicLoadBalancer)
+!define ClassicLoadBalancerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, ClassicLoadBalancer, ClassicLoadBalancer)

--- a/awslib/NetworkingAndContentDelivery/ClientVPN.puml
+++ b/awslib/NetworkingAndContentDelivery/ClientVPN.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ClientVPN [64x64/16z] {
+xPK73gGm3037AIxX_--z2jhabYn5vHgZGXqdDhPeVneF3mzUiuZawlVi38W8a6z4K4ZgqLfe0hsXQtzHh-aErb_AnHqazDTuSMdt-VsErrngd5pUts_zfBPZ
+WhHRKFSgPmBOpajHV6bj2S6FqvzNUwdeSkGNxCFUya4DVUot-47dGucZnkscG00a-skg16ok3myD97rZLEeyG0ZUrKVGBQp4guYAJ9SlGzlcJHbhMcPVAEFx
+ZQ3eU-1tX3ZZ1sdY3uc5nN0wl7UulfSyKBmhinpc7m8Z4eVvAwKxZO6kw7Kw8O8jwplhcUUVpRUygkb8JES3tIRDrfJ8szTOVfu8-gc1itf4R7w2jFdn3SjG
+3-OFI7l--iWEVrmvrzLN05tzcb8grWxeymymWzZoFyzFtodBEZnh_Q_wALh2x_ej8q9kj_rMH4hSy7LxFM9eshCuo01uku8b6KZM_ZGU7Xw-0W
+}
+
+AWSEntityColoring(ClientVPN)
+!define ClientVPN(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, ClientVPN, ClientVPN)
+!define ClientVPN(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, ClientVPN, ClientVPN)
+!define ClientVPNParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, ClientVPN, ClientVPN)
+!define ClientVPNParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, ClientVPN, ClientVPN)

--- a/awslib/NetworkingAndContentDelivery/CloudFront.puml
+++ b/awslib/NetworkingAndContentDelivery/CloudFront.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CloudFront [64x64/16z] {
+xLO93kig31ols73_-_vV54L-8YZfsvUEjkB6U0OcZljlYWy-o6ZkBVAhSbq81qZypJr2yOAQk-dSIEEDsWgGAI0v_aVFkPq-vU04yXS9XermZvuCO0OVG04x
+VdgtAQEBUDZhnpq4T4eT3UHEyBaAWZn8vwohDaQ0-qGov9PyJU-CruheM2RVI71GIS-ki5TGpiZKiaKIeguq0H6KO9G2AnHMqw4z6A1M7h5LGTsyh0wj4Jtg
+pHDYNzxhGYv9-vP0rl8DbDUw2Bav_FBKQ5LrriqClhFEeInDFNk5bQrZPo8wYZG2GB6JbaGR-JAEUxDGyCgjcd95W4sOiq57ILZFHgzli64Y73xwKBIiLYvy
+3Etw-AL5vej7zY2aG2z9E_mwtyV1ZnYmRWH8dAJRJNux9Hg1R8OOi2Lfmx-TnXmzIo_aBFzMAXNrY5AyH0NKldID8BV-gQLEkfDwvkgVrRzLQhtxKFKx_phi
+sXynspWuz-zFDRaWriRIGg3r_TttZ_Ly56tCyxdi7xNCKhyeEfevugP_hlSxExY3r_wvzk_B0-9fwLPQuVxxCTfQ8fN0iNm_LYXu6d55fhVPq--_dnSDfaa4
+c9zzW0M-HcCm8C_c1yXOtgqqG9_EB_1UCGoy1E_cfpBtDG8W-URyHbBcDucVDZ-ky-jlYWy--0y
+}
+
+AWSEntityColoring(CloudFront)
+!define CloudFront(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, CloudFront, CloudFront)
+!define CloudFront(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, CloudFront, CloudFront)
+!define CloudFrontParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, CloudFront, CloudFront)
+!define CloudFrontParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, CloudFront, CloudFront)

--- a/awslib/NetworkingAndContentDelivery/CloudFrontDownloadDistribution.puml
+++ b/awslib/NetworkingAndContentDelivery/CloudFrontDownloadDistribution.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CloudFrontDownloadDistribution [64x64/16z] {
+jPS7ZWCn24NN7RZ_VLEH5cLUIB62IihCn_2f_lkbb9jy1QrzYgfTH5Lchv-1fzg3w7nRHPSxHDOS5vbB_7T_7osZ1RzB6_AUXYh1Ll19SY_65JqAFopZgc4a
+uLfcDalomZIpLHBRjUN-DNtgGxq-2hfPolMGod1RXxTxFsXSLmMeTnxDDJiwDCs4j2umoWniXNU7cI0fo9Lu6ECvMZweItsmIuAVm1_n4itjmI7Y3oa8jQ31
+Ui2p1ngETpeOZpA20HAEHpmR8F_apwS5W-NaMLJ3jmybdkgMV2fY6XInL8sbmWvqu0ZuesVTzPHlyCNj5dO_nmUWGkw2_vJ3Ua-4cKt0vy_cBUqA92y8fp3W
+EVzoVChVJ_747-EPFuWVupb-b3_S_pX_E7y7Zla-E7-zVhWrrSfDpkk7wZSgR1Q_TgXVwX-z4N-jS__W_hLwnFU5_Ijyu_dWU9ylQ3xtxsut1LMa-W_gtv5Q
+LX2_Of1uVhdDmPTaVf5_pbbTgpgNm4y-lrrnJ-TtlZyqzOsEzWVONuX4wxo_y4x4ziExkB_n_iJx6--F8BW_RkwlU_jpsTpVz-uF-_UN_VlJ_lrj__wuVt_T
+lp_lona
+}
+
+AWSEntityColoring(CloudFrontDownloadDistribution)
+!define CloudFrontDownloadDistribution(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, CloudFrontDownloadDistribution, CloudFrontDownloadDistribution)
+!define CloudFrontDownloadDistribution(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, CloudFrontDownloadDistribution, CloudFrontDownloadDistribution)
+!define CloudFrontDownloadDistributionParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, CloudFrontDownloadDistribution, CloudFrontDownloadDistribution)
+!define CloudFrontDownloadDistributionParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, CloudFrontDownloadDistribution, CloudFrontDownloadDistribution)

--- a/awslib/NetworkingAndContentDelivery/CloudFrontEdgeLocation.puml
+++ b/awslib/NetworkingAndContentDelivery/CloudFrontEdgeLocation.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CloudFrontEdgeLocation [64x64/16z] {
+xTTLmiCW40HW5jQ6-z_tbyPTwYtpLlaINCBLeIlopv5F1_JdynMflCcfMECvd0etNivvUK5VVF75cy_4zdlacM2_zmmR1TcFU0sZw34_gQpjzCLJPCnvSAHD
+dyIH_pBZ_mANjEmfsSKk-IgmH7C-AkhVESwNFtBzV6WSU0w1lNgjnFNsYr8LnFzDurLGVKTxsf-gTq6qyLsPzlYkhfs7qB7-9q7dmMV63-DMyvVFhHzynVfr
+nVhv8Vj7ySKNV_tzwVhxsnMXQ--lrzwVhyul
+}
+
+AWSEntityColoring(CloudFrontEdgeLocation)
+!define CloudFrontEdgeLocation(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, CloudFrontEdgeLocation, CloudFrontEdgeLocation)
+!define CloudFrontEdgeLocation(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, CloudFrontEdgeLocation, CloudFrontEdgeLocation)
+!define CloudFrontEdgeLocationParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, CloudFrontEdgeLocation, CloudFrontEdgeLocation)
+!define CloudFrontEdgeLocationParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, CloudFrontEdgeLocation, CloudFrontEdgeLocation)

--- a/awslib/NetworkingAndContentDelivery/CloudFrontStreamingDistribution.puml
+++ b/awslib/NetworkingAndContentDelivery/CloudFrontStreamingDistribution.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CloudFrontStreamingDistribution [64x64/16z] {
+rPU9SWGX24ILGON-___DwLQiwHhA33cf8zbTNmjUGFbEgszs2nNjvWu0xjPLFWTtnycyRqkelICsUdknFXwVTP-sTYnnrwFPdeBOwYl7P74KxPLk5ojUcmDe
+rtGT07eD1dG0emQ--r52E_mo1d70I9jSCC3b0XyqMfKKnnHWtSxk0XnG1unLQNRYex4DiBBB5pjlem1Uz_dgW9m4ZnBn_Ftghb90nFCIB7V1oNlYEG9Vfsyb
+vDdQue3nzCop0_Qn-Briy7IAPFbldwTPfoUx_18rkR_1Km0QZ3dYttJgr3jydNuRXR_1Bw1ZtEC7_FqWz7jyXzUtCDezlW7_di-kNtB_ykSdVtwLnuWoht9n
+V_Z-YaFFlCA5xo-_7zCZwC8lNz7xiGYnmEGPdswl_x70v0cdMUdzdiJa6P_lD-KF4X102AVyySXVBF3AJvpp5-LF5XZ089povqN-LapJ87z7zOCIJlL3NBye
+uLI_nFMJ4avZm_gjY9ID-etgHpAg7tFrQwv-hidwFTS_vFkNVF-Kxz_o_ME-Vyttptbx1W
+}
+
+AWSEntityColoring(CloudFrontStreamingDistribution)
+!define CloudFrontStreamingDistribution(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, CloudFrontStreamingDistribution, CloudFrontStreamingDistribution)
+!define CloudFrontStreamingDistribution(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, CloudFrontStreamingDistribution, CloudFrontStreamingDistribution)
+!define CloudFrontStreamingDistributionParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, CloudFrontStreamingDistribution, CloudFrontStreamingDistribution)
+!define CloudFrontStreamingDistributionParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, CloudFrontStreamingDistribution, CloudFrontStreamingDistribution)

--- a/awslib/NetworkingAndContentDelivery/CloudMap.puml
+++ b/awslib/NetworkingAndContentDelivery/CloudMap.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CloudMap [64x64/16z] {
+xTDNWjim34NH1n2T-zzlCEB8KnahNscwRch7JL3zMTtTtTs53Y8Q6eyDaR-W1pf2Dw8wfRLuBGE6GAT06R2g0H9X8AvoczvU6nWGYk4gPg2ym1qKLQUlq2Ho
+0g0Ak-09NkzypO08D0YESUNRospqyEa67SWfrpn1j1kdTmY6WWLaqASyS6Qdru4GW68WhdnzNsMTtZ4gl09SJsipL_NmnV1Pw_bP0j7LcvyEhZACzBmokAkO
+fwyIQ19I0SdQfm1R78ts0khGlZ53PoW1lkK6yhKq6qGvCn6phvdcSxXzmnDjLa6GgZnFH2UqzatVNWKAdIS_5XL7QsWUI7TJnCYru82bvXI8cK1dCBqBlFdw
+_8xpcjyvenSCUEyfV-ODyEOVlNtvdXk_-3fT0dNNgtvjLo2Qwxf-Zpxv9DgDhZMX26houjEEiZvuX-pEFmaeN_ZhsFEHpm-U4VlnRGvOBQy04I3lVGv8xH90
+3dvwxuNtFeqmQfyH03e227XT8D3gdCPjQODftx2iFwExkxkx7m
+}
+
+AWSEntityColoring(CloudMap)
+!define CloudMap(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, CloudMap, CloudMap)
+!define CloudMap(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, CloudMap, CloudMap)
+!define CloudMapParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, CloudMap, CloudMap)
+!define CloudMapParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, CloudMap, CloudMap)

--- a/awslib/NetworkingAndContentDelivery/DirectConnect.puml
+++ b/awslib/NetworkingAndContentDelivery/DirectConnect.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DirectConnect [64x64/16z] {
+xPO7rkCm20O_H17W-zztd-s_Y3mtRM-JdZ3g4ETlo7_-4zwjUtobtHaR99xp1A-ccZ814hEw4rhFZJ12ysbTynC1nPJVe3cYQ3EwWhF2q7JJ7a_q84HMWi00
+G3tlwP238Q6P2T3lVQb1iG-0zwRftc-8Jrc8EDOtGziJFeC85EFSbcix59--eqKAxFDNWErADm0oVD9bAUkf3MZzOkkXaLdwPvGU_M8N7EJ3L2858BJCg1iC
+FrkwNbAGNG49hIcq6FXG3xInBLgxPgI0MksI47SdhuEtxMOuAD8WHqUiOh3n_RhqojZsFC0ryDZNeVyMmM_zUohatlSnY05iymy521JtumyQenIGMFqq0lln
+4Q_KKH9bRluYDRw3Jqk77lWfy39D-5NXZKlV1R3hmjzMhFWHROVkgbWNmefMtx53R94tnChh-6CddxFvxTsVn_JjQUaQqxOB3qYVr8DGcMp0835Wu5c_BwMq
+pFlv2_tbs_mG0XK0zkS-0_JAn5LCAKJNHUlgZw2YFy_FVX3g5lcxyP__V04
+}
+
+AWSEntityColoring(DirectConnect)
+!define DirectConnect(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, DirectConnect, DirectConnect)
+!define DirectConnect(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, DirectConnect, DirectConnect)
+!define DirectConnectParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, DirectConnect, DirectConnect)
+!define DirectConnectParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, DirectConnect, DirectConnect)

--- a/awslib/NetworkingAndContentDelivery/ELBApplicationLoadBalancer.puml
+++ b/awslib/NetworkingAndContentDelivery/ELBApplicationLoadBalancer.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ELBApplicationLoadBalancer [64x64/16z] {
+jPUDcgKW28Q55B3xl-35bBE4DUDPd_tcpv5U43iHfXTX9gddfIgKCNsZW-GC4ZeMOIXYSPbKREkG0WiqrH4EtEHOKANVF9H6ruAp1OVf9ngbXSvlvdoPyHNF
+LGD4UlqAKk_yIuB0UX4zcZYwVby2l-2O5eJc8E82dqK-wcEMsG4vF9NpKIKv1tHFIXSFoV4ooV49D8NiKxhdNfmpXvJx7ZX0pDqARmiM_m-dTTxsE_yrLLZc
+PuZCrIflYoQpIFgUJpAkAY7yAf_77TL4qiIdIP4ty6Xk8dyU6FHosRLxE1jcpJnUEoXzzq9ciwPTwcXt4dIOYaOzJ4y51tDBubKOaWjXT4tg0_wL1rsxn7iL
+8npfNVKK_PwZYgcLMp5XcZVGQjdQ_OlYDarFF4zwuYdmov_VoAyyF_yhFj_2P5NBDMVqpKXkUz9i4DyvfmIF9hdLLnE5-wVVBxoRho-y1bS0Rdo5ItoFptss
+dXG-l-7v8GiRUGj8uVcnvtUP3y_lhNu0yBZrrm3wi2sR-x0DmDSFNx-mrgj5gWZI1wrRAcDMu1ZcYgv-MVtqPIkZZRWbCeJqiRlwsSkmyLGATPvBARNpLOVS
+UHsHyGOMcyWzayuVVTji8u_6NzUZkxpO-ylny1CFnjlxozwVQxp5jspTgxZFC15tNaTa-Ukmvszs1wK1Vhl_pKteNq3g9S74OwIpUSnoGhD3w5z2_xJOG-BK
+lotB-hVOFwx9-iUvVrt7URD_tkpVDyyFs-UN_VFJ_lbj__ouVtxTFp_ldj__
+}
+
+AWSEntityColoring(ELBApplicationLoadBalancer)
+!define ELBApplicationLoadBalancer(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, ELBApplicationLoadBalancer, ELBApplicationLoadBalancer)
+!define ELBApplicationLoadBalancer(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, ELBApplicationLoadBalancer, ELBApplicationLoadBalancer)
+!define ELBApplicationLoadBalancerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, ELBApplicationLoadBalancer, ELBApplicationLoadBalancer)
+!define ELBApplicationLoadBalancerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, ELBApplicationLoadBalancer, ELBApplicationLoadBalancer)

--- a/awslib/NetworkingAndContentDelivery/ELBNetworkLoadBalancer.puml
+++ b/awslib/NetworkingAndContentDelivery/ELBNetworkLoadBalancer.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ELBNetworkLoadBalancer [64x64/16z] {
+l9JRkkCW24OLaTFxF_0O9FFPKZB7lTSjBlmXhQq0a4JDKI64zYSC4dj3QFoct6V8AamBldF8xBzXayPrn-4UWPH-rM5Ujax85OZIamroNOrL6RqCfOwhh6vN
+u9MXEa6hnhyOiBEPqSSIfylB25peq7u3Y0P9bzv-Yowv0HLwsO3UDw_z5n84wrpNrwy0lp6xMA1zxm1UQlYhpFOJs86btKmpBZH025-DnuBSzttFTfUguRsr
+4Fh8-_m8_v3e8JtlaJ7vrmHqNo-jPFZUEFjD8i1yMXxivm0_-1WRKDFwCR5DzvHpmU67w0rdOVkBmKDCqlUBuCEt1xKjOvc-ADP0-ZsR5xnxPjju1LGRtZ1e
+WQlHf1CV43Gvdg8-wWS7C8PuWHldbp8pp72PtNsLcyk7zDRd_BuPCVKaUex5fyUS_t-1cgZ9iqzNdFpzugHwDVdvjUfgZ0iwVRO5VVG1nWQm-FsxLlfi9ylz
+BZ_dr-VyFqgl3m400228OVxMWGZ2psklVpk_tP_TtxsVlT_y7_k_zd_c_zxysFpA_DpyJdv8Vbb-IdvBVan-JNvEVaz_Q7zvVtf_UtzyVtr_Ndy7
+}
+
+AWSEntityColoring(ELBNetworkLoadBalancer)
+!define ELBNetworkLoadBalancer(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, ELBNetworkLoadBalancer, ELBNetworkLoadBalancer)
+!define ELBNetworkLoadBalancer(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, ELBNetworkLoadBalancer, ELBNetworkLoadBalancer)
+!define ELBNetworkLoadBalancerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, ELBNetworkLoadBalancer, ELBNetworkLoadBalancer)
+!define ELBNetworkLoadBalancerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, ELBNetworkLoadBalancer, ELBNetworkLoadBalancer)

--- a/awslib/NetworkingAndContentDelivery/ElasticLoadBalancing.puml
+++ b/awslib/NetworkingAndContentDelivery/ElasticLoadBalancing.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ElasticLoadBalancing [64x64/16z] {
+xLO5ikj039EzNaDw__EM6NUY3m-YGj0mCaxV10iMX4SHqe8jRAwu0ysxeCqJBo1sXuO-qtnV7VJ8B7b37auKnSfp_Yl5dy8_lnlkzwdI0RHk0_6BXWFqobA3
+k0Bu6BrKGCtTJG69eqCAhTMK4JMGPNbIPKTpAQDfsyycfukWOpJd0fAtJ2fw1tmmHe9yl0N9uHphJmYHkWxi6mPhz-e3zEAJ2m3nrzpRyyIzf92vlIRJ48yt
+BmcV1oBoaQJfRMM9tAgFLyaWKi_LoXv0dHqYvLd_MVx8-97vG-OlKJzq_VBzW-vVTF-a-pSxF-ZvHSxFRpx_XTwV-FsDtn_v_VN_Oy623G
+}
+
+AWSEntityColoring(ElasticLoadBalancing)
+!define ElasticLoadBalancing(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, ElasticLoadBalancing, ElasticLoadBalancing)
+!define ElasticLoadBalancing(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, ElasticLoadBalancing, ElasticLoadBalancing)
+!define ElasticLoadBalancingParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, ElasticLoadBalancing, ElasticLoadBalancing)
+!define ElasticLoadBalancingParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, ElasticLoadBalancing, ElasticLoadBalancing)

--- a/awslib/NetworkingAndContentDelivery/GlobalAccelerator.puml
+++ b/awslib/NetworkingAndContentDelivery/GlobalAccelerator.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $GlobalAccelerator [64x64/16z] {
+xLNNegHA22moTF___zu3EZVjhexdPMEDMOekahD-LFp17rH-e3x9TI4CIFonZzGcigWA4m3DHsihGDRAz-ueZ01zNqCGo0_g1yQ94oZUfFknM8KolSBVBSdV
+fVTArbmmew6rLxpd881SAndW8II1ZtWIk0-X27668F3TfG2L0RfsWEgEBx2cK-m4hu71TZAqh-HMFVS1d4kG-v04gbIqOxwBW94T0g4tpwpA33xlSpHT8LkW
+GLSeuTyGBs-k8A_uYXYvQss5cSe7r8OvudT0h_Y4MWuxh6l2FwydDzhEx-IV4kbVXiUZ8he98627rThrhqnjcrBiheXTLS3Xkq1kvjQd4oxGVjO9yAicDdJR
+NC1tmExu7EvXS_AOWqAZJ-_nPK_ySt9TVKJCpHs_3Sx47IV7rFjCcjx5dz1NiOjewED0aQ-MqAlwpQ8AVna70MGlbmcUovlnQRFfNmzNWfh7qKi6lniWUmrf
+6k7Vq6CkTXjSODexGT8SwfKHuGm0p4sbI_bdy0gm9_K0CLOVCWJWhg2kInHw0OPqqv-P2yZU1ghpxINc4rSCpj7AisS9AC-Fumsa9PO0fk1YAeKuWQlZadMB
+8kwJ4m0mWT6OTPbgtQF6Q2yNd62hVRvv5sLgAgE1HCqirnDimV_0Z_W1I6Ha428ZKW5_HWUiOsOSyuz73WHHH5CCv7Z913_d9m78n_nJ__IRDU-f_XNCTlxl
+J1pExEiv32oGzMcKO1h_yyXSFox-u0_-0W
+}
+
+AWSEntityColoring(GlobalAccelerator)
+!define GlobalAccelerator(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, GlobalAccelerator, GlobalAccelerator)
+!define GlobalAccelerator(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, GlobalAccelerator, GlobalAccelerator)
+!define GlobalAcceleratorParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, GlobalAccelerator, GlobalAccelerator)
+!define GlobalAcceleratorParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, GlobalAccelerator, GlobalAccelerator)

--- a/awslib/NetworkingAndContentDelivery/NetworkingandContentDelivery.puml
+++ b/awslib/NetworkingAndContentDelivery/NetworkingandContentDelivery.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $NetworkingandContentDelivery [64x64/16z] {
+xTPLeYKn28JX0WAXoFxNEtRSanwxzZ_pjKlml_fAi4i45give2SVezOQlFIrsdlmNvxy3TzD07LkypIezsWGRlAAlXiKsU8TMRiIlku97xNF86tL1rY7iZNe
+ecyN9pqIiURLwYBJ1PzDqQul9wUzGvhdjOSwftpSkr_yzIJbZ1Uh-r5bmdTaFIZHN_j0FGmnu_c8SyOduhUElqpum9lKXAV0axTbGypuOiFT96QVV-Ql0l8Z
+HEvQ_FwD5AKPHN9i-NvsA8VPeA8lUaRGqQhAhAeQd16SzYa0u7NmvR_6SjQha0QUF66awAGdObGYJpwHDGASyoLjFqq5bFijDgb97p3RNJtfNNPNq0mnwojK
+_TTC7wE3LUMgKNF-ya9SdFQYBqC4h3PxDg1ntPyYtyFwvykFt_FErVB2R-ZFUQXjIGM7P5Fu27q7
+}
+
+AWSEntityColoring(NetworkingandContentDelivery)
+!define NetworkingandContentDelivery(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, NetworkingandContentDelivery, NetworkingandContentDelivery)
+!define NetworkingandContentDelivery(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, NetworkingandContentDelivery, NetworkingandContentDelivery)
+!define NetworkingandContentDeliveryParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, NetworkingandContentDelivery, NetworkingandContentDelivery)
+!define NetworkingandContentDeliveryParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, NetworkingandContentDelivery, NetworkingandContentDelivery)

--- a/awslib/NetworkingAndContentDelivery/PrivateLink.puml
+++ b/awslib/NetworkingAndContentDelivery/PrivateLink.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $PrivateLink [64x64/16z] {
+xPHL0iCm34CbXwpc_kST5BULHfzvFqN5xExlD1gDXgJljJaGWCNobJe2e9a1iCzFS8B9xtSg0KYVoe6uH5w8y9dpH7vwDiHFzE7LOTbou3a5jWw8oaPBUily
+Ek4HDmZGJ-K2jruYUgS4wjpzsAr9_SkQpZEPZt8bdZbG4_8doLatxelUSxgHSovtomcmW_CBmQX7jM66Dw6I0UPxSY1fdBuRyVx2yaWOFVC8-4xfKARvkKCH
+iNFLARFGUBETnOXKnm68hXi5rcbfnxcDq_P84dhwNFkRCAaMcS3DiGsJ7Ss2_lNYtrn6tzB7qG_ElHIx9G1nBduyrC_sbRJOT-iFMkdN_YzTNdjVSo8vJz_A
+_rN-H8JY0-LkjTVRGsEjnk3PhWmBOVLhpJiRqUO4bpXHrYFcXE_jRIlgR-l4-gUqlz4L0DWX170qWP4uXE5iY-gGxbyq6et65G
+}
+
+AWSEntityColoring(PrivateLink)
+!define PrivateLink(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, PrivateLink, PrivateLink)
+!define PrivateLink(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, PrivateLink, PrivateLink)
+!define PrivateLinkParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, PrivateLink, PrivateLink)
+!define PrivateLinkParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, PrivateLink, PrivateLink)

--- a/awslib/NetworkingAndContentDelivery/Route53.puml
+++ b/awslib/NetworkingAndContentDelivery/Route53.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Route53 [64x64/16z] {
+xLO7Sbqn25oQ0B_xtpSFXlbnaz9xrasog0iC_-dtnN_yHyINQXZvCtNWcG4d-wJw0h0UwWHGl7mw8m05f7NI0AkVx1VfftC-IR3B2M1HQNVjzRumG7uPA4_w
+0YahYm60DDgnKjruvGZieU0nd-vHH_UwX7lE_nbwuAwYa_9q5MxNWCPSSh5KXbiE7V2AeI9VxiiOuFgnkdKMEbBlWg6tIv2NQ8EBFvuBgHFkO1IyBRsNbRWo
+bfazSlRxiYAl08__G_w-PrZWf_nBu6vGmgR42RhR-rJ0A0dTnUT57nqxi99ts6Qou4t10OPr1MINNLmBTfu-kxBrLVZ6BUprLqHBFo_3EkkF_mIUwnDe_9_r
+jLFKqd-UH7AnfasEdiTtGapezPnMd-3oEC1MrjjNFET9u6MikTS3WGb4IRKi4V6Qf6X5Xz7Fo7tspN9fXQWAqBw427rQa1RQg4Ut_xC6YKShEo66XwpZnhrT
+9V8yyH6TkZkuZheblwTlhzyJk2j1b2gFHcIxezb0CK47kArknglAEnK7CQ5oiJwL-q8rYCAFlLy8g-xDtYB2hEFnD0EbN_wFeBr-vo-mytotJEniLn4aTjeX
+e2p-3yQ30LcHRweRIm2EGuX9_R8O0B5D6CCcpJgeUkHXUMUB2yt6V6nJaZQOnnKU1EhbTnzBYopJg2pTEhq22HG7VbDwJsLBXm94W4PRpDvhCi4VE4RPg30w
+Mkt3AbrCRSvuo7fTUWu-slnCJAnUPt_az4LesYLJfX1VWMAxAlBqbHZ-VjBdrv-F__YF3m
+}
+
+AWSEntityColoring(Route53)
+!define Route53(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, Route53, Route53)
+!define Route53(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, Route53, Route53)
+!define Route53Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, Route53, Route53)
+!define Route53Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, Route53, Route53)

--- a/awslib/NetworkingAndContentDelivery/Route53HostedZone.puml
+++ b/awslib/NetworkingAndContentDelivery/Route53HostedZone.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Route53HostedZone [64x64/16z] {
+jPO7UYin28GbrE2__trVaJVcitWbk4pY9ZFi30kooXjHurBlVmsBwng2nKn2IlrBWWNjp0XdT8FrH_e0w2VzJD01HebeR2pn5OErm5oLB3PQYKwXDGEctDYB
+hNI_tE9b0jOQc9JeT7pbDrKrW5b-OVhIfM_4ggmhk3G5t8gBtj2Ra7dMS8BUdOobgckunBYaC1-BQZNLQGRziNOb1Q-X9ql09RkP7BnaCslULS_jNc7b-GjK
+hjvvphzMbv9qi2dYoT8Ld8-I5NBz0tgqmyZmnranO-MARt4XWN2v2JLbVmP3yds-X7ADxFL7y9_X1_-6bWGKAo_U_rRUrtyjt_yF0fwRFtUJS1yv-V5taWzJ
+6lqkmAsaO5YuzzaUYAEN7q95ysGdLcC-nvzO3REOAy1R-C_hf_fUcCV2ujQJtuJw4-thl30--G4Qp_x-Zt0QInvVN0ehj_yjC6U8WVL4wGnCpfEwzczfg5s9
+1-1XWAsG8f3N3Xpncsa0-37NuQTW06pMlmgx0beui5xf3viXnLJpg3EpwGpaW2f3sHxhjJ0CG8S4xjyWq_YwfTss8oaPN1TL4NKfpsG8x6INvZexDcfewnn4
+ocVn4m
+}
+
+AWSEntityColoring(Route53HostedZone)
+!define Route53HostedZone(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, Route53HostedZone, Route53HostedZone)
+!define Route53HostedZone(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, Route53HostedZone, Route53HostedZone)
+!define Route53HostedZoneParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, Route53HostedZone, Route53HostedZone)
+!define Route53HostedZoneParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, Route53HostedZone, Route53HostedZone)

--- a/awslib/NetworkingAndContentDelivery/Route53RouteTable.puml
+++ b/awslib/NetworkingAndContentDelivery/Route53RouteTable.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Route53RouteTable [64x64/16z] {
+pPS74l9M30PNNNhtlsyAps7i_91YIFbeiePrrywO_pmMjsE0h0yYN-53RYL-uvrRyUVs0L4GCrL1p8KT5K3SzhAwSYhYnESCU7Slexj70AoNWqwL0zZK64VX
+5rup1W0TGP5b0EdZKCbE1z40dVXSUB3DPm78qWDn60EEfZw8CNJfItuS89edBwkx5HwiBjqhadd9xszTUkPTgd_WNs-_4c224p-ApNd_6NiK5zxtNmoe0b3P
+F1t4e48dsOXIIRmyVpw0hfa9bX-yJO_HzIYKQlJHuNh_2I02eAeg271ycO38jRZUVxVotFxSp5Vc5w_RSRuHkHq0UjrEVyUV5RTIt_IV1rXcXcBF2wEXW5Sf
+0197Fogl_fEU0Ol8PLJa5a3CSl1nFxItYjttpYjlFi1JGsi3SiplZcfjVXmRUUclohE0jZ_S5Cvs77ld7zbWrSL_DN7Xt_il1i17phmIymF_UliTW8x2nTzs
+uHb_ux-jroap9VNGUPLMumvKWplPMiMLrm8y0TcJsGQaWLINa0b4G2GyEiIt_ENSYdzhVkv7FlJ7f_xwE1_w-pl-cvlvlzn_0P89NbsbU1_Amig0w3O0hIa1
+87y_Fp8pe6Q-b7ny0zdRdwPxqMqIU36_8eSY_EnFfHtQUQRgdJyElWF0bfpy6M4S6R_uwvq_Ey_-gvnZEURF_Dd7zzMVFfoq_jxVp2xbfJzb_7aKzjAVjXlb
+hfGTwyksBZAeSNSYYR7-mPy9M02IMUMa0c50TWhXH5Ob7X2TNxt_xZy__TVFVvy-l_xd-Ha
+}
+
+AWSEntityColoring(Route53RouteTable)
+!define Route53RouteTable(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, Route53RouteTable, Route53RouteTable)
+!define Route53RouteTable(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, Route53RouteTable, Route53RouteTable)
+!define Route53RouteTableParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, Route53RouteTable, Route53RouteTable)
+!define Route53RouteTableParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, Route53RouteTable, Route53RouteTable)

--- a/awslib/NetworkingAndContentDelivery/SitetoSiteVPN.puml
+++ b/awslib/NetworkingAndContentDelivery/SitetoSiteVPN.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SitetoSiteVPN [64x64/16z] {
+xTDd0i8m20NW1sH0Sl_xkeqhbU8VrtEFBmNIjk_DF_-OMHnh8W2SWqla7HO6K29SGCMshvQ1l9udi9tweFKLrC6t2m2sqZFgrIXMTg3Wgsq4UQNjMoqt1vHz
+0yMUSqBT5rnlfbd7J9Ou8-t7bxITCZuBs1pSiQbJ3beCG4iBE3m_gLySzKVcPuClBp3VFmMPv_oP-LQj-TAtlbz_rhvzyLXB8a9W6JbzpXvVC8-vV3Pz56Ed
+ByS-Rnls-j5cOHAD-mmGe55l8Dr-bAXNfEq0YEAUMrTmk7y19q89UnDW-odYntNJN_JjatrXZVcHp_Ebl-P97WSkNp4DUtopUTfNvPz_DW
+}
+
+AWSEntityColoring(SitetoSiteVPN)
+!define SitetoSiteVPN(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, SitetoSiteVPN, SitetoSiteVPN)
+!define SitetoSiteVPN(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, SitetoSiteVPN, SitetoSiteVPN)
+!define SitetoSiteVPNParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, SitetoSiteVPN, SitetoSiteVPN)
+!define SitetoSiteVPNParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, SitetoSiteVPN, SitetoSiteVPN)

--- a/awslib/NetworkingAndContentDelivery/TransitGateway.puml
+++ b/awslib/NetworkingAndContentDelivery/TransitGateway.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $TransitGateway [64x64/16z] {
+xLO53iGm37DWQTF-_xs7OvuYEh1Ww8QXV2N--CEpgJoWblqwEmb6a7IDRGIG6kC1Ddq-sGNP36WgrK1c1AibAS1dTMW0oUK1WjVgeF905g0vHHVGMv93ti_-
+reeWf-ZSkhkLJEYU6NA2BgDxTTV92pcqdKSPyFR_AFfyu8C4yj6ZDq0pUK7OZGBFFnFD1V0EtI1bdry4jiqdv2D-1krOh-M8NtJR0u9qp4-RCVI5QiO0syB8
+ZNBEq5hS9-4dcYI0UwcAlELzCmBK-s1AVXOEk6ChG6PR4L0m8DJ9CyWqPCuW0HYwvJxGWwfjZdAdPsuLQ9v49q0s-LQVRWGzCNYJsXTFnrL3d1_LF-g_QFoY
+-HFDts3zHEits3-Y_IlOFwFzEpW_WlChE3-3ypkuFmJtbzZ-5DlVWllZL-AFF-u
+}
+
+AWSEntityColoring(TransitGateway)
+!define TransitGateway(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, TransitGateway, TransitGateway)
+!define TransitGateway(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, TransitGateway, TransitGateway)
+!define TransitGatewayParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, TransitGateway, TransitGateway)
+!define TransitGatewayParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, TransitGateway, TransitGateway)

--- a/awslib/NetworkingAndContentDelivery/VPC.puml
+++ b/awslib/NetworkingAndContentDelivery/VPC.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $VPC [64x64/16z] {
+xTPLWYCW48JXQeFkulxdNI7Z0qbOb_bUeZyMvR_emuVAthE-DMwAIQDuhWcW7k4AIECf1pmvLG1sd4loIUhX00rIVCdW1ta1-UOUHH-ih3jN7tmZ8Kq1MFAc
+4gd5c82Q0fstzDLc4vABara9jDMeS-KZ4BnkE99R1UKDTgsdejMDD-xLtW5uNPaStdbDTu7qRQx9ZGhLI8vHiLjYW-xYPfYq5KSBBYboksPeL3N5tE3WIiAu
+40A89vb9vhmLjPm6iHmLrZdctDfgiDlcRTpGbhqFfWCmmsMiG3kPtuS34e-hjyr4JDYwfpu77RBhAQXTpoUoxmEsw-kUdWghx-bB8P7rqb5F1jx8ivxLtFI5
+EkYNVa8VwBnRmOOXduVJuIVzPS7-VC0n37NG6xBaiPZNH7YWmSVJEzFXeyDvO4wfy2BB8KL5yaJ0M0gO2IH7W_6C8Xw_nceqe7Yc19PaNNQ0pbEbB_vETVBS
+wk_S-T_9NlodVFZm6G
+}
+
+AWSEntityColoring(VPC)
+!define VPC(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPC, VPC)
+!define VPC(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPC, VPC)
+!define VPCParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPC, VPC)
+!define VPCParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPC, VPC)

--- a/awslib/NetworkingAndContentDelivery/VPCCustomerGateway.puml
+++ b/awslib/NetworkingAndContentDelivery/VPCCustomerGateway.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $VPCCustomerGateway [64x64/16z] {
+j995WkrG20LnEVlVxvUEq_QKIUnMOQ5t1d_4GwXOL3S0T5UOt0T7OqJ7pGgh1QaC_nUHsxFTJfVhgMzMhziCKjTQHQuzbVo8Eu1sFee1ZfJi3S2_fpa11DCP
+Fmk80q3o3xMtqWKV0jB-jWTfe7ZYKy05j7o39mqyWHm2oaCml35n5K1q2cAhSrXphiBeFqy6-BTdZzCrNncH0afaSsSrZG8qquoD_nJSW0oXqi_yV5_NMINT
+mrDUPjfele_dHf_JEzt0p_KStJVVotEZZk47tSjJ03BkRkHdraRH_JmLUeXkusS3jf-nk8Ltsx_Pwk451-87VYwEr-E5sd3OZ_mujeAD7FZWlnCaUlaHOddR
+IZFagzLgBu90yqSRlaXJH4SuuFETI2uLEB3nWhj3NiC_N__Vqkk32000143WqRyq8Tu6Rg3wOVzqVdH-TNzqV_5-wFtI-udtM_y7_Y_zd_Y_bH-GNv2VbD-G
+7v5VZPz3VZT_S7znVt9_StzqVtL_zXW
+}
+
+AWSEntityColoring(VPCCustomerGateway)
+!define VPCCustomerGateway(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCCustomerGateway, VPCCustomerGateway)
+!define VPCCustomerGateway(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCCustomerGateway, VPCCustomerGateway)
+!define VPCCustomerGatewayParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCCustomerGateway, VPCCustomerGateway)
+!define VPCCustomerGatewayParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCCustomerGateway, VPCCustomerGateway)

--- a/awslib/NetworkingAndContentDelivery/VPCElasticNetworkAdapter.puml
+++ b/awslib/NetworkingAndContentDelivery/VPCElasticNetworkAdapter.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $VPCElasticNetworkAdapter [64x64/16z] {
+nTS7pkim30FWU5ky_tqxY1WsAcKWUeF_7bzRCSF9zcyIVBn9zl00IFHu0RhJepeziiTt0QB3rmnqZzygK3r-wyyhe8zoi1V4T1L1-_oVNK5ek0wzNS4jZiB_
+PGLwswRBS6wpWi37lXjMe7qkfUHmXSqAw6LKT1bMe7mVFfn7Lq3_PO9skIqaZGfqV_tZ0ovIPmMc5_HS3gFt0ktrjjHRcXMS-63kFjEpWXFVeH9NlrQWlTbY
+MlrQWUqR3-aEuQilshC2sy__gn1-ZTgpWYlVTfyCpmeydXMS-thcMK7WSDhNyVpXcPV-ZG3xrvFNRtcLa_wqtt9jFwcRlVriRqVlFvQlOHNC-3Qg_LTv0DBc
+QnIcVASL4UZZHpy_8ByhI-C2o9HrUEstcFlYAwGKeU_VRqjUXzT-c94EeSnvVnGrlFODQ-Zd56fu-dd-PcTJ4rNXTrBC9Om-p_NZPmLPVg6t_FIEzOlUiNxI
+EzVlvhb-O7VNoTRmJEXtV1d3Fxb-o_GS_kdrPzc7TtWE_zWxhvyBX_z_zm-VvFzw_zJ_t_qZxr__s_tpUTu
+}
+
+AWSEntityColoring(VPCElasticNetworkAdapter)
+!define VPCElasticNetworkAdapter(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCElasticNetworkAdapter, VPCElasticNetworkAdapter)
+!define VPCElasticNetworkAdapter(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCElasticNetworkAdapter, VPCElasticNetworkAdapter)
+!define VPCElasticNetworkAdapterParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCElasticNetworkAdapter, VPCElasticNetworkAdapter)
+!define VPCElasticNetworkAdapterParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCElasticNetworkAdapter, VPCElasticNetworkAdapter)

--- a/awslib/NetworkingAndContentDelivery/VPCElasticNetworkInterface.puml
+++ b/awslib/NetworkingAndContentDelivery/VPCElasticNetworkInterface.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $VPCElasticNetworkInterface [64x64/16z] {
+r9K74kCW34KDGktV_xufH1xB8NZ8zdrJNByQ86s_azBv8MbjOkvuu6xIwdTYSRpXicoY6JgcmWz4z-UshZQcb7SXjZKBrIBMIKvsdGK3S9vKlB03uBcwA00f
+5py802qNiJjjbv1FSwWEMDYUKmpmEf7hje26WT6kR4l8fpXrnVlyNmPiMyRUbx42NjRrnO7wPf2sBw1pk2qbj5o2T1Oyeg_qe2ncuDazxrPN8-4KWC7BeVVL
+4jfHV8ax8dk-Phk6-YwA9OYxG9vwnpLwykgmN5Zh2UaSXqRMEVopNYvtd-Qm6q23llzH1hAUW1PsoaVzXoPEILyYRilfPxrZW7Tz4ZhqizvW_4G1xhpf5VxQ
+23BJoxuzOykSzG8lFGsUwEC_ZWB5d_dzVw5lr_fv_M8N6w0TZFLBw_Vr-YlySl-m3THX_qptxvoyV-VdPqe-FzFpwoPfBdVugR47ECxlf7yua99YT7nla4Zz
+8nbAUXA3bpmTvEL4-v9AJM77NTA7fb7G2wnmYkuwU0rdMS_8TFqBo_qxpu-pdf3nmw2c-J7CBp7RFLHAbED5IVDhc9_g2Ftw_Cppc_K1VJ-_xwNNWGm00020
+iEKl7SIZUE07y0lvIVs6VaI_cfz3lzi_-B_uF_c_-J_wl_e_UmC
+}
+
+AWSEntityColoring(VPCElasticNetworkInterface)
+!define VPCElasticNetworkInterface(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCElasticNetworkInterface, VPCElasticNetworkInterface)
+!define VPCElasticNetworkInterface(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCElasticNetworkInterface, VPCElasticNetworkInterface)
+!define VPCElasticNetworkInterfaceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCElasticNetworkInterface, VPCElasticNetworkInterface)
+!define VPCElasticNetworkInterfaceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCElasticNetworkInterface, VPCElasticNetworkInterface)

--- a/awslib/NetworkingAndContentDelivery/VPCEndpoints.puml
+++ b/awslib/NetworkingAndContentDelivery/VPCEndpoints.puml
@@ -1,0 +1,18 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $VPCEndpoints [64x64/16z] {
+jLTPckOW20pWHkv_u34Lkvaolvd5htaoXYeM5_3uIH78Vq4rbUP-Td5l9Uc_WKj7idZvQuhKRaYh9NSfzUix_JswPPEO4yljxnYqiQzpJEqzYdoXyoBZaY-6
+l4PBxV-Bl2YKhb3bnNUtz_ZCbp7ezKkckPmdPRcCw09UMJMDf3Df3OA9jqpvNkoT4duIQoNJ0mYQS89qUU5Qc2OCkDY9DY-ZzlyocwPOo0dfdnHIXzXO8DOq
+OzOlhSlTa1G1LPWEi_H5QYdm3kyXzNjezHnIxSjjuCVGVpUV8xSDnl8THywttraHPiT7mbD4xq9uhG3TTgs2gYhXkmCjabyEmZUObZXuc1Zus4LA8y8tEqYi
+4PwimXF6unT92Nn47KI4PxrvdWD0zkspdhxo6bO0FF9HJx7SIxmClnjjnUezAlSwZdHTuGFeDAcf1sD9Zo1OuIiIA4x99W714b-mxUJUl6eVHDCv20WVMpZm
+vrhAp-6t_T_EttFzqdhzV5w_v_ufVWfE5CEFnlW0OlzIK8efsh_Oh1mgffxdn_hNDPNu_616aMe-F_FvXKvSJdJ5WVjv0R4olWeqoLP1R4AKGKJ5JIulsbHV
+b3CDjtaKaO8bKrBh26roFuBZYrdyeWbA5_QJKfHcOaF4PnPevZwqG53zuFe56R4d5E6SKNhJDo_LBwwVuG3SiUW_Z4ikrq-ktqV4Bhbv1pU4eL7oYOpwX_Wx
+s4KLqt0camLTzo-8lShKDnPoDx_sJ-ak-t9XnP32FEc-zs_QxinrmQ3PM__6_IEt7zotS__uth-AvL9hoKaV_UjU_ooR_VlU-s7__RB_Vjf_l-s_7_VVh_ll
+vttv1G
+}
+
+AWSEntityColoring(VPCEndpoints)
+!define VPCEndpoints(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCEndpoints, VPCEndpoints)
+!define VPCEndpoints(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCEndpoints, VPCEndpoints)
+!define VPCEndpointsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCEndpoints, VPCEndpoints)
+!define VPCEndpointsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCEndpoints, VPCEndpoints)

--- a/awslib/NetworkingAndContentDelivery/VPCFlowLogs.puml
+++ b/awslib/NetworkingAndContentDelivery/VPCFlowLogs.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $VPCFlowLogs [64x64/16z] {
+j9E7reKW38Ff05hV_ttT6XUU-e-SSLrVI0Ct_QTerezGrcBktIXtAyhVuEBTHLx25ceBOhNaKQLkzngdBSjXRf9iCGSsP7sQoTwdo1ET6urJdXnocwOwlY_q
+ya4PFwZqajqblKgyEGDFh-3T44sBS0ElAQ0AWujlMOoafPKgJpdhjhfqRJ6-lM-SxLTDRUNQTHjvd8bsNkL96JpvbWM6WYJql3_u9iaK5r8CrEPbvb6NufKl
+wS6JN4LddaO4owzrW2_TLRhpg0dJEuLv130KKrAAvzzF4P-lulsTLqMI68-fOVGvFs8hdeVwoxhdqTM7uZmsZjRSDeyFtj_pwsns0FtyPsJLz2XIfNGqg7E1
+vAWl9l75eCp7ZjR3oomnCTSvmTmKUEk-YV-2_tN-t_Stb5udH0008102X_wb2R56y3kW-Ud-wFxg_UZzul_G_wN_4_-tvWVcb-OdvhVo0_8ByfFo6_8Zygln
+SyZlvW_kB-vFxc_kZ-wlxizU0m
+}
+
+AWSEntityColoring(VPCFlowLogs)
+!define VPCFlowLogs(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCFlowLogs, VPCFlowLogs)
+!define VPCFlowLogs(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCFlowLogs, VPCFlowLogs)
+!define VPCFlowLogsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCFlowLogs, VPCFlowLogs)
+!define VPCFlowLogsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCFlowLogs, VPCFlowLogs)

--- a/awslib/NetworkingAndContentDelivery/VPCInternetGateway.puml
+++ b/awslib/NetworkingAndContentDelivery/VPCInternetGateway.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $VPCInternetGateway [64x64/16z] {
+rPS55Xin34HZYtF_0o_sxJWEg55H3xBqvP4pfjllZBR7LsXdzOZx6X6kt7yErft424sdO3yGDvKrr7xSSvvs8QYxaNWkGtVKEjVaxwkGZPONFTvaoo2lwMRh
+UsrlFj3r0sjlj0Uzhu_YPGrzUzK-McfhfB_0xPO8WmHZNhsbGf_fj4phhx-LDUSagHDlGPDQV_mR-rfJ6rXIZyly9aEEjhxg3mbfyjeOZhQYKIuF1NKx01Ng
+Mv3OdYvaw08O2u7gPOUvFNC_GGM1pSlWOQEZ3rXKLOx9et7SeL61QuVcTTN9--SML-tQJ_SR2F2hynKAst8rEU68WCaZLXuQwjSLy6lQdGxZtjgjdPF7Xlh5
+Gwk74kJZiGFxLXRoHzMG27ZKYS-1HzaCtadmw24-yxHl-7RgTYW_pGC87sTuV1I74VGxNW-hW7bpF5Zul-Uh_LVy_wh-gVgtEdwgunVcZpoFymScolCW6wvo
+FCg7-JlBu_oDwqUQn_K3rwyyZ-iNhfzv7jTFNByFKujCF3x7zNlUFnnhzyJ3Szm_pFiNZZrGtFGSzY-OtrwT6U0vV5lRlnNtZyNzQst_t8hxzzhveNv-gP-V
+wkUt-lcnVdwjdv_hiG
+}
+
+AWSEntityColoring(VPCInternetGateway)
+!define VPCInternetGateway(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCInternetGateway, VPCInternetGateway)
+!define VPCInternetGateway(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCInternetGateway, VPCInternetGateway)
+!define VPCInternetGatewayParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCInternetGateway, VPCInternetGateway)
+!define VPCInternetGatewayParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCInternetGateway, VPCInternetGateway)

--- a/awslib/NetworkingAndContentDelivery/VPCNATGateway.puml
+++ b/awslib/NetworkingAndContentDelivery/VPCNATGateway.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $VPCNATGateway [64x64/16z] {
+jLS9bkGW25N3Vly3JvbGbXDIj3E-_hstVcGLBB-9UkA_g0r8LEq5LI5e_qOcjHkKbaM0N1HXmXU8tt_3EblmcEok1ygQX2Qphj4coQt0piOl7g_O9M0IBZOp
+gia6CZEkYUvwb1I7VhMXzQNwOqhrGzeNEfS5i0k8SkdrOo5Bw4bFlaxdP_V4lJ5mqdzEBamWzp0sCws-OWe_Eb7DsatWuR-edOx8SRYw3XW6YJ5SSGHy0zgZ
+2oOjjMllV3eZIKLjG1ujqFbuB1y-MXSkAR_Wf81Snxl-VD9BVOET7nIGZ_DfSkGzWXJvdaLj-ctmGtBTpm-dwhH19rqIlbiTr2yeK59-D00yToOa_3hd4BYS
+kim_T7YdkjxYwqlwexjt8gfnMVOVJl7Xqu5L9qQCN-IF3NIcNVNaNSWVrxyByDyV-1BpL-i0cZPs0O4_rqzLUu2UbTe51FwjVfize_F1Napd1_yHg1dNYc-8
+AGvqOpeTt7zp_EBz5VqFfkXqZv-dmUn_oEFNDpWnvAztfvmF8tz3_SJ-4VdmgPzGlwNbzGDEyleDzyT1BUKNEERx8zvVBd_z_eht9wtm_THuVuS2JE_ls3_a
+7a9E-qViNvN_hc1A-rVidttDk13n2LAJf7-6_atjCa1jG9F-7UO7zJ6CPG2J-I7EBsQqDB_4cSZvi3m_nVbDJ8_r-ItEZmtgqlouER_kpSzrStxVUp_ilr_s
+tq_xxxVzz-F--tN__RoFFm
+}
+
+AWSEntityColoring(VPCNATGateway)
+!define VPCNATGateway(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCNATGateway, VPCNATGateway)
+!define VPCNATGateway(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCNATGateway, VPCNATGateway)
+!define VPCNATGatewayParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCNATGateway, VPCNATGateway)
+!define VPCNATGatewayParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCNATGateway, VPCNATGateway)

--- a/awslib/NetworkingAndContentDelivery/VPCNetworkAccessControlList.puml
+++ b/awslib/NetworkingAndContentDelivery/VPCNetworkAccessControlList.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $VPCNetworkAccessControlList [64x64/16z] {
+j9M7eYCX24K51U7-__zkOHF3cuMycfkUyL04cV5AKUXBA2yrTm1mDrtyELWT5xb-sCGoX6oh_97k--_rSTfafhnfYdtC0bkAjSZ9-2ak05oegOOu0EbfsW2K
+dYnG09lwsE5pFDNqDWTsmEZTbZB0kS7t-81s6AZiwlYGj8fpVyHxlrO06n-MNSl8WDF7UNA0BmRdlKAg7QPw5hqDTwM4nD7r7rpI5gIpu2bwGSz3KWQUtSke
+UQAQ7v82C3YL_3B0LicJmnwRhwFY1I79VEuYJjyAdW4NSO0BFdcDI0fUWHcbqeAFh9EXWZVO-RZmEUmLReWBVaUf2vuf0bjX9m27NdXoxCQ_mkEddkiKW-d1
+iva1Rl41C-C77sEEZk5mGm1WV7Z1HN9uDlpZDpp2XDvu-4oyxIDB_7JSU8ssetDD0Qonxln_dKktoz3Z8_ChWfw7vzGhPysCLDOB-1H_mpVnT_kN-Nx_-lfb
+lgjVqpyDN_HFqRzD_Ph-BSvFuxyxF_dyPjwJ06dFRvuVVV-lPduqyujqlv5ICx-w-PdLpiz-VcUryxk_VrJgxn-_Iwy38W0008Q0ftzf8NuX1k2Ny1FvhVw0
+_eB-fFw6_eZ-QluS-hlrW_UBzvFtc_UZzwltisy
+}
+
+AWSEntityColoring(VPCNetworkAccessControlList)
+!define VPCNetworkAccessControlList(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCNetworkAccessControlList, VPCNetworkAccessControlList)
+!define VPCNetworkAccessControlList(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCNetworkAccessControlList, VPCNetworkAccessControlList)
+!define VPCNetworkAccessControlListParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCNetworkAccessControlList, VPCNetworkAccessControlList)
+!define VPCNetworkAccessControlListParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCNetworkAccessControlList, VPCNetworkAccessControlList)

--- a/awslib/NetworkingAndContentDelivery/VPCPeering.puml
+++ b/awslib/NetworkingAndContentDelivery/VPCPeering.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $VPCPeering [64x64/16z] {
+j9G7aWGX24L11U7T_xwRxUfM9rRjgx0xCtuoo7-YFxmbBSqZ4o0pl9NNn9vCf3zjeWK_H7Vxmllut9vNXrML0wqMpraeSOrLzPfJtC_2W3ILGSsiCb1Bm6wh
+jGEkSfB3oO2e0rrlnZvUd-IRhwBivGcXYtmoe05PRiYxpAvW3ahwOc3OzLbk1OhD1dp4ELdjChqoAL34m9UtQ-D2hhY9LAWYvd8bvZOMI9MPeL_GX38PhFAy
+NkertBOajEZNSZKvI59VqskIP_Sch-d5JW44gQ_gDOcZ-BZiqTPKzZYKwR_dMBmciNzXxdlt8-l9q7g989iyIA0TDQf-NKUIpS7nyHhQdnqT6-VdYUn5rG2p
+SnO-jb7_uWvYoB7JIFZnxMNXnpeVmgGlSkca7ca28Qk1JluEWW_vRZeqeZZOQi1_V2ZOk8lrYw8YTRfbzU_owy-BSMSDXbwJWogQoybAI9NAGUfjlQqJeGws
+wlVnTr8MahwDVwtVNX_qJVss_NDektLP-xUVdm9ugsSieMxcPp-_ZGrzEx_x_Qd1HDfkVsxlhzOBHRVxkzoF5mXoChIYPdh_Vet_NhY_YzVFqkk0200014BO
+qRyq8MO8Vy3_flt0_TBznFrMFw1Vq4_gD_GZ-jNy7FhT-i7xnVl9-ytxqVlL-zbl
+}
+
+AWSEntityColoring(VPCPeering)
+!define VPCPeering(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCPeering, VPCPeering)
+!define VPCPeering(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCPeering, VPCPeering)
+!define VPCPeeringParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCPeering, VPCPeering)
+!define VPCPeeringParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCPeering, VPCPeering)

--- a/awslib/NetworkingAndContentDelivery/VPCRouter.puml
+++ b/awslib/NetworkingAndContentDelivery/VPCRouter.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $VPCRouter [64x64/16z] {
+jPU7SkCm34G1iEx-__zUeHrRsg4zqc4EwGaUMYnoOV_JVDa_eL7x14WIcBt6FRY3OkYNGzJ9PNFqziVw-FcvNgTdAuU-lRHvBKBCSwtkvvxczouQIJH_XmFU
+W3UGR9zf7oJxiMwGEFxSIGx_KZlACTwZwQD_mSSU0k9hWyk6IKp45XTFwtnQDucw2U1J_Hg9IbQGJUDELtvezaeYWem0MJU-ccoQPYbMrYUjpAQM52IqfDxi
+mLlhsYp8a835DbO-_twUUnrsXxTncWa8lySxY6FwPlTuQuS29k5tUGVdU_ZTxlBMoP3lBlAQTLLobrzTIw1hl3PGDpwrAb_h9dPznd75oNhcAwa1_5dtNEqh
+pthaAvL_W-2mRO0tlyLjh04wTkCh8Ek3NpZARe3mrKQpA6UB62jbaB6oZmXriKR-y9DRYrWVMvjvdapNdvrVyl-NVVraNx_PvoVx_2RFZ-pvbJq_i-Tt_lx8
+tr_v-pD_Vwj-sFEg7rI_NDKVgb_scgYJxN5-DBBlVLM_wGdIWemcfuVeDz6F8bN9gVZu8a1LwouJJIouwcS9iFdLzAlwlM3Xgj-lxmy5ABe_vFUN_FwKtz_o
+-sD-Vytlptdx3G
+}
+
+AWSEntityColoring(VPCRouter)
+!define VPCRouter(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCRouter, VPCRouter)
+!define VPCRouter(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCRouter, VPCRouter)
+!define VPCRouterParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCRouter, VPCRouter)
+!define VPCRouterParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCRouter, VPCRouter)

--- a/awslib/NetworkingAndContentDelivery/VPCVPNConnection.puml
+++ b/awslib/NetworkingAndContentDelivery/VPCVPNConnection.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $VPCVPNConnection [64x64/16z] {
+xPC5Wkr020HX3BhlVz-losg4i2xrD58pMEHrKTMwEmmaOLChzWG3hCihzFzRhpd_1p4kwYHzwCs1avnNzILt398Zhol8yMJ1blRjQRY3z0lHcpncvJEmhLWL
+z7Jsjd5wPIlGjoDj9priCMIJR4TXwT8j7VG85BA5qsz-qRRqoDgmuyEZl6WR-ehyHz-mu_pc0WsN1doHQ8zqxnTm4lU210lWPVo87wEd6RvHW2LfPkYr_gtG
+2_CJ-i7ysidyMkWRpq_6bzNaW4C_GTrlynzEp2qGv_V2HthoDj6qhtk-jNFimC_Cy7exNwUxJwtwpVaNRqKV90majEGFSgde8aV9Dq9lsbhodHw_xxB_84r5
+hPg_E0a7wLBpzQR_MfxV0M9KvpTg_tx-ZpzjLVtWxVmVt-SvVk2dsFF5ahh93ff3Nf3V
+}
+
+AWSEntityColoring(VPCVPNConnection)
+!define VPCVPNConnection(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCVPNConnection, VPCVPNConnection)
+!define VPCVPNConnection(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCVPNConnection, VPCVPNConnection)
+!define VPCVPNConnectionParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCVPNConnection, VPCVPNConnection)
+!define VPCVPNConnectionParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCVPNConnection, VPCVPNConnection)

--- a/awslib/NetworkingAndContentDelivery/VPCVPNGateway.puml
+++ b/awslib/NetworkingAndContentDelivery/VPCVPNGateway.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $VPCVPNGateway [64x64/16z] {
+jPS7aXqX34I_20fp_mCRYh6xt0op-5FkpOkUa42ap_-KIDTNQ2hg4LTJX6j9_mPhNAJGRHV51-AcjKdjzzzbd_QQ1V-JN7tFGtAAbNBozongfwiiPgDs3tLD
+YxLsbHS3RGOcBx57ViylnpA7r9lanvBgdQG5RfyD6HoGNvsBiDQvzFIEaxqQqpRgnjABBIREkP1Gl5mspjEOMauouvP5iiqE9AuhaSDCmMCkCratvJjSz6Lp
+ZcMlkIccw6KWiERsXg3xkQhpI0W6UHxmWkn3kFclbDCmfW0ShVhvYQyFLPJmsmClAvvx7P4m7qiUMPEZ9I_C8-nvSAMhDyeVvSPB5qrHkVq8xH3Fejr5xhZz
+SXgvjP05mBYCUAsFKkBjYb48kfWvaX2lLmZ-kycpvJjVpChtl8n3IxxZnqwBNNd5BySlDLIaEKdhyNkSFy4UCBw3f_dZ-k7-5MLEF41j0F7OLRr_KVvKlrW_
+pATn_qdCO_qWJE9n0jd0cKTYs3-87xuJrm_l7t34F0QVU8IDt_Pu3f_tRuxVdUAd_Hldn_xwm_d1vzS-BmsXynEyswCSFCvFdD-R-n-Vttn_IFwYHFS7kh_i
+2fdGdMXFiENxsrfyVpkyFnxUNy_kpt9uVpzxFvo_NyxVJ-Vlj_Ftu_dxzVpzVAvV
+}
+
+AWSEntityColoring(VPCVPNGateway)
+!define VPCVPNGateway(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCVPNGateway, VPCVPNGateway)
+!define VPCVPNGateway(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCVPNGateway, VPCVPNGateway)
+!define VPCVPNGatewayParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCVPNGateway, VPCVPNGateway)
+!define VPCVPNGatewayParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCVPNGateway, VPCVPNGateway)

--- a/awslib/NetworkingAndContentDelivery/all.puml
+++ b/awslib/NetworkingAndContentDelivery/all.puml
@@ -1,0 +1,478 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $AppMesh [64x64/16z] {
+xPPNWjim34G7XIYZ-vytFN4tbtBwwdtPaXux0V3_vU2Wcwym0ETkje88SkDEKc4E2UwY3D-Gs3TrhHvUxO3j6NoUHX9SOWpU45Py6o6GvZK6U7DAXZxuC0GO
+ET4DmAE1zi1i9GjgSDvdIvYYPlx3_KwP-dH0_MuBeO3ChuEYjtROdHTM1UNS9rbDzccjeyagic5lyp_ZqFo-SOEVMVFB03CR0dYj-QVx2vpiPNzBsC3OkE1N
+yKG3WkI9whM06S3Wag_eoxyyes7BVhzlNrxpkxdaFu_rDhl_1L44JsJmH41b6h_y_C1Jpgz3m1KrZR_mlhiS8S1q0I92WD4tVYZW4PpJ0wXhlqvnO4udcQD_
+-5daA2wXa60BYgbGBjCEg02YW1LtK0wO0vhSIK84yKVgjzFz-NyvEFW8
+}
+
+AWSEntityColoring(AppMesh)
+!define AppMesh(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, AppMesh, AppMesh)
+!define AppMesh(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, AppMesh, AppMesh)
+!define AppMeshParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, AppMesh, AppMesh)
+!define AppMeshParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, AppMesh, AppMesh)
+
+sprite $ClassicLoadBalancer [64x64/16z] {
+fPS9akqi24P50U7iVx__OFdUjOpftAvyFJSv60S6ousgUYH36Qwr_4RDWqtXxKjORC8PtVzJZvmkJBwWFUTmoyCoNoZzoOCba5QlbZfDFz4rWD0ximvplSKL
+o4cVfGdSFU50VvYWTC2FfiuON6wqlaA_mMlHlDFVUTUZWmuXOmvtoZyE9AuEd84N9-salZlmVULJXX_oVA9XTP2WYxKEsmCVaEiQr8yrXhi7llhYG24-XnPw
+UURBwg23VMQJyinRquIi5yX1opC_5PyP-FH4b2U-viG_zfWlOA0tV5NxJoCJI1tg7xlE5SW5MVdg2KFPsy4-mGPsuerLNQwyGHkhLw-y113MHAHg1x9T-3fM
+C8XouIKPnD3qe3i_q0f-uIMMJEAGRa3RUOUgq2wyBquT05T8sVW6wY0xtvR3BH0Q80QsyG8UPDdv3dKTeoZKagHivoE997PUHZX9dTbkZbyKTEE3XBxp2aqw
+f6eovMDF-iRtOTfv9simbURCPpgvyNxaEw7GBI5DIf4cqyPNVD37hZYqrMOWt_5XO2tc-4L-vFlr_NC9TxKaRDgkwtVOFmDf2RW6KpQF-sN_3kTdHBIerjaF
+f2V8Y9Jh-JcTtpMZZFWOtnpgzVoUuiV0blFhub0hn25-Jl4hkJXD0482sY5-Z_cZRQMAQ05-oX_d_6LB8oDggW7zdB_E-TF6e7yUd9tD8N_UvczD8BkRzGJm
+S_w-hn_YVDJROj_gnstzaZ4q6LPFzY3biNxEpkl0A_YNzNldTyYW_vRlOBVzopEl4BVzqpDV4-gvVoD-Kf9R_xRtZq_AsJ-U-zVQdwG3xpVzynUgFpJW-eph
+nD_S7rxVNzxVdzxVtzxV7z_VNz_Vdz_Ut_y5
+}
+
+AWSEntityColoring(ClassicLoadBalancer)
+!define ClassicLoadBalancer(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, ClassicLoadBalancer, ClassicLoadBalancer)
+!define ClassicLoadBalancer(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, ClassicLoadBalancer, ClassicLoadBalancer)
+!define ClassicLoadBalancerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, ClassicLoadBalancer, ClassicLoadBalancer)
+!define ClassicLoadBalancerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, ClassicLoadBalancer, ClassicLoadBalancer)
+
+sprite $ClientVPN [64x64/16z] {
+xPK73gGm3037AIxX_--z2jhabYn5vHgZGXqdDhPeVneF3mzUiuZawlVi38W8a6z4K4ZgqLfe0hsXQtzHh-aErb_AnHqazDTuSMdt-VsErrngd5pUts_zfBPZ
+WhHRKFSgPmBOpajHV6bj2S6FqvzNUwdeSkGNxCFUya4DVUot-47dGucZnkscG00a-skg16ok3myD97rZLEeyG0ZUrKVGBQp4guYAJ9SlGzlcJHbhMcPVAEFx
+ZQ3eU-1tX3ZZ1sdY3uc5nN0wl7UulfSyKBmhinpc7m8Z4eVvAwKxZO6kw7Kw8O8jwplhcUUVpRUygkb8JES3tIRDrfJ8szTOVfu8-gc1itf4R7w2jFdn3SjG
+3-OFI7l--iWEVrmvrzLN05tzcb8grWxeymymWzZoFyzFtodBEZnh_Q_wALh2x_ej8q9kj_rMH4hSy7LxFM9eshCuo01uku8b6KZM_ZGU7Xw-0W
+}
+
+AWSEntityColoring(ClientVPN)
+!define ClientVPN(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, ClientVPN, ClientVPN)
+!define ClientVPN(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, ClientVPN, ClientVPN)
+!define ClientVPNParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, ClientVPN, ClientVPN)
+!define ClientVPNParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, ClientVPN, ClientVPN)
+
+sprite $CloudFront [64x64/16z] {
+xLO93kig31ols73_-_vV54L-8YZfsvUEjkB6U0OcZljlYWy-o6ZkBVAhSbq81qZypJr2yOAQk-dSIEEDsWgGAI0v_aVFkPq-vU04yXS9XermZvuCO0OVG04x
+VdgtAQEBUDZhnpq4T4eT3UHEyBaAWZn8vwohDaQ0-qGov9PyJU-CruheM2RVI71GIS-ki5TGpiZKiaKIeguq0H6KO9G2AnHMqw4z6A1M7h5LGTsyh0wj4Jtg
+pHDYNzxhGYv9-vP0rl8DbDUw2Bav_FBKQ5LrriqClhFEeInDFNk5bQrZPo8wYZG2GB6JbaGR-JAEUxDGyCgjcd95W4sOiq57ILZFHgzli64Y73xwKBIiLYvy
+3Etw-AL5vej7zY2aG2z9E_mwtyV1ZnYmRWH8dAJRJNux9Hg1R8OOi2Lfmx-TnXmzIo_aBFzMAXNrY5AyH0NKldID8BV-gQLEkfDwvkgVrRzLQhtxKFKx_phi
+sXynspWuz-zFDRaWriRIGg3r_TttZ_Ly56tCyxdi7xNCKhyeEfevugP_hlSxExY3r_wvzk_B0-9fwLPQuVxxCTfQ8fN0iNm_LYXu6d55fhVPq--_dnSDfaa4
+c9zzW0M-HcCm8C_c1yXOtgqqG9_EB_1UCGoy1E_cfpBtDG8W-URyHbBcDucVDZ-ky-jlYWy--0y
+}
+
+AWSEntityColoring(CloudFront)
+!define CloudFront(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, CloudFront, CloudFront)
+!define CloudFront(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, CloudFront, CloudFront)
+!define CloudFrontParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, CloudFront, CloudFront)
+!define CloudFrontParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, CloudFront, CloudFront)
+
+sprite $CloudFrontDownloadDistribution [64x64/16z] {
+jPS7ZWCn24NN7RZ_VLEH5cLUIB62IihCn_2f_lkbb9jy1QrzYgfTH5Lchv-1fzg3w7nRHPSxHDOS5vbB_7T_7osZ1RzB6_AUXYh1Ll19SY_65JqAFopZgc4a
+uLfcDalomZIpLHBRjUN-DNtgGxq-2hfPolMGod1RXxTxFsXSLmMeTnxDDJiwDCs4j2umoWniXNU7cI0fo9Lu6ECvMZweItsmIuAVm1_n4itjmI7Y3oa8jQ31
+Ui2p1ngETpeOZpA20HAEHpmR8F_apwS5W-NaMLJ3jmybdkgMV2fY6XInL8sbmWvqu0ZuesVTzPHlyCNj5dO_nmUWGkw2_vJ3Ua-4cKt0vy_cBUqA92y8fp3W
+EVzoVChVJ_747-EPFuWVupb-b3_S_pX_E7y7Zla-E7-zVhWrrSfDpkk7wZSgR1Q_TgXVwX-z4N-jS__W_hLwnFU5_Ijyu_dWU9ylQ3xtxsut1LMa-W_gtv5Q
+LX2_Of1uVhdDmPTaVf5_pbbTgpgNm4y-lrrnJ-TtlZyqzOsEzWVONuX4wxo_y4x4ziExkB_n_iJx6--F8BW_RkwlU_jpsTpVz-uF-_UN_VlJ_lrj__wuVt_T
+lp_lona
+}
+
+AWSEntityColoring(CloudFrontDownloadDistribution)
+!define CloudFrontDownloadDistribution(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, CloudFrontDownloadDistribution, CloudFrontDownloadDistribution)
+!define CloudFrontDownloadDistribution(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, CloudFrontDownloadDistribution, CloudFrontDownloadDistribution)
+!define CloudFrontDownloadDistributionParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, CloudFrontDownloadDistribution, CloudFrontDownloadDistribution)
+!define CloudFrontDownloadDistributionParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, CloudFrontDownloadDistribution, CloudFrontDownloadDistribution)
+
+sprite $CloudFrontEdgeLocation [64x64/16z] {
+xTTLmiCW40HW5jQ6-z_tbyPTwYtpLlaINCBLeIlopv5F1_JdynMflCcfMECvd0etNivvUK5VVF75cy_4zdlacM2_zmmR1TcFU0sZw34_gQpjzCLJPCnvSAHD
+dyIH_pBZ_mANjEmfsSKk-IgmH7C-AkhVESwNFtBzV6WSU0w1lNgjnFNsYr8LnFzDurLGVKTxsf-gTq6qyLsPzlYkhfs7qB7-9q7dmMV63-DMyvVFhHzynVfr
+nVhv8Vj7ySKNV_tzwVhxsnMXQ--lrzwVhyul
+}
+
+AWSEntityColoring(CloudFrontEdgeLocation)
+!define CloudFrontEdgeLocation(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, CloudFrontEdgeLocation, CloudFrontEdgeLocation)
+!define CloudFrontEdgeLocation(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, CloudFrontEdgeLocation, CloudFrontEdgeLocation)
+!define CloudFrontEdgeLocationParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, CloudFrontEdgeLocation, CloudFrontEdgeLocation)
+!define CloudFrontEdgeLocationParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, CloudFrontEdgeLocation, CloudFrontEdgeLocation)
+
+sprite $CloudFrontStreamingDistribution [64x64/16z] {
+rPU9SWGX24ILGON-___DwLQiwHhA33cf8zbTNmjUGFbEgszs2nNjvWu0xjPLFWTtnycyRqkelICsUdknFXwVTP-sTYnnrwFPdeBOwYl7P74KxPLk5ojUcmDe
+rtGT07eD1dG0emQ--r52E_mo1d70I9jSCC3b0XyqMfKKnnHWtSxk0XnG1unLQNRYex4DiBBB5pjlem1Uz_dgW9m4ZnBn_Ftghb90nFCIB7V1oNlYEG9Vfsyb
+vDdQue3nzCop0_Qn-Briy7IAPFbldwTPfoUx_18rkR_1Km0QZ3dYttJgr3jydNuRXR_1Bw1ZtEC7_FqWz7jyXzUtCDezlW7_di-kNtB_ykSdVtwLnuWoht9n
+V_Z-YaFFlCA5xo-_7zCZwC8lNz7xiGYnmEGPdswl_x70v0cdMUdzdiJa6P_lD-KF4X102AVyySXVBF3AJvpp5-LF5XZ089povqN-LapJ87z7zOCIJlL3NBye
+uLI_nFMJ4avZm_gjY9ID-etgHpAg7tFrQwv-hidwFTS_vFkNVF-Kxz_o_ME-Vyttptbx1W
+}
+
+AWSEntityColoring(CloudFrontStreamingDistribution)
+!define CloudFrontStreamingDistribution(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, CloudFrontStreamingDistribution, CloudFrontStreamingDistribution)
+!define CloudFrontStreamingDistribution(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, CloudFrontStreamingDistribution, CloudFrontStreamingDistribution)
+!define CloudFrontStreamingDistributionParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, CloudFrontStreamingDistribution, CloudFrontStreamingDistribution)
+!define CloudFrontStreamingDistributionParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, CloudFrontStreamingDistribution, CloudFrontStreamingDistribution)
+
+sprite $CloudMap [64x64/16z] {
+xTDNWjim34NH1n2T-zzlCEB8KnahNscwRch7JL3zMTtTtTs53Y8Q6eyDaR-W1pf2Dw8wfRLuBGE6GAT06R2g0H9X8AvoczvU6nWGYk4gPg2ym1qKLQUlq2Ho
+0g0Ak-09NkzypO08D0YESUNRospqyEa67SWfrpn1j1kdTmY6WWLaqASyS6Qdru4GW68WhdnzNsMTtZ4gl09SJsipL_NmnV1Pw_bP0j7LcvyEhZACzBmokAkO
+fwyIQ19I0SdQfm1R78ts0khGlZ53PoW1lkK6yhKq6qGvCn6phvdcSxXzmnDjLa6GgZnFH2UqzatVNWKAdIS_5XL7QsWUI7TJnCYru82bvXI8cK1dCBqBlFdw
+_8xpcjyvenSCUEyfV-ODyEOVlNtvdXk_-3fT0dNNgtvjLo2Qwxf-Zpxv9DgDhZMX26houjEEiZvuX-pEFmaeN_ZhsFEHpm-U4VlnRGvOBQy04I3lVGv8xH90
+3dvwxuNtFeqmQfyH03e227XT8D3gdCPjQODftx2iFwExkxkx7m
+}
+
+AWSEntityColoring(CloudMap)
+!define CloudMap(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, CloudMap, CloudMap)
+!define CloudMap(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, CloudMap, CloudMap)
+!define CloudMapParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, CloudMap, CloudMap)
+!define CloudMapParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, CloudMap, CloudMap)
+
+sprite $DirectConnect [64x64/16z] {
+xPO7rkCm20O_H17W-zztd-s_Y3mtRM-JdZ3g4ETlo7_-4zwjUtobtHaR99xp1A-ccZ814hEw4rhFZJ12ysbTynC1nPJVe3cYQ3EwWhF2q7JJ7a_q84HMWi00
+G3tlwP238Q6P2T3lVQb1iG-0zwRftc-8Jrc8EDOtGziJFeC85EFSbcix59--eqKAxFDNWErADm0oVD9bAUkf3MZzOkkXaLdwPvGU_M8N7EJ3L2858BJCg1iC
+FrkwNbAGNG49hIcq6FXG3xInBLgxPgI0MksI47SdhuEtxMOuAD8WHqUiOh3n_RhqojZsFC0ryDZNeVyMmM_zUohatlSnY05iymy521JtumyQenIGMFqq0lln
+4Q_KKH9bRluYDRw3Jqk77lWfy39D-5NXZKlV1R3hmjzMhFWHROVkgbWNmefMtx53R94tnChh-6CddxFvxTsVn_JjQUaQqxOB3qYVr8DGcMp0835Wu5c_BwMq
+pFlv2_tbs_mG0XK0zkS-0_JAn5LCAKJNHUlgZw2YFy_FVX3g5lcxyP__V04
+}
+
+AWSEntityColoring(DirectConnect)
+!define DirectConnect(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, DirectConnect, DirectConnect)
+!define DirectConnect(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, DirectConnect, DirectConnect)
+!define DirectConnectParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, DirectConnect, DirectConnect)
+!define DirectConnectParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, DirectConnect, DirectConnect)
+
+sprite $ELBApplicationLoadBalancer [64x64/16z] {
+jPUDcgKW28Q55B3xl-35bBE4DUDPd_tcpv5U43iHfXTX9gddfIgKCNsZW-GC4ZeMOIXYSPbKREkG0WiqrH4EtEHOKANVF9H6ruAp1OVf9ngbXSvlvdoPyHNF
+LGD4UlqAKk_yIuB0UX4zcZYwVby2l-2O5eJc8E82dqK-wcEMsG4vF9NpKIKv1tHFIXSFoV4ooV49D8NiKxhdNfmpXvJx7ZX0pDqARmiM_m-dTTxsE_yrLLZc
+PuZCrIflYoQpIFgUJpAkAY7yAf_77TL4qiIdIP4ty6Xk8dyU6FHosRLxE1jcpJnUEoXzzq9ciwPTwcXt4dIOYaOzJ4y51tDBubKOaWjXT4tg0_wL1rsxn7iL
+8npfNVKK_PwZYgcLMp5XcZVGQjdQ_OlYDarFF4zwuYdmov_VoAyyF_yhFj_2P5NBDMVqpKXkUz9i4DyvfmIF9hdLLnE5-wVVBxoRho-y1bS0Rdo5ItoFptss
+dXG-l-7v8GiRUGj8uVcnvtUP3y_lhNu0yBZrrm3wi2sR-x0DmDSFNx-mrgj5gWZI1wrRAcDMu1ZcYgv-MVtqPIkZZRWbCeJqiRlwsSkmyLGATPvBARNpLOVS
+UHsHyGOMcyWzayuVVTji8u_6NzUZkxpO-ylny1CFnjlxozwVQxp5jspTgxZFC15tNaTa-Ukmvszs1wK1Vhl_pKteNq3g9S74OwIpUSnoGhD3w5z2_xJOG-BK
+lotB-hVOFwx9-iUvVrt7URD_tkpVDyyFs-UN_VFJ_lbj__ouVtxTFp_ldj__
+}
+
+AWSEntityColoring(ELBApplicationLoadBalancer)
+!define ELBApplicationLoadBalancer(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, ELBApplicationLoadBalancer, ELBApplicationLoadBalancer)
+!define ELBApplicationLoadBalancer(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, ELBApplicationLoadBalancer, ELBApplicationLoadBalancer)
+!define ELBApplicationLoadBalancerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, ELBApplicationLoadBalancer, ELBApplicationLoadBalancer)
+!define ELBApplicationLoadBalancerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, ELBApplicationLoadBalancer, ELBApplicationLoadBalancer)
+
+sprite $ELBNetworkLoadBalancer [64x64/16z] {
+l9JRkkCW24OLaTFxF_0O9FFPKZB7lTSjBlmXhQq0a4JDKI64zYSC4dj3QFoct6V8AamBldF8xBzXayPrn-4UWPH-rM5Ujax85OZIamroNOrL6RqCfOwhh6vN
+u9MXEa6hnhyOiBEPqSSIfylB25peq7u3Y0P9bzv-Yowv0HLwsO3UDw_z5n84wrpNrwy0lp6xMA1zxm1UQlYhpFOJs86btKmpBZH025-DnuBSzttFTfUguRsr
+4Fh8-_m8_v3e8JtlaJ7vrmHqNo-jPFZUEFjD8i1yMXxivm0_-1WRKDFwCR5DzvHpmU67w0rdOVkBmKDCqlUBuCEt1xKjOvc-ADP0-ZsR5xnxPjju1LGRtZ1e
+WQlHf1CV43Gvdg8-wWS7C8PuWHldbp8pp72PtNsLcyk7zDRd_BuPCVKaUex5fyUS_t-1cgZ9iqzNdFpzugHwDVdvjUfgZ0iwVRO5VVG1nWQm-FsxLlfi9ylz
+BZ_dr-VyFqgl3m400228OVxMWGZ2psklVpk_tP_TtxsVlT_y7_k_zd_c_zxysFpA_DpyJdv8Vbb-IdvBVan-JNvEVaz_Q7zvVtf_UtzyVtr_Ndy7
+}
+
+AWSEntityColoring(ELBNetworkLoadBalancer)
+!define ELBNetworkLoadBalancer(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, ELBNetworkLoadBalancer, ELBNetworkLoadBalancer)
+!define ELBNetworkLoadBalancer(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, ELBNetworkLoadBalancer, ELBNetworkLoadBalancer)
+!define ELBNetworkLoadBalancerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, ELBNetworkLoadBalancer, ELBNetworkLoadBalancer)
+!define ELBNetworkLoadBalancerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, ELBNetworkLoadBalancer, ELBNetworkLoadBalancer)
+
+sprite $ElasticLoadBalancing [64x64/16z] {
+xLO5ikj039EzNaDw__EM6NUY3m-YGj0mCaxV10iMX4SHqe8jRAwu0ysxeCqJBo1sXuO-qtnV7VJ8B7b37auKnSfp_Yl5dy8_lnlkzwdI0RHk0_6BXWFqobA3
+k0Bu6BrKGCtTJG69eqCAhTMK4JMGPNbIPKTpAQDfsyycfukWOpJd0fAtJ2fw1tmmHe9yl0N9uHphJmYHkWxi6mPhz-e3zEAJ2m3nrzpRyyIzf92vlIRJ48yt
+BmcV1oBoaQJfRMM9tAgFLyaWKi_LoXv0dHqYvLd_MVx8-97vG-OlKJzq_VBzW-vVTF-a-pSxF-ZvHSxFRpx_XTwV-FsDtn_v_VN_Oy623G
+}
+
+AWSEntityColoring(ElasticLoadBalancing)
+!define ElasticLoadBalancing(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, ElasticLoadBalancing, ElasticLoadBalancing)
+!define ElasticLoadBalancing(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, ElasticLoadBalancing, ElasticLoadBalancing)
+!define ElasticLoadBalancingParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, ElasticLoadBalancing, ElasticLoadBalancing)
+!define ElasticLoadBalancingParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, ElasticLoadBalancing, ElasticLoadBalancing)
+
+sprite $GlobalAccelerator [64x64/16z] {
+xLNNegHA22moTF___zu3EZVjhexdPMEDMOekahD-LFp17rH-e3x9TI4CIFonZzGcigWA4m3DHsihGDRAz-ueZ01zNqCGo0_g1yQ94oZUfFknM8KolSBVBSdV
+fVTArbmmew6rLxpd881SAndW8II1ZtWIk0-X27668F3TfG2L0RfsWEgEBx2cK-m4hu71TZAqh-HMFVS1d4kG-v04gbIqOxwBW94T0g4tpwpA33xlSpHT8LkW
+GLSeuTyGBs-k8A_uYXYvQss5cSe7r8OvudT0h_Y4MWuxh6l2FwydDzhEx-IV4kbVXiUZ8he98627rThrhqnjcrBiheXTLS3Xkq1kvjQd4oxGVjO9yAicDdJR
+NC1tmExu7EvXS_AOWqAZJ-_nPK_ySt9TVKJCpHs_3Sx47IV7rFjCcjx5dz1NiOjewED0aQ-MqAlwpQ8AVna70MGlbmcUovlnQRFfNmzNWfh7qKi6lniWUmrf
+6k7Vq6CkTXjSODexGT8SwfKHuGm0p4sbI_bdy0gm9_K0CLOVCWJWhg2kInHw0OPqqv-P2yZU1ghpxINc4rSCpj7AisS9AC-Fumsa9PO0fk1YAeKuWQlZadMB
+8kwJ4m0mWT6OTPbgtQF6Q2yNd62hVRvv5sLgAgE1HCqirnDimV_0Z_W1I6Ha428ZKW5_HWUiOsOSyuz73WHHH5CCv7Z913_d9m78n_nJ__IRDU-f_XNCTlxl
+J1pExEiv32oGzMcKO1h_yyXSFox-u0_-0W
+}
+
+AWSEntityColoring(GlobalAccelerator)
+!define GlobalAccelerator(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, GlobalAccelerator, GlobalAccelerator)
+!define GlobalAccelerator(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, GlobalAccelerator, GlobalAccelerator)
+!define GlobalAcceleratorParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, GlobalAccelerator, GlobalAccelerator)
+!define GlobalAcceleratorParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, GlobalAccelerator, GlobalAccelerator)
+
+sprite $NetworkingandContentDelivery [64x64/16z] {
+xTPLeYKn28JX0WAXoFxNEtRSanwxzZ_pjKlml_fAi4i45give2SVezOQlFIrsdlmNvxy3TzD07LkypIezsWGRlAAlXiKsU8TMRiIlku97xNF86tL1rY7iZNe
+ecyN9pqIiURLwYBJ1PzDqQul9wUzGvhdjOSwftpSkr_yzIJbZ1Uh-r5bmdTaFIZHN_j0FGmnu_c8SyOduhUElqpum9lKXAV0axTbGypuOiFT96QVV-Ql0l8Z
+HEvQ_FwD5AKPHN9i-NvsA8VPeA8lUaRGqQhAhAeQd16SzYa0u7NmvR_6SjQha0QUF66awAGdObGYJpwHDGASyoLjFqq5bFijDgb97p3RNJtfNNPNq0mnwojK
+_TTC7wE3LUMgKNF-ya9SdFQYBqC4h3PxDg1ntPyYtyFwvykFt_FErVB2R-ZFUQXjIGM7P5Fu27q7
+}
+
+AWSEntityColoring(NetworkingandContentDelivery)
+!define NetworkingandContentDelivery(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, NetworkingandContentDelivery, NetworkingandContentDelivery)
+!define NetworkingandContentDelivery(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, NetworkingandContentDelivery, NetworkingandContentDelivery)
+!define NetworkingandContentDeliveryParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, NetworkingandContentDelivery, NetworkingandContentDelivery)
+!define NetworkingandContentDeliveryParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, NetworkingandContentDelivery, NetworkingandContentDelivery)
+
+sprite $PrivateLink [64x64/16z] {
+xPHL0iCm34CbXwpc_kST5BULHfzvFqN5xExlD1gDXgJljJaGWCNobJe2e9a1iCzFS8B9xtSg0KYVoe6uH5w8y9dpH7vwDiHFzE7LOTbou3a5jWw8oaPBUily
+Ek4HDmZGJ-K2jruYUgS4wjpzsAr9_SkQpZEPZt8bdZbG4_8doLatxelUSxgHSovtomcmW_CBmQX7jM66Dw6I0UPxSY1fdBuRyVx2yaWOFVC8-4xfKARvkKCH
+iNFLARFGUBETnOXKnm68hXi5rcbfnxcDq_P84dhwNFkRCAaMcS3DiGsJ7Ss2_lNYtrn6tzB7qG_ElHIx9G1nBduyrC_sbRJOT-iFMkdN_YzTNdjVSo8vJz_A
+_rN-H8JY0-LkjTVRGsEjnk3PhWmBOVLhpJiRqUO4bpXHrYFcXE_jRIlgR-l4-gUqlz4L0DWX170qWP4uXE5iY-gGxbyq6et65G
+}
+
+AWSEntityColoring(PrivateLink)
+!define PrivateLink(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, PrivateLink, PrivateLink)
+!define PrivateLink(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, PrivateLink, PrivateLink)
+!define PrivateLinkParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, PrivateLink, PrivateLink)
+!define PrivateLinkParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, PrivateLink, PrivateLink)
+
+sprite $Route53 [64x64/16z] {
+xLO7Sbqn25oQ0B_xtpSFXlbnaz9xrasog0iC_-dtnN_yHyINQXZvCtNWcG4d-wJw0h0UwWHGl7mw8m05f7NI0AkVx1VfftC-IR3B2M1HQNVjzRumG7uPA4_w
+0YahYm60DDgnKjruvGZieU0nd-vHH_UwX7lE_nbwuAwYa_9q5MxNWCPSSh5KXbiE7V2AeI9VxiiOuFgnkdKMEbBlWg6tIv2NQ8EBFvuBgHFkO1IyBRsNbRWo
+bfazSlRxiYAl08__G_w-PrZWf_nBu6vGmgR42RhR-rJ0A0dTnUT57nqxi99ts6Qou4t10OPr1MINNLmBTfu-kxBrLVZ6BUprLqHBFo_3EkkF_mIUwnDe_9_r
+jLFKqd-UH7AnfasEdiTtGapezPnMd-3oEC1MrjjNFET9u6MikTS3WGb4IRKi4V6Qf6X5Xz7Fo7tspN9fXQWAqBw427rQa1RQg4Ut_xC6YKShEo66XwpZnhrT
+9V8yyH6TkZkuZheblwTlhzyJk2j1b2gFHcIxezb0CK47kArknglAEnK7CQ5oiJwL-q8rYCAFlLy8g-xDtYB2hEFnD0EbN_wFeBr-vo-mytotJEniLn4aTjeX
+e2p-3yQ30LcHRweRIm2EGuX9_R8O0B5D6CCcpJgeUkHXUMUB2yt6V6nJaZQOnnKU1EhbTnzBYopJg2pTEhq22HG7VbDwJsLBXm94W4PRpDvhCi4VE4RPg30w
+Mkt3AbrCRSvuo7fTUWu-slnCJAnUPt_az4LesYLJfX1VWMAxAlBqbHZ-VjBdrv-F__YF3m
+}
+
+AWSEntityColoring(Route53)
+!define Route53(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, Route53, Route53)
+!define Route53(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, Route53, Route53)
+!define Route53Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, Route53, Route53)
+!define Route53Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, Route53, Route53)
+
+sprite $Route53HostedZone [64x64/16z] {
+jPO7UYin28GbrE2__trVaJVcitWbk4pY9ZFi30kooXjHurBlVmsBwng2nKn2IlrBWWNjp0XdT8FrH_e0w2VzJD01HebeR2pn5OErm5oLB3PQYKwXDGEctDYB
+hNI_tE9b0jOQc9JeT7pbDrKrW5b-OVhIfM_4ggmhk3G5t8gBtj2Ra7dMS8BUdOobgckunBYaC1-BQZNLQGRziNOb1Q-X9ql09RkP7BnaCslULS_jNc7b-GjK
+hjvvphzMbv9qi2dYoT8Ld8-I5NBz0tgqmyZmnranO-MARt4XWN2v2JLbVmP3yds-X7ADxFL7y9_X1_-6bWGKAo_U_rRUrtyjt_yF0fwRFtUJS1yv-V5taWzJ
+6lqkmAsaO5YuzzaUYAEN7q95ysGdLcC-nvzO3REOAy1R-C_hf_fUcCV2ujQJtuJw4-thl30--G4Qp_x-Zt0QInvVN0ehj_yjC6U8WVL4wGnCpfEwzczfg5s9
+1-1XWAsG8f3N3Xpncsa0-37NuQTW06pMlmgx0beui5xf3viXnLJpg3EpwGpaW2f3sHxhjJ0CG8S4xjyWq_YwfTss8oaPN1TL4NKfpsG8x6INvZexDcfewnn4
+ocVn4m
+}
+
+AWSEntityColoring(Route53HostedZone)
+!define Route53HostedZone(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, Route53HostedZone, Route53HostedZone)
+!define Route53HostedZone(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, Route53HostedZone, Route53HostedZone)
+!define Route53HostedZoneParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, Route53HostedZone, Route53HostedZone)
+!define Route53HostedZoneParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, Route53HostedZone, Route53HostedZone)
+
+sprite $Route53RouteTable [64x64/16z] {
+pPS74l9M30PNNNhtlsyAps7i_91YIFbeiePrrywO_pmMjsE0h0yYN-53RYL-uvrRyUVs0L4GCrL1p8KT5K3SzhAwSYhYnESCU7Slexj70AoNWqwL0zZK64VX
+5rup1W0TGP5b0EdZKCbE1z40dVXSUB3DPm78qWDn60EEfZw8CNJfItuS89edBwkx5HwiBjqhadd9xszTUkPTgd_WNs-_4c224p-ApNd_6NiK5zxtNmoe0b3P
+F1t4e48dsOXIIRmyVpw0hfa9bX-yJO_HzIYKQlJHuNh_2I02eAeg271ycO38jRZUVxVotFxSp5Vc5w_RSRuHkHq0UjrEVyUV5RTIt_IV1rXcXcBF2wEXW5Sf
+0197Fogl_fEU0Ol8PLJa5a3CSl1nFxItYjttpYjlFi1JGsi3SiplZcfjVXmRUUclohE0jZ_S5Cvs77ld7zbWrSL_DN7Xt_il1i17phmIymF_UliTW8x2nTzs
+uHb_ux-jroap9VNGUPLMumvKWplPMiMLrm8y0TcJsGQaWLINa0b4G2GyEiIt_ENSYdzhVkv7FlJ7f_xwE1_w-pl-cvlvlzn_0P89NbsbU1_Amig0w3O0hIa1
+87y_Fp8pe6Q-b7ny0zdRdwPxqMqIU36_8eSY_EnFfHtQUQRgdJyElWF0bfpy6M4S6R_uwvq_Ey_-gvnZEURF_Dd7zzMVFfoq_jxVp2xbfJzb_7aKzjAVjXlb
+hfGTwyksBZAeSNSYYR7-mPy9M02IMUMa0c50TWhXH5Ob7X2TNxt_xZy__TVFVvy-l_xd-Ha
+}
+
+AWSEntityColoring(Route53RouteTable)
+!define Route53RouteTable(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, Route53RouteTable, Route53RouteTable)
+!define Route53RouteTable(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, Route53RouteTable, Route53RouteTable)
+!define Route53RouteTableParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, Route53RouteTable, Route53RouteTable)
+!define Route53RouteTableParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, Route53RouteTable, Route53RouteTable)
+
+sprite $SitetoSiteVPN [64x64/16z] {
+xTDd0i8m20NW1sH0Sl_xkeqhbU8VrtEFBmNIjk_DF_-OMHnh8W2SWqla7HO6K29SGCMshvQ1l9udi9tweFKLrC6t2m2sqZFgrIXMTg3Wgsq4UQNjMoqt1vHz
+0yMUSqBT5rnlfbd7J9Ou8-t7bxITCZuBs1pSiQbJ3beCG4iBE3m_gLySzKVcPuClBp3VFmMPv_oP-LQj-TAtlbz_rhvzyLXB8a9W6JbzpXvVC8-vV3Pz56Ed
+ByS-Rnls-j5cOHAD-mmGe55l8Dr-bAXNfEq0YEAUMrTmk7y19q89UnDW-odYntNJN_JjatrXZVcHp_Ebl-P97WSkNp4DUtopUTfNvPz_DW
+}
+
+AWSEntityColoring(SitetoSiteVPN)
+!define SitetoSiteVPN(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, SitetoSiteVPN, SitetoSiteVPN)
+!define SitetoSiteVPN(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, SitetoSiteVPN, SitetoSiteVPN)
+!define SitetoSiteVPNParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, SitetoSiteVPN, SitetoSiteVPN)
+!define SitetoSiteVPNParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, SitetoSiteVPN, SitetoSiteVPN)
+
+sprite $TransitGateway [64x64/16z] {
+xLO53iGm37DWQTF-_xs7OvuYEh1Ww8QXV2N--CEpgJoWblqwEmb6a7IDRGIG6kC1Ddq-sGNP36WgrK1c1AibAS1dTMW0oUK1WjVgeF905g0vHHVGMv93ti_-
+reeWf-ZSkhkLJEYU6NA2BgDxTTV92pcqdKSPyFR_AFfyu8C4yj6ZDq0pUK7OZGBFFnFD1V0EtI1bdry4jiqdv2D-1krOh-M8NtJR0u9qp4-RCVI5QiO0syB8
+ZNBEq5hS9-4dcYI0UwcAlELzCmBK-s1AVXOEk6ChG6PR4L0m8DJ9CyWqPCuW0HYwvJxGWwfjZdAdPsuLQ9v49q0s-LQVRWGzCNYJsXTFnrL3d1_LF-g_QFoY
+-HFDts3zHEits3-Y_IlOFwFzEpW_WlChE3-3ypkuFmJtbzZ-5DlVWllZL-AFF-u
+}
+
+AWSEntityColoring(TransitGateway)
+!define TransitGateway(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, TransitGateway, TransitGateway)
+!define TransitGateway(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, TransitGateway, TransitGateway)
+!define TransitGatewayParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, TransitGateway, TransitGateway)
+!define TransitGatewayParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, TransitGateway, TransitGateway)
+
+sprite $VPC [64x64/16z] {
+xTPLWYCW48JXQeFkulxdNI7Z0qbOb_bUeZyMvR_emuVAthE-DMwAIQDuhWcW7k4AIECf1pmvLG1sd4loIUhX00rIVCdW1ta1-UOUHH-ih3jN7tmZ8Kq1MFAc
+4gd5c82Q0fstzDLc4vABara9jDMeS-KZ4BnkE99R1UKDTgsdejMDD-xLtW5uNPaStdbDTu7qRQx9ZGhLI8vHiLjYW-xYPfYq5KSBBYboksPeL3N5tE3WIiAu
+40A89vb9vhmLjPm6iHmLrZdctDfgiDlcRTpGbhqFfWCmmsMiG3kPtuS34e-hjyr4JDYwfpu77RBhAQXTpoUoxmEsw-kUdWghx-bB8P7rqb5F1jx8ivxLtFI5
+EkYNVa8VwBnRmOOXduVJuIVzPS7-VC0n37NG6xBaiPZNH7YWmSVJEzFXeyDvO4wfy2BB8KL5yaJ0M0gO2IH7W_6C8Xw_nceqe7Yc19PaNNQ0pbEbB_vETVBS
+wk_S-T_9NlodVFZm6G
+}
+
+AWSEntityColoring(VPC)
+!define VPC(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPC, VPC)
+!define VPC(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPC, VPC)
+!define VPCParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPC, VPC)
+!define VPCParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPC, VPC)
+
+sprite $VPCCustomerGateway [64x64/16z] {
+j995WkrG20LnEVlVxvUEq_QKIUnMOQ5t1d_4GwXOL3S0T5UOt0T7OqJ7pGgh1QaC_nUHsxFTJfVhgMzMhziCKjTQHQuzbVo8Eu1sFee1ZfJi3S2_fpa11DCP
+Fmk80q3o3xMtqWKV0jB-jWTfe7ZYKy05j7o39mqyWHm2oaCml35n5K1q2cAhSrXphiBeFqy6-BTdZzCrNncH0afaSsSrZG8qquoD_nJSW0oXqi_yV5_NMINT
+mrDUPjfele_dHf_JEzt0p_KStJVVotEZZk47tSjJ03BkRkHdraRH_JmLUeXkusS3jf-nk8Ltsx_Pwk451-87VYwEr-E5sd3OZ_mujeAD7FZWlnCaUlaHOddR
+IZFagzLgBu90yqSRlaXJH4SuuFETI2uLEB3nWhj3NiC_N__Vqkk32000143WqRyq8Tu6Rg3wOVzqVdH-TNzqV_5-wFtI-udtM_y7_Y_zd_Y_bH-GNv2VbD-G
+7v5VZPz3VZT_S7znVt9_StzqVtL_zXW
+}
+
+AWSEntityColoring(VPCCustomerGateway)
+!define VPCCustomerGateway(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCCustomerGateway, VPCCustomerGateway)
+!define VPCCustomerGateway(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCCustomerGateway, VPCCustomerGateway)
+!define VPCCustomerGatewayParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCCustomerGateway, VPCCustomerGateway)
+!define VPCCustomerGatewayParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCCustomerGateway, VPCCustomerGateway)
+
+sprite $VPCElasticNetworkAdapter [64x64/16z] {
+nTS7pkim30FWU5ky_tqxY1WsAcKWUeF_7bzRCSF9zcyIVBn9zl00IFHu0RhJepeziiTt0QB3rmnqZzygK3r-wyyhe8zoi1V4T1L1-_oVNK5ek0wzNS4jZiB_
+PGLwswRBS6wpWi37lXjMe7qkfUHmXSqAw6LKT1bMe7mVFfn7Lq3_PO9skIqaZGfqV_tZ0ovIPmMc5_HS3gFt0ktrjjHRcXMS-63kFjEpWXFVeH9NlrQWlTbY
+MlrQWUqR3-aEuQilshC2sy__gn1-ZTgpWYlVTfyCpmeydXMS-thcMK7WSDhNyVpXcPV-ZG3xrvFNRtcLa_wqtt9jFwcRlVriRqVlFvQlOHNC-3Qg_LTv0DBc
+QnIcVASL4UZZHpy_8ByhI-C2o9HrUEstcFlYAwGKeU_VRqjUXzT-c94EeSnvVnGrlFODQ-Zd56fu-dd-PcTJ4rNXTrBC9Om-p_NZPmLPVg6t_FIEzOlUiNxI
+EzVlvhb-O7VNoTRmJEXtV1d3Fxb-o_GS_kdrPzc7TtWE_zWxhvyBX_z_zm-VvFzw_zJ_t_qZxr__s_tpUTu
+}
+
+AWSEntityColoring(VPCElasticNetworkAdapter)
+!define VPCElasticNetworkAdapter(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCElasticNetworkAdapter, VPCElasticNetworkAdapter)
+!define VPCElasticNetworkAdapter(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCElasticNetworkAdapter, VPCElasticNetworkAdapter)
+!define VPCElasticNetworkAdapterParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCElasticNetworkAdapter, VPCElasticNetworkAdapter)
+!define VPCElasticNetworkAdapterParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCElasticNetworkAdapter, VPCElasticNetworkAdapter)
+
+sprite $VPCElasticNetworkInterface [64x64/16z] {
+r9K74kCW34KDGktV_xufH1xB8NZ8zdrJNByQ86s_azBv8MbjOkvuu6xIwdTYSRpXicoY6JgcmWz4z-UshZQcb7SXjZKBrIBMIKvsdGK3S9vKlB03uBcwA00f
+5py802qNiJjjbv1FSwWEMDYUKmpmEf7hje26WT6kR4l8fpXrnVlyNmPiMyRUbx42NjRrnO7wPf2sBw1pk2qbj5o2T1Oyeg_qe2ncuDazxrPN8-4KWC7BeVVL
+4jfHV8ax8dk-Phk6-YwA9OYxG9vwnpLwykgmN5Zh2UaSXqRMEVopNYvtd-Qm6q23llzH1hAUW1PsoaVzXoPEILyYRilfPxrZW7Tz4ZhqizvW_4G1xhpf5VxQ
+23BJoxuzOykSzG8lFGsUwEC_ZWB5d_dzVw5lr_fv_M8N6w0TZFLBw_Vr-YlySl-m3THX_qptxvoyV-VdPqe-FzFpwoPfBdVugR47ECxlf7yua99YT7nla4Zz
+8nbAUXA3bpmTvEL4-v9AJM77NTA7fb7G2wnmYkuwU0rdMS_8TFqBo_qxpu-pdf3nmw2c-J7CBp7RFLHAbED5IVDhc9_g2Ftw_Cppc_K1VJ-_xwNNWGm00020
+iEKl7SIZUE07y0lvIVs6VaI_cfz3lzi_-B_uF_c_-J_wl_e_UmC
+}
+
+AWSEntityColoring(VPCElasticNetworkInterface)
+!define VPCElasticNetworkInterface(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCElasticNetworkInterface, VPCElasticNetworkInterface)
+!define VPCElasticNetworkInterface(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCElasticNetworkInterface, VPCElasticNetworkInterface)
+!define VPCElasticNetworkInterfaceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCElasticNetworkInterface, VPCElasticNetworkInterface)
+!define VPCElasticNetworkInterfaceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCElasticNetworkInterface, VPCElasticNetworkInterface)
+
+sprite $VPCEndpoints [64x64/16z] {
+jLTPckOW20pWHkv_u34Lkvaolvd5htaoXYeM5_3uIH78Vq4rbUP-Td5l9Uc_WKj7idZvQuhKRaYh9NSfzUix_JswPPEO4yljxnYqiQzpJEqzYdoXyoBZaY-6
+l4PBxV-Bl2YKhb3bnNUtz_ZCbp7ezKkckPmdPRcCw09UMJMDf3Df3OA9jqpvNkoT4duIQoNJ0mYQS89qUU5Qc2OCkDY9DY-ZzlyocwPOo0dfdnHIXzXO8DOq
+OzOlhSlTa1G1LPWEi_H5QYdm3kyXzNjezHnIxSjjuCVGVpUV8xSDnl8THywttraHPiT7mbD4xq9uhG3TTgs2gYhXkmCjabyEmZUObZXuc1Zus4LA8y8tEqYi
+4PwimXF6unT92Nn47KI4PxrvdWD0zkspdhxo6bO0FF9HJx7SIxmClnjjnUezAlSwZdHTuGFeDAcf1sD9Zo1OuIiIA4x99W714b-mxUJUl6eVHDCv20WVMpZm
+vrhAp-6t_T_EttFzqdhzV5w_v_ufVWfE5CEFnlW0OlzIK8efsh_Oh1mgffxdn_hNDPNu_616aMe-F_FvXKvSJdJ5WVjv0R4olWeqoLP1R4AKGKJ5JIulsbHV
+b3CDjtaKaO8bKrBh26roFuBZYrdyeWbA5_QJKfHcOaF4PnPevZwqG53zuFe56R4d5E6SKNhJDo_LBwwVuG3SiUW_Z4ikrq-ktqV4Bhbv1pU4eL7oYOpwX_Wx
+s4KLqt0camLTzo-8lShKDnPoDx_sJ-ak-t9XnP32FEc-zs_QxinrmQ3PM__6_IEt7zotS__uth-AvL9hoKaV_UjU_ooR_VlU-s7__RB_Vjf_l-s_7_VVh_ll
+vttv1G
+}
+
+AWSEntityColoring(VPCEndpoints)
+!define VPCEndpoints(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCEndpoints, VPCEndpoints)
+!define VPCEndpoints(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCEndpoints, VPCEndpoints)
+!define VPCEndpointsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCEndpoints, VPCEndpoints)
+!define VPCEndpointsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCEndpoints, VPCEndpoints)
+
+sprite $VPCFlowLogs [64x64/16z] {
+j9E7reKW38Ff05hV_ttT6XUU-e-SSLrVI0Ct_QTerezGrcBktIXtAyhVuEBTHLx25ceBOhNaKQLkzngdBSjXRf9iCGSsP7sQoTwdo1ET6urJdXnocwOwlY_q
+ya4PFwZqajqblKgyEGDFh-3T44sBS0ElAQ0AWujlMOoafPKgJpdhjhfqRJ6-lM-SxLTDRUNQTHjvd8bsNkL96JpvbWM6WYJql3_u9iaK5r8CrEPbvb6NufKl
+wS6JN4LddaO4owzrW2_TLRhpg0dJEuLv130KKrAAvzzF4P-lulsTLqMI68-fOVGvFs8hdeVwoxhdqTM7uZmsZjRSDeyFtj_pwsns0FtyPsJLz2XIfNGqg7E1
+vAWl9l75eCp7ZjR3oomnCTSvmTmKUEk-YV-2_tN-t_Stb5udH0008102X_wb2R56y3kW-Ud-wFxg_UZzul_G_wN_4_-tvWVcb-OdvhVo0_8ByfFo6_8Zygln
+SyZlvW_kB-vFxc_kZ-wlxizU0m
+}
+
+AWSEntityColoring(VPCFlowLogs)
+!define VPCFlowLogs(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCFlowLogs, VPCFlowLogs)
+!define VPCFlowLogs(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCFlowLogs, VPCFlowLogs)
+!define VPCFlowLogsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCFlowLogs, VPCFlowLogs)
+!define VPCFlowLogsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCFlowLogs, VPCFlowLogs)
+
+sprite $VPCInternetGateway [64x64/16z] {
+rPS55Xin34HZYtF_0o_sxJWEg55H3xBqvP4pfjllZBR7LsXdzOZx6X6kt7yErft424sdO3yGDvKrr7xSSvvs8QYxaNWkGtVKEjVaxwkGZPONFTvaoo2lwMRh
+UsrlFj3r0sjlj0Uzhu_YPGrzUzK-McfhfB_0xPO8WmHZNhsbGf_fj4phhx-LDUSagHDlGPDQV_mR-rfJ6rXIZyly9aEEjhxg3mbfyjeOZhQYKIuF1NKx01Ng
+Mv3OdYvaw08O2u7gPOUvFNC_GGM1pSlWOQEZ3rXKLOx9et7SeL61QuVcTTN9--SML-tQJ_SR2F2hynKAst8rEU68WCaZLXuQwjSLy6lQdGxZtjgjdPF7Xlh5
+Gwk74kJZiGFxLXRoHzMG27ZKYS-1HzaCtadmw24-yxHl-7RgTYW_pGC87sTuV1I74VGxNW-hW7bpF5Zul-Uh_LVy_wh-gVgtEdwgunVcZpoFymScolCW6wvo
+FCg7-JlBu_oDwqUQn_K3rwyyZ-iNhfzv7jTFNByFKujCF3x7zNlUFnnhzyJ3Szm_pFiNZZrGtFGSzY-OtrwT6U0vV5lRlnNtZyNzQst_t8hxzzhveNv-gP-V
+wkUt-lcnVdwjdv_hiG
+}
+
+AWSEntityColoring(VPCInternetGateway)
+!define VPCInternetGateway(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCInternetGateway, VPCInternetGateway)
+!define VPCInternetGateway(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCInternetGateway, VPCInternetGateway)
+!define VPCInternetGatewayParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCInternetGateway, VPCInternetGateway)
+!define VPCInternetGatewayParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCInternetGateway, VPCInternetGateway)
+
+sprite $VPCNATGateway [64x64/16z] {
+jLS9bkGW25N3Vly3JvbGbXDIj3E-_hstVcGLBB-9UkA_g0r8LEq5LI5e_qOcjHkKbaM0N1HXmXU8tt_3EblmcEok1ygQX2Qphj4coQt0piOl7g_O9M0IBZOp
+gia6CZEkYUvwb1I7VhMXzQNwOqhrGzeNEfS5i0k8SkdrOo5Bw4bFlaxdP_V4lJ5mqdzEBamWzp0sCws-OWe_Eb7DsatWuR-edOx8SRYw3XW6YJ5SSGHy0zgZ
+2oOjjMllV3eZIKLjG1ujqFbuB1y-MXSkAR_Wf81Snxl-VD9BVOET7nIGZ_DfSkGzWXJvdaLj-ctmGtBTpm-dwhH19rqIlbiTr2yeK59-D00yToOa_3hd4BYS
+kim_T7YdkjxYwqlwexjt8gfnMVOVJl7Xqu5L9qQCN-IF3NIcNVNaNSWVrxyByDyV-1BpL-i0cZPs0O4_rqzLUu2UbTe51FwjVfize_F1Napd1_yHg1dNYc-8
+AGvqOpeTt7zp_EBz5VqFfkXqZv-dmUn_oEFNDpWnvAztfvmF8tz3_SJ-4VdmgPzGlwNbzGDEyleDzyT1BUKNEERx8zvVBd_z_eht9wtm_THuVuS2JE_ls3_a
+7a9E-qViNvN_hc1A-rVidttDk13n2LAJf7-6_atjCa1jG9F-7UO7zJ6CPG2J-I7EBsQqDB_4cSZvi3m_nVbDJ8_r-ItEZmtgqlouER_kpSzrStxVUp_ilr_s
+tq_xxxVzz-F--tN__RoFFm
+}
+
+AWSEntityColoring(VPCNATGateway)
+!define VPCNATGateway(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCNATGateway, VPCNATGateway)
+!define VPCNATGateway(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCNATGateway, VPCNATGateway)
+!define VPCNATGatewayParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCNATGateway, VPCNATGateway)
+!define VPCNATGatewayParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCNATGateway, VPCNATGateway)
+
+sprite $VPCNetworkAccessControlList [64x64/16z] {
+j9M7eYCX24K51U7-__zkOHF3cuMycfkUyL04cV5AKUXBA2yrTm1mDrtyELWT5xb-sCGoX6oh_97k--_rSTfafhnfYdtC0bkAjSZ9-2ak05oegOOu0EbfsW2K
+dYnG09lwsE5pFDNqDWTsmEZTbZB0kS7t-81s6AZiwlYGj8fpVyHxlrO06n-MNSl8WDF7UNA0BmRdlKAg7QPw5hqDTwM4nD7r7rpI5gIpu2bwGSz3KWQUtSke
+UQAQ7v82C3YL_3B0LicJmnwRhwFY1I79VEuYJjyAdW4NSO0BFdcDI0fUWHcbqeAFh9EXWZVO-RZmEUmLReWBVaUf2vuf0bjX9m27NdXoxCQ_mkEddkiKW-d1
+iva1Rl41C-C77sEEZk5mGm1WV7Z1HN9uDlpZDpp2XDvu-4oyxIDB_7JSU8ssetDD0Qonxln_dKktoz3Z8_ChWfw7vzGhPysCLDOB-1H_mpVnT_kN-Nx_-lfb
+lgjVqpyDN_HFqRzD_Ph-BSvFuxyxF_dyPjwJ06dFRvuVVV-lPduqyujqlv5ICx-w-PdLpiz-VcUryxk_VrJgxn-_Iwy38W0008Q0ftzf8NuX1k2Ny1FvhVw0
+_eB-fFw6_eZ-QluS-hlrW_UBzvFtc_UZzwltisy
+}
+
+AWSEntityColoring(VPCNetworkAccessControlList)
+!define VPCNetworkAccessControlList(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCNetworkAccessControlList, VPCNetworkAccessControlList)
+!define VPCNetworkAccessControlList(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCNetworkAccessControlList, VPCNetworkAccessControlList)
+!define VPCNetworkAccessControlListParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCNetworkAccessControlList, VPCNetworkAccessControlList)
+!define VPCNetworkAccessControlListParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCNetworkAccessControlList, VPCNetworkAccessControlList)
+
+sprite $VPCPeering [64x64/16z] {
+j9G7aWGX24L11U7T_xwRxUfM9rRjgx0xCtuoo7-YFxmbBSqZ4o0pl9NNn9vCf3zjeWK_H7Vxmllut9vNXrML0wqMpraeSOrLzPfJtC_2W3ILGSsiCb1Bm6wh
+jGEkSfB3oO2e0rrlnZvUd-IRhwBivGcXYtmoe05PRiYxpAvW3ahwOc3OzLbk1OhD1dp4ELdjChqoAL34m9UtQ-D2hhY9LAWYvd8bvZOMI9MPeL_GX38PhFAy
+NkertBOajEZNSZKvI59VqskIP_Sch-d5JW44gQ_gDOcZ-BZiqTPKzZYKwR_dMBmciNzXxdlt8-l9q7g989iyIA0TDQf-NKUIpS7nyHhQdnqT6-VdYUn5rG2p
+SnO-jb7_uWvYoB7JIFZnxMNXnpeVmgGlSkca7ca28Qk1JluEWW_vRZeqeZZOQi1_V2ZOk8lrYw8YTRfbzU_owy-BSMSDXbwJWogQoybAI9NAGUfjlQqJeGws
+wlVnTr8MahwDVwtVNX_qJVss_NDektLP-xUVdm9ugsSieMxcPp-_ZGrzEx_x_Qd1HDfkVsxlhzOBHRVxkzoF5mXoChIYPdh_Vet_NhY_YzVFqkk0200014BO
+qRyq8MO8Vy3_flt0_TBznFrMFw1Vq4_gD_GZ-jNy7FhT-i7xnVl9-ytxqVlL-zbl
+}
+
+AWSEntityColoring(VPCPeering)
+!define VPCPeering(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCPeering, VPCPeering)
+!define VPCPeering(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCPeering, VPCPeering)
+!define VPCPeeringParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCPeering, VPCPeering)
+!define VPCPeeringParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCPeering, VPCPeering)
+
+sprite $VPCRouter [64x64/16z] {
+jPU7SkCm34G1iEx-__zUeHrRsg4zqc4EwGaUMYnoOV_JVDa_eL7x14WIcBt6FRY3OkYNGzJ9PNFqziVw-FcvNgTdAuU-lRHvBKBCSwtkvvxczouQIJH_XmFU
+W3UGR9zf7oJxiMwGEFxSIGx_KZlACTwZwQD_mSSU0k9hWyk6IKp45XTFwtnQDucw2U1J_Hg9IbQGJUDELtvezaeYWem0MJU-ccoQPYbMrYUjpAQM52IqfDxi
+mLlhsYp8a835DbO-_twUUnrsXxTncWa8lySxY6FwPlTuQuS29k5tUGVdU_ZTxlBMoP3lBlAQTLLobrzTIw1hl3PGDpwrAb_h9dPznd75oNhcAwa1_5dtNEqh
+pthaAvL_W-2mRO0tlyLjh04wTkCh8Ek3NpZARe3mrKQpA6UB62jbaB6oZmXriKR-y9DRYrWVMvjvdapNdvrVyl-NVVraNx_PvoVx_2RFZ-pvbJq_i-Tt_lx8
+tr_v-pD_Vwj-sFEg7rI_NDKVgb_scgYJxN5-DBBlVLM_wGdIWemcfuVeDz6F8bN9gVZu8a1LwouJJIouwcS9iFdLzAlwlM3Xgj-lxmy5ABe_vFUN_FwKtz_o
+-sD-Vytlptdx3G
+}
+
+AWSEntityColoring(VPCRouter)
+!define VPCRouter(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCRouter, VPCRouter)
+!define VPCRouter(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCRouter, VPCRouter)
+!define VPCRouterParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCRouter, VPCRouter)
+!define VPCRouterParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCRouter, VPCRouter)
+
+sprite $VPCVPNConnection [64x64/16z] {
+xPC5Wkr020HX3BhlVz-losg4i2xrD58pMEHrKTMwEmmaOLChzWG3hCihzFzRhpd_1p4kwYHzwCs1avnNzILt398Zhol8yMJ1blRjQRY3z0lHcpncvJEmhLWL
+z7Jsjd5wPIlGjoDj9priCMIJR4TXwT8j7VG85BA5qsz-qRRqoDgmuyEZl6WR-ehyHz-mu_pc0WsN1doHQ8zqxnTm4lU210lWPVo87wEd6RvHW2LfPkYr_gtG
+2_CJ-i7ysidyMkWRpq_6bzNaW4C_GTrlynzEp2qGv_V2HthoDj6qhtk-jNFimC_Cy7exNwUxJwtwpVaNRqKV90majEGFSgde8aV9Dq9lsbhodHw_xxB_84r5
+hPg_E0a7wLBpzQR_MfxV0M9KvpTg_tx-ZpzjLVtWxVmVt-SvVk2dsFF5ahh93ff3Nf3V
+}
+
+AWSEntityColoring(VPCVPNConnection)
+!define VPCVPNConnection(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCVPNConnection, VPCVPNConnection)
+!define VPCVPNConnection(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCVPNConnection, VPCVPNConnection)
+!define VPCVPNConnectionParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCVPNConnection, VPCVPNConnection)
+!define VPCVPNConnectionParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCVPNConnection, VPCVPNConnection)
+
+sprite $VPCVPNGateway [64x64/16z] {
+jPS7aXqX34I_20fp_mCRYh6xt0op-5FkpOkUa42ap_-KIDTNQ2hg4LTJX6j9_mPhNAJGRHV51-AcjKdjzzzbd_QQ1V-JN7tFGtAAbNBozongfwiiPgDs3tLD
+YxLsbHS3RGOcBx57ViylnpA7r9lanvBgdQG5RfyD6HoGNvsBiDQvzFIEaxqQqpRgnjABBIREkP1Gl5mspjEOMauouvP5iiqE9AuhaSDCmMCkCratvJjSz6Lp
+ZcMlkIccw6KWiERsXg3xkQhpI0W6UHxmWkn3kFclbDCmfW0ShVhvYQyFLPJmsmClAvvx7P4m7qiUMPEZ9I_C8-nvSAMhDyeVvSPB5qrHkVq8xH3Fejr5xhZz
+SXgvjP05mBYCUAsFKkBjYb48kfWvaX2lLmZ-kycpvJjVpChtl8n3IxxZnqwBNNd5BySlDLIaEKdhyNkSFy4UCBw3f_dZ-k7-5MLEF41j0F7OLRr_KVvKlrW_
+pATn_qdCO_qWJE9n0jd0cKTYs3-87xuJrm_l7t34F0QVU8IDt_Pu3f_tRuxVdUAd_Hldn_xwm_d1vzS-BmsXynEyswCSFCvFdD-R-n-Vttn_IFwYHFS7kh_i
+2fdGdMXFiENxsrfyVpkyFnxUNy_kpt9uVpzxFvo_NyxVJ-Vlj_Ftu_dxzVpzVAvV
+}
+
+AWSEntityColoring(VPCVPNGateway)
+!define VPCVPNGateway(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #693CC5, VPCVPNGateway, VPCVPNGateway)
+!define VPCVPNGateway(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #693CC5, VPCVPNGateway, VPCVPNGateway)
+!define VPCVPNGatewayParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #693CC5, VPCVPNGateway, VPCVPNGateway)
+!define VPCVPNGatewayParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #693CC5, VPCVPNGateway, VPCVPNGateway)
+

--- a/awslib/Robotics/RoboMaker.puml
+++ b/awslib/Robotics/RoboMaker.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $RoboMaker [64x64/16z] {
+xTDNkkOi30DWsRWg-r_lNqYcdCAGpDqfxyrNzPW8u2VrxLjNk4Sr_qgPO18hFjO6oF08Dm6i-Km997YGvC5KIF4HXv5bAg9MfC7vJB470140evbygWKQJNOe
+fFcSsujtj_MBOSs7373ouY8Fjgw6CQ22P6YIT40mU9UhbA42JXs3fA2eADxKmncGENyaIL4UTZy_opA8S-e4p1JHjwkJ8Fl5zPb6yWQ70CNAMUMyFbcLOG9e
+SckW0j4YoS1v-2uv0BinNmNL8Xc0yuKKZ7tzCrOLa7ppesBSFBe55DzetTxXD6-IYk0x2fkJK9WjvMgXlkamC23aM8rfGU_c3pQK2uROFt-UDNNCCgOoo_ax
+Z3k78pbB1BHvne0vkQ6RTBahwkoYnhLSHIIaoHPn3tBD0Soy8uxv93F5GsTr0a3-lFXhVa92aTUzC3jNBX9GBhKBocQU1i0ubG1IPxu5Lglw1K1UULOKBvtH
+_9a7V7c-xCmlpBmuT9LFt-UrCJvN_db_k_rRsEmVEmIrpLjjpgzdB6pEB-dOaitztGb-6j--_Gi
+}
+
+AWSEntityColoring(RoboMaker)
+!define RoboMaker(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, RoboMaker, RoboMaker)
+!define RoboMaker(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, RoboMaker, RoboMaker)
+!define RoboMakerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, RoboMaker, RoboMaker)
+!define RoboMakerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, RoboMaker, RoboMaker)

--- a/awslib/Robotics/RoboMakerCloudExtensionROS.puml
+++ b/awslib/Robotics/RoboMakerCloudExtensionROS.puml
@@ -1,0 +1,19 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $RoboMakerCloudExtensionROS [64x64/16z] {
+tPS7cYOj28HR1QJg_lVzWqzfvyrns9tWm2ks5f_qzgEjMYlVGIT9nAElDAkVmy5X_S5d8DaVrzQyRSEIZ6OWsuHi0lKySns8WYYWaZ5MCSCII0LrqckVCpUI
+FlcaW2PtCfKJu5fQZWGsHi4PCmQ4AxyT-GAIPIKfcqtUSTYaqj6Bub77V5gRPTh-a4WIHJc5dCr99aRKpJf9fN-t645eJpxBx7NxZBN8xcNxnLPU7UNpI0q0
+KHuGIo3j2Gu0lHurZof4ZhMPZBSoGPD6UYIPym3dyHc92EndLkeIB3CwHvoHFdAnZSdWNIcJg2DNhWBC8fdtaOlsFpYo5TA7nwPy2nXwYhBAnBJ8iHAmt_bs
+vNto8EWt_hn-4XwdzHSGz_N7DicnVzxF-rVd_hc3zDl-2HahRn2p2ZFhiMBOtyvF1rCxY5vNafD-cFwi7o6J-Ihz2lbJp7fs-pgaxKX9KZV3PzF4wMIow32H
+U3Yczy-_498gXZ8MCGMGTI8jOTlzyxSEYPHEjgN_AfarIeagRUwQGr796QdAZy6FMF5EZ0bFry_v_b55gNvyJBPkbWfLpzoQSh__siYb7vM4LLzPgzikCdFX
+w_vLPTEhWQmgkS_UBEVxtuJuxi3d1LJCsZeOal3fQ79yXJMrIH_EBBpk0okxftfe-6egHjyrao9qpbcVAEzsK1n9k-ktSRXo5RFl-85WBmtCU_rqefMWvhDp
+_vRiCqaTeKe2AEZUlod9683qoOTkpACfVztyc3-MBxe_FVzk8a12GyzuRw3ZjJN3vuHUFE8bfaNudw_vKkltq1rasc6oyXBOdj8Kd5es0mbxJRDcgAsiWkdc
+a4gCm-mMfhi86ZOGRSh_yFwIX1jsoIoYaMcTz4--lnGoT5cS-o_zRK2IDaEy7NZrTonx6fjyarilZQdtb_6BhGQElUybttQ0HAII3N3NE7gIg7ineDsReNXf
+pER6cl9qDUCtiqJwcoE4_0hx5m
+}
+
+AWSEntityColoring(RoboMakerCloudExtensionROS)
+!define RoboMakerCloudExtensionROS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, RoboMakerCloudExtensionROS, RoboMakerCloudExtensionROS)
+!define RoboMakerCloudExtensionROS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, RoboMakerCloudExtensionROS, RoboMakerCloudExtensionROS)
+!define RoboMakerCloudExtensionROSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, RoboMakerCloudExtensionROS, RoboMakerCloudExtensionROS)
+!define RoboMakerCloudExtensionROSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, RoboMakerCloudExtensionROS, RoboMakerCloudExtensionROS)

--- a/awslib/Robotics/RoboMakerDevEnvironment.puml
+++ b/awslib/Robotics/RoboMakerDevEnvironment.puml
@@ -1,0 +1,18 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $RoboMakerDevEnvironment [64x64/16z] {
+xPPNmkig38IDXChC_XTyRonS2QU-dlbh29zQXF1swP_4JFy2TvACzbhj4Vt7NDETCUwAMfDX9wwrhTRUKY3R_mG8aIJbWmEG_KqI8FUqalYMNZ3Ojqtu-Qsr
+rnZq4PG8QRkfG7pXZVWmZH-Y5wy4-vuzQLQy4FIlTSjUuJ4SH1KZhUe0acEjXxTjBG4_wk_gS4fx8GaWfwrDTVAwr7hdMZtITU1_m0V9Ad0B86JFn6CfUtad
+aTox9izIExYMFFWaP5FIFhyYAf8WiH2f3nwCyTi-fgj5d5WLYzJPVn_-S_XVythng_n_Zz_yxBhcGBJjukKv3DgRBsc4ozicglVpPi00BNwXYK_U33G2-PLN
+bPdVaRWCB7dDcdepNuqGY_YVfpP7_xzu8_7Z-WLf6lK1TC0UV9_E_iJd9y1MRGSas-0dVCddoIU06oyxhhPB5xoJqRFYrqI_nsyVxr4JC1Tyk-etrxzwULUi
+-bU2XBUP7sgogwtuSLSj-KNz9lqzF_UFT5bjcLNjBZTUC7bh8bEstMlJD3-C_hZnnCTdQUsEavHABVmnl_HndJNdAVXqVt-Rd-hzUT3IkdPFtWU3Zg2Lp6h4
+kVw5fnu8xWQarxznDkBCDx1AuR1HwfYV91BUllC-y21fuv_-q_wvGYJpTLc2cBWcTxudZeDXrGZEajLIdoSX-iaRUTOvotqdG11I0VWJ7xO7BoGyIR_lLKc6
+oZbvgcsh6q2wWMZ5LyXvJA9-pRjNaPoWxdkixjTwomzBxQTyiX-yddmdlIcOvTycFWOlg2KGNPEKOHgyRbOmNdpbNwfwLBsl_fUiSWvVxSLBRRt9KFXvVtOp
+ES-elVWWPNfKxBAONo3QWrSoVzI_ybI_EYb6qIXBFlYME9bo3cj59RIGWI-rtQQNIuqgr5hzhJOE3o82967RRqkJXqAsFv5O93BieF_fFm
+}
+
+AWSEntityColoring(RoboMakerDevEnvironment)
+!define RoboMakerDevEnvironment(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, RoboMakerDevEnvironment, RoboMakerDevEnvironment)
+!define RoboMakerDevEnvironment(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, RoboMakerDevEnvironment, RoboMakerDevEnvironment)
+!define RoboMakerDevEnvironmentParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, RoboMakerDevEnvironment, RoboMakerDevEnvironment)
+!define RoboMakerDevEnvironmentParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, RoboMakerDevEnvironment, RoboMakerDevEnvironment)

--- a/awslib/Robotics/RoboMakerFleetManagement.puml
+++ b/awslib/Robotics/RoboMakerFleetManagement.puml
@@ -1,0 +1,20 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $RoboMakerFleetManagement [64x64/16z] {
+jPQBSYGX24KR4E7U___WZMA5gimuMxMFivkabQUAJJ__5Wjas1-RJsxyLQ81t1rB_Haa8aXQpnSABjuxq4HiJH3wF0PcMIVoU0WoWiHR-pmfoyby4dB-CihJ
+Vd1Itzk3S-L1ZZLsSjj7ss-5SR4V9BIqSgTzyhHUSHB3K7czOgFyJZ9jvFS1wD0EqGTpHPARV1KvICpdDqXiDNadCdkP_WErYur-agkFkyzQ6jC-5ZK-Yg-r
+sLiFlIL7OjWaSSan27KIEKtUXxUgEUip_s4lnWscld6VpwdzhiMcPaX6WYH3NzCxonXz5tveLEN929Bmfwd4PrMU7dTBLtEqoeXfzMH1SjtrHa1cW8nQVYwv
+WTGIcqTcHdYD1yYinuE1YvH-vnXE59tWDt1PulYvGp8JbUv1KPkfmIB1JQrzLh0hSim7ICRINXunaoVrMOkz4UGiBOQkaUvT7eybYL4QVZKVvJrALseaO1wV
+Ou-Wz-mXfSaOCaWxYrRrF1V5okjXHBXqFT2t0aWI8Ds-c3mJTL5gLLrVdG-8IiBwyCW-Gj-XjHEO5ILhP3kyeng21HkudMvXTQjEGAOyy-HpvdKUTqgwsXSQ
+n9bAbnrdT6jOG-j6qtJBs4sbQKKGAa5gNyF62MbFB_UsL3Rnj9OScsw59yDDoJkVsTTdwrkI8HsbwCnARktFtAspCh3z1RFj_Jmiqew_vkXFSWQ9N93C0YJE
+0pr8nplxP0PHCMwKV89-Ynz9nWP47CYCHMxv9NuGYZgE7-kNBfWjVx_-IOW6C9_x_fTyzFw_gRVx-RUawt5C-tbAVPilzPVCRrTetpZJSgz_wMjJW3s8hMPv
+qbPo3lzY974MWf2dbjysjJTz_ykXUf9DZEMqEbMvAoIo5mr2jj8OoPyWRFBSztbx_Ux-X-uS9bzuTv6iDdjh8I1qko6dVhzdWf1wdK5FqxrW5S59Ud-JWd5w
+dsqLoEV-KndagE-J_LiS5Lr0skUlK3_l2I9Ptoy8a0nf-HL5PR02Ri0Ynv9ctQuxtV-b2u28KR8s_vW1h1w7puZfrlTeFhz5WcHOFNjMw6A-hlt-LUkwj-iU
+yuvEBf1LUVhyWGVq-t8yVu9vW1XLH7-6LGxoPzRzoVZdYEdpl_W5
+}
+
+AWSEntityColoring(RoboMakerFleetManagement)
+!define RoboMakerFleetManagement(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, RoboMakerFleetManagement, RoboMakerFleetManagement)
+!define RoboMakerFleetManagement(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, RoboMakerFleetManagement, RoboMakerFleetManagement)
+!define RoboMakerFleetManagementParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, RoboMakerFleetManagement, RoboMakerFleetManagement)
+!define RoboMakerFleetManagementParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, RoboMakerFleetManagement, RoboMakerFleetManagement)

--- a/awslib/Robotics/RoboMakerSimulation.puml
+++ b/awslib/Robotics/RoboMakerSimulation.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $RoboMakerSimulation [64x64/16z] {
+xPQ5rjim34O5jkZz7tX7Rkq6_l1ukmTAkV4d6Hhui_aFsmCKGEC-Rkcx3Zn2ho3f6mma72wIFjOwyUjvoiid3nm-Ngq_VP_uVfhk0-8aFrwW-KI8rD0x_Plo
+4tsYj-zrOATzzWW5kBj-q3DilUrpX7hO4zzE-bpfINvoTPoffH00cNlgSr_NVZ5quaBZSuuiUP-kX0ryxQEvGlQA9y6ZNbW_2233gH65V6HUdZyRFbBUeRmw
+X9yoT_j7afcBUOlEdYQK29Esz9Zs_HhX32KIWZHR1HO9WtcKFJz58x1mUVKRF2nBKSz05AowuwE7SvCKlU-KSAL-sEoFZpMYTccqVZfpM7Yx_keHqOQXV6S8
+2HUTJVtM_aUBb7eIhJZRzdHq_cJcGhYvSGzyRe47HBZ8k_XiED3q9PnWK3DCAuJwlEOR5YaR_RFfDzH2OJRIvUDBwn1k-0g3iVv4i0Ml-ObZJEl1-Dp7PxTs
+MtkL68osSNxb5fr-zVv8_CuZxrsuvLFRE0DYd9QJPgPoYv0l_GmGMik7_bwiXz5ULleqqFJp1fjuWKOr4zmylrZzIzagdlt_H5gJyjhtCh1xpqy3-GTzV-OZ
+ufP_7RtX5_yG5vy_jVdnuVhpBx1yK650EK-5Nyj_lW4
+}
+
+AWSEntityColoring(RoboMakerSimulation)
+!define RoboMakerSimulation(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, RoboMakerSimulation, RoboMakerSimulation)
+!define RoboMakerSimulation(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, RoboMakerSimulation, RoboMakerSimulation)
+!define RoboMakerSimulationParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, RoboMakerSimulation, RoboMakerSimulation)
+!define RoboMakerSimulationParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, RoboMakerSimulation, RoboMakerSimulation)

--- a/awslib/Robotics/Robotics.puml
+++ b/awslib/Robotics/Robotics.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Robotics [64x64/16z] {
+xTO7ejmW38JX6J601FU_R-JN-nhI4__kvTjUZD_L5H-NH6chLS2UVPjZiNZjnu_sbx-yjs9Mck_vA8191YWsl9CjHkJOI5_tKSCBikAvkkx7x63jlH9zRhr-
+ddjdqXRRxvzB_Ztllv7s7JxGEsBVEoJufezAtCKQ6xu1wXxXNK1RzeBYSJq4BNgztjMW9T_VxcdeA_xzksvSy1t-rZlwQJ_5d7VLk7yVTL1gdlJkLd8EmaPc
+87oCOkxdl05r375q-Fq3fyQe2Kxve9Y-eHL4RgBaQdgASSAxeVBO5dAHDK9tYmhpszx8UWyZHlQuJ4_Q2IzJ-hUbb-aly0Me7_iAbDi-ok7dMpuFN-8h_nW9
+qxiCvBdFd-oJT5r__1H_-Hgh-Ik_qO_piBAJ4OznA_mBVGC
+}
+
+AWSEntityColoring(Robotics)
+!define Robotics(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, Robotics, Robotics)
+!define Robotics(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, Robotics, Robotics)
+!define RoboticsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, Robotics, Robotics)
+!define RoboticsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, Robotics, Robotics)

--- a/awslib/Robotics/all.puml
+++ b/awslib/Robotics/all.puml
@@ -1,0 +1,99 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $RoboMaker [64x64/16z] {
+xTDNkkOi30DWsRWg-r_lNqYcdCAGpDqfxyrNzPW8u2VrxLjNk4Sr_qgPO18hFjO6oF08Dm6i-Km997YGvC5KIF4HXv5bAg9MfC7vJB470140evbygWKQJNOe
+fFcSsujtj_MBOSs7373ouY8Fjgw6CQ22P6YIT40mU9UhbA42JXs3fA2eADxKmncGENyaIL4UTZy_opA8S-e4p1JHjwkJ8Fl5zPb6yWQ70CNAMUMyFbcLOG9e
+SckW0j4YoS1v-2uv0BinNmNL8Xc0yuKKZ7tzCrOLa7ppesBSFBe55DzetTxXD6-IYk0x2fkJK9WjvMgXlkamC23aM8rfGU_c3pQK2uROFt-UDNNCCgOoo_ax
+Z3k78pbB1BHvne0vkQ6RTBahwkoYnhLSHIIaoHPn3tBD0Soy8uxv93F5GsTr0a3-lFXhVa92aTUzC3jNBX9GBhKBocQU1i0ubG1IPxu5Lglw1K1UULOKBvtH
+_9a7V7c-xCmlpBmuT9LFt-UrCJvN_db_k_rRsEmVEmIrpLjjpgzdB6pEB-dOaitztGb-6j--_Gi
+}
+
+AWSEntityColoring(RoboMaker)
+!define RoboMaker(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, RoboMaker, RoboMaker)
+!define RoboMaker(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, RoboMaker, RoboMaker)
+!define RoboMakerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, RoboMaker, RoboMaker)
+!define RoboMakerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, RoboMaker, RoboMaker)
+
+sprite $RoboMakerCloudExtensionROS [64x64/16z] {
+tPS7cYOj28HR1QJg_lVzWqzfvyrns9tWm2ks5f_qzgEjMYlVGIT9nAElDAkVmy5X_S5d8DaVrzQyRSEIZ6OWsuHi0lKySns8WYYWaZ5MCSCII0LrqckVCpUI
+FlcaW2PtCfKJu5fQZWGsHi4PCmQ4AxyT-GAIPIKfcqtUSTYaqj6Bub77V5gRPTh-a4WIHJc5dCr99aRKpJf9fN-t645eJpxBx7NxZBN8xcNxnLPU7UNpI0q0
+KHuGIo3j2Gu0lHurZof4ZhMPZBSoGPD6UYIPym3dyHc92EndLkeIB3CwHvoHFdAnZSdWNIcJg2DNhWBC8fdtaOlsFpYo5TA7nwPy2nXwYhBAnBJ8iHAmt_bs
+vNto8EWt_hn-4XwdzHSGz_N7DicnVzxF-rVd_hc3zDl-2HahRn2p2ZFhiMBOtyvF1rCxY5vNafD-cFwi7o6J-Ihz2lbJp7fs-pgaxKX9KZV3PzF4wMIow32H
+U3Yczy-_498gXZ8MCGMGTI8jOTlzyxSEYPHEjgN_AfarIeagRUwQGr796QdAZy6FMF5EZ0bFry_v_b55gNvyJBPkbWfLpzoQSh__siYb7vM4LLzPgzikCdFX
+w_vLPTEhWQmgkS_UBEVxtuJuxi3d1LJCsZeOal3fQ79yXJMrIH_EBBpk0okxftfe-6egHjyrao9qpbcVAEzsK1n9k-ktSRXo5RFl-85WBmtCU_rqefMWvhDp
+_vRiCqaTeKe2AEZUlod9683qoOTkpACfVztyc3-MBxe_FVzk8a12GyzuRw3ZjJN3vuHUFE8bfaNudw_vKkltq1rasc6oyXBOdj8Kd5es0mbxJRDcgAsiWkdc
+a4gCm-mMfhi86ZOGRSh_yFwIX1jsoIoYaMcTz4--lnGoT5cS-o_zRK2IDaEy7NZrTonx6fjyarilZQdtb_6BhGQElUybttQ0HAII3N3NE7gIg7ineDsReNXf
+pER6cl9qDUCtiqJwcoE4_0hx5m
+}
+
+AWSEntityColoring(RoboMakerCloudExtensionROS)
+!define RoboMakerCloudExtensionROS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, RoboMakerCloudExtensionROS, RoboMakerCloudExtensionROS)
+!define RoboMakerCloudExtensionROS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, RoboMakerCloudExtensionROS, RoboMakerCloudExtensionROS)
+!define RoboMakerCloudExtensionROSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, RoboMakerCloudExtensionROS, RoboMakerCloudExtensionROS)
+!define RoboMakerCloudExtensionROSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, RoboMakerCloudExtensionROS, RoboMakerCloudExtensionROS)
+
+sprite $RoboMakerDevEnvironment [64x64/16z] {
+xPPNmkig38IDXChC_XTyRonS2QU-dlbh29zQXF1swP_4JFy2TvACzbhj4Vt7NDETCUwAMfDX9wwrhTRUKY3R_mG8aIJbWmEG_KqI8FUqalYMNZ3Ojqtu-Qsr
+rnZq4PG8QRkfG7pXZVWmZH-Y5wy4-vuzQLQy4FIlTSjUuJ4SH1KZhUe0acEjXxTjBG4_wk_gS4fx8GaWfwrDTVAwr7hdMZtITU1_m0V9Ad0B86JFn6CfUtad
+aTox9izIExYMFFWaP5FIFhyYAf8WiH2f3nwCyTi-fgj5d5WLYzJPVn_-S_XVythng_n_Zz_yxBhcGBJjukKv3DgRBsc4ozicglVpPi00BNwXYK_U33G2-PLN
+bPdVaRWCB7dDcdepNuqGY_YVfpP7_xzu8_7Z-WLf6lK1TC0UV9_E_iJd9y1MRGSas-0dVCddoIU06oyxhhPB5xoJqRFYrqI_nsyVxr4JC1Tyk-etrxzwULUi
+-bU2XBUP7sgogwtuSLSj-KNz9lqzF_UFT5bjcLNjBZTUC7bh8bEstMlJD3-C_hZnnCTdQUsEavHABVmnl_HndJNdAVXqVt-Rd-hzUT3IkdPFtWU3Zg2Lp6h4
+kVw5fnu8xWQarxznDkBCDx1AuR1HwfYV91BUllC-y21fuv_-q_wvGYJpTLc2cBWcTxudZeDXrGZEajLIdoSX-iaRUTOvotqdG11I0VWJ7xO7BoGyIR_lLKc6
+oZbvgcsh6q2wWMZ5LyXvJA9-pRjNaPoWxdkixjTwomzBxQTyiX-yddmdlIcOvTycFWOlg2KGNPEKOHgyRbOmNdpbNwfwLBsl_fUiSWvVxSLBRRt9KFXvVtOp
+ES-elVWWPNfKxBAONo3QWrSoVzI_ybI_EYb6qIXBFlYME9bo3cj59RIGWI-rtQQNIuqgr5hzhJOE3o82967RRqkJXqAsFv5O93BieF_fFm
+}
+
+AWSEntityColoring(RoboMakerDevEnvironment)
+!define RoboMakerDevEnvironment(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, RoboMakerDevEnvironment, RoboMakerDevEnvironment)
+!define RoboMakerDevEnvironment(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, RoboMakerDevEnvironment, RoboMakerDevEnvironment)
+!define RoboMakerDevEnvironmentParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, RoboMakerDevEnvironment, RoboMakerDevEnvironment)
+!define RoboMakerDevEnvironmentParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, RoboMakerDevEnvironment, RoboMakerDevEnvironment)
+
+sprite $RoboMakerFleetManagement [64x64/16z] {
+jPQBSYGX24KR4E7U___WZMA5gimuMxMFivkabQUAJJ__5Wjas1-RJsxyLQ81t1rB_Haa8aXQpnSABjuxq4HiJH3wF0PcMIVoU0WoWiHR-pmfoyby4dB-CihJ
+Vd1Itzk3S-L1ZZLsSjj7ss-5SR4V9BIqSgTzyhHUSHB3K7czOgFyJZ9jvFS1wD0EqGTpHPARV1KvICpdDqXiDNadCdkP_WErYur-agkFkyzQ6jC-5ZK-Yg-r
+sLiFlIL7OjWaSSan27KIEKtUXxUgEUip_s4lnWscld6VpwdzhiMcPaX6WYH3NzCxonXz5tveLEN929Bmfwd4PrMU7dTBLtEqoeXfzMH1SjtrHa1cW8nQVYwv
+WTGIcqTcHdYD1yYinuE1YvH-vnXE59tWDt1PulYvGp8JbUv1KPkfmIB1JQrzLh0hSim7ICRINXunaoVrMOkz4UGiBOQkaUvT7eybYL4QVZKVvJrALseaO1wV
+Ou-Wz-mXfSaOCaWxYrRrF1V5okjXHBXqFT2t0aWI8Ds-c3mJTL5gLLrVdG-8IiBwyCW-Gj-XjHEO5ILhP3kyeng21HkudMvXTQjEGAOyy-HpvdKUTqgwsXSQ
+n9bAbnrdT6jOG-j6qtJBs4sbQKKGAa5gNyF62MbFB_UsL3Rnj9OScsw59yDDoJkVsTTdwrkI8HsbwCnARktFtAspCh3z1RFj_Jmiqew_vkXFSWQ9N93C0YJE
+0pr8nplxP0PHCMwKV89-Ynz9nWP47CYCHMxv9NuGYZgE7-kNBfWjVx_-IOW6C9_x_fTyzFw_gRVx-RUawt5C-tbAVPilzPVCRrTetpZJSgz_wMjJW3s8hMPv
+qbPo3lzY974MWf2dbjysjJTz_ykXUf9DZEMqEbMvAoIo5mr2jj8OoPyWRFBSztbx_Ux-X-uS9bzuTv6iDdjh8I1qko6dVhzdWf1wdK5FqxrW5S59Ud-JWd5w
+dsqLoEV-KndagE-J_LiS5Lr0skUlK3_l2I9Ptoy8a0nf-HL5PR02Ri0Ynv9ctQuxtV-b2u28KR8s_vW1h1w7puZfrlTeFhz5WcHOFNjMw6A-hlt-LUkwj-iU
+yuvEBf1LUVhyWGVq-t8yVu9vW1XLH7-6LGxoPzRzoVZdYEdpl_W5
+}
+
+AWSEntityColoring(RoboMakerFleetManagement)
+!define RoboMakerFleetManagement(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, RoboMakerFleetManagement, RoboMakerFleetManagement)
+!define RoboMakerFleetManagement(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, RoboMakerFleetManagement, RoboMakerFleetManagement)
+!define RoboMakerFleetManagementParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, RoboMakerFleetManagement, RoboMakerFleetManagement)
+!define RoboMakerFleetManagementParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, RoboMakerFleetManagement, RoboMakerFleetManagement)
+
+sprite $RoboMakerSimulation [64x64/16z] {
+xPQ5rjim34O5jkZz7tX7Rkq6_l1ukmTAkV4d6Hhui_aFsmCKGEC-Rkcx3Zn2ho3f6mma72wIFjOwyUjvoiid3nm-Ngq_VP_uVfhk0-8aFrwW-KI8rD0x_Plo
+4tsYj-zrOATzzWW5kBj-q3DilUrpX7hO4zzE-bpfINvoTPoffH00cNlgSr_NVZ5quaBZSuuiUP-kX0ryxQEvGlQA9y6ZNbW_2233gH65V6HUdZyRFbBUeRmw
+X9yoT_j7afcBUOlEdYQK29Esz9Zs_HhX32KIWZHR1HO9WtcKFJz58x1mUVKRF2nBKSz05AowuwE7SvCKlU-KSAL-sEoFZpMYTccqVZfpM7Yx_keHqOQXV6S8
+2HUTJVtM_aUBb7eIhJZRzdHq_cJcGhYvSGzyRe47HBZ8k_XiED3q9PnWK3DCAuJwlEOR5YaR_RFfDzH2OJRIvUDBwn1k-0g3iVv4i0Ml-ObZJEl1-Dp7PxTs
+MtkL68osSNxb5fr-zVv8_CuZxrsuvLFRE0DYd9QJPgPoYv0l_GmGMik7_bwiXz5ULleqqFJp1fjuWKOr4zmylrZzIzagdlt_H5gJyjhtCh1xpqy3-GTzV-OZ
+ufP_7RtX5_yG5vy_jVdnuVhpBx1yK650EK-5Nyj_lW4
+}
+
+AWSEntityColoring(RoboMakerSimulation)
+!define RoboMakerSimulation(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, RoboMakerSimulation, RoboMakerSimulation)
+!define RoboMakerSimulation(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, RoboMakerSimulation, RoboMakerSimulation)
+!define RoboMakerSimulationParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, RoboMakerSimulation, RoboMakerSimulation)
+!define RoboMakerSimulationParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, RoboMakerSimulation, RoboMakerSimulation)
+
+sprite $Robotics [64x64/16z] {
+xTO7ejmW38JX6J601FU_R-JN-nhI4__kvTjUZD_L5H-NH6chLS2UVPjZiNZjnu_sbx-yjs9Mck_vA8191YWsl9CjHkJOI5_tKSCBikAvkkx7x63jlH9zRhr-
+ddjdqXRRxvzB_Ztllv7s7JxGEsBVEoJufezAtCKQ6xu1wXxXNK1RzeBYSJq4BNgztjMW9T_VxcdeA_xzksvSy1t-rZlwQJ_5d7VLk7yVTL1gdlJkLd8EmaPc
+87oCOkxdl05r375q-Fq3fyQe2Kxve9Y-eHL4RgBaQdgASSAxeVBO5dAHDK9tYmhpszx8UWyZHlQuJ4_Q2IzJ-hUbb-aly0Me7_iAbDi-ok7dMpuFN-8h_nW9
+qxiCvBdFd-oJT5r__1H_-Hgh-Ik_qO_piBAJ4OznA_mBVGC
+}
+
+AWSEntityColoring(Robotics)
+!define Robotics(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, Robotics, Robotics)
+!define Robotics(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, Robotics, Robotics)
+!define RoboticsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, Robotics, Robotics)
+!define RoboticsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, Robotics, Robotics)
+

--- a/awslib/Satellite/GroundStation.puml
+++ b/awslib/Satellite/GroundStation.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $GroundStation [64x64/16z] {
+xTHLWkn640NHI2ZAk__r3WZcoo39Vjod6K9SLJ-bbnTj7iSrUsjZbXxbAzbvVxA41fRjGu1DrKs9jUQ0HKyOgZkKU3U838VeDnUWZdTeBJoo1zwnfLkhxrXt
+C22Jo9jxi99cP8ySHWPZrIsgsMZB89SpLwbkKirAmbXhIVM0D03RweSCydQjBnqtfavrpVm2en5h7jR5Q-VlT5tf1vOV7CyCBCzdlzWlVD_t8Ir2vtCmLHSe
+Q2eDsbwM9YaDl2xHCeOqYRDlT2rZgYxHWAuorjwNiwRHwYeDY6gqhTSWElHcXw5_tmN76gnj_Ov1LpCmiqjJYQe1n6UVW4-LEbsrxTRbwTV0mRfKfMIeukg0
+a6QmyLgpFXWrdRWp2_QgIIXOKYSQPEb6FwHrzClOzgHkhV_itGt8fNhMizUgX_siO5lvmtxf3-nV_VYFVOxHjxvFVz83R3rmlvzzCpJQfxfBX-DD_OHUNju1
+}
+
+AWSEntityColoring(GroundStation)
+!define GroundStation(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, GroundStation, GroundStation)
+!define GroundStation(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, GroundStation, GroundStation)
+!define GroundStationParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, GroundStation, GroundStation)
+!define GroundStationParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, GroundStation, GroundStation)

--- a/awslib/Satellite/Satellite.puml
+++ b/awslib/Satellite/Satellite.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Satellite [64x64/16z] {
+xTO5ekn644DHbPggfEn_kuyPsqxoSUum73FXPtKf7by3RHvj07psqqVJ6wzZkGxuYxzuttRQspdwIFcSTpK40qoVyXKnvvYBIEzx--7PFHP1n2ArwrspCO9z
+oPLaPVN8slJM0DZ7w0I6N4NSQkzvPs2Kxwg1I4yacwKjxuLMjkwoYyY9HMhFEz7bbpFJa0s1jkSLrEi1YbHfONh3Uw2iLpanRUrvHRVUv1xoG6ru9_AzJ-J4
+j3Ry27tGux--yrvexqVl1IphU-y9TB_LIQ1Pttid1b__qre4isrvaMxq2rmZm2MpRtdCVoRaMseh1n4zRGjpopDMObcgDLeW-f8jUQ5slAi12CRjSnif-sc-
+jE7bsn63SsN9zlDQoJqlsMvHjb_laDu__bkCUiM3XyuVBc8-7pydA1_niZeuIpVL37JvwFdBsO2u2MZf4-S_kzReVQoopvq_VT_b-k5xV_57U-s7wc3vof_e
+l_DWEnEVHnkdmf_GDG
+}
+
+AWSEntityColoring(Satellite)
+!define Satellite(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, Satellite, Satellite)
+!define Satellite(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, Satellite, Satellite)
+!define SatelliteParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, Satellite, Satellite)
+!define SatelliteParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, Satellite, Satellite)

--- a/awslib/Satellite/all.puml
+++ b/awslib/Satellite/all.puml
@@ -1,0 +1,30 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $GroundStation [64x64/16z] {
+xTHLWkn640NHI2ZAk__r3WZcoo39Vjod6K9SLJ-bbnTj7iSrUsjZbXxbAzbvVxA41fRjGu1DrKs9jUQ0HKyOgZkKU3U838VeDnUWZdTeBJoo1zwnfLkhxrXt
+C22Jo9jxi99cP8ySHWPZrIsgsMZB89SpLwbkKirAmbXhIVM0D03RweSCydQjBnqtfavrpVm2en5h7jR5Q-VlT5tf1vOV7CyCBCzdlzWlVD_t8Ir2vtCmLHSe
+Q2eDsbwM9YaDl2xHCeOqYRDlT2rZgYxHWAuorjwNiwRHwYeDY6gqhTSWElHcXw5_tmN76gnj_Ov1LpCmiqjJYQe1n6UVW4-LEbsrxTRbwTV0mRfKfMIeukg0
+a6QmyLgpFXWrdRWp2_QgIIXOKYSQPEb6FwHrzClOzgHkhV_itGt8fNhMizUgX_siO5lvmtxf3-nV_VYFVOxHjxvFVz83R3rmlvzzCpJQfxfBX-DD_OHUNju1
+}
+
+AWSEntityColoring(GroundStation)
+!define GroundStation(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, GroundStation, GroundStation)
+!define GroundStation(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, GroundStation, GroundStation)
+!define GroundStationParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, GroundStation, GroundStation)
+!define GroundStationParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, GroundStation, GroundStation)
+
+sprite $Satellite [64x64/16z] {
+xTO5ekn644DHbPggfEn_kuyPsqxoSUum73FXPtKf7by3RHvj07psqqVJ6wzZkGxuYxzuttRQspdwIFcSTpK40qoVyXKnvvYBIEzx--7PFHP1n2ArwrspCO9z
+oPLaPVN8slJM0DZ7w0I6N4NSQkzvPs2Kxwg1I4yacwKjxuLMjkwoYyY9HMhFEz7bbpFJa0s1jkSLrEi1YbHfONh3Uw2iLpanRUrvHRVUv1xoG6ru9_AzJ-J4
+j3Ry27tGux--yrvexqVl1IphU-y9TB_LIQ1Pttid1b__qre4isrvaMxq2rmZm2MpRtdCVoRaMseh1n4zRGjpopDMObcgDLeW-f8jUQ5slAi12CRjSnif-sc-
+jE7bsn63SsN9zlDQoJqlsMvHjb_laDu__bkCUiM3XyuVBc8-7pydA1_niZeuIpVL37JvwFdBsO2u2MZf4-S_kzReVQoopvq_VT_b-k5xV_57U-s7wc3vof_e
+l_DWEnEVHnkdmf_GDG
+}
+
+AWSEntityColoring(Satellite)
+!define Satellite(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3B48CC, Satellite, Satellite)
+!define Satellite(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3B48CC, Satellite, Satellite)
+!define SatelliteParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3B48CC, Satellite, Satellite)
+!define SatelliteParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3B48CC, Satellite, Satellite)
+

--- a/awslib/SecurityIdentityAndCompliance/Artifact.puml
+++ b/awslib/SecurityIdentityAndCompliance/Artifact.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Artifact [64x64/16z] {
+xPQ7hgD034Ml1tV-_tyNJInb2A3dVIfRJtevPhgTlod_-K-OgPh5jrpT20Lj6lbJE4-DvO1d8FPi4moGU6GHBWHmP0ybq6U3OtwP7HYGtFE20DpGDv1dw8hb
+n0bRGn-HgJWXEOdnPG2UUYhOjB0n6ru1E1-P7iNhLVSiTiOx047pcI1ubh-sIGaLm46HZp0axtoFWVf5mFc4W_BjwuiPLUUaJWZ-V7bTVBo8P4pAqyS612WM
+trvandmTvGSXdWPVSl7Fx5n-2lHfwVZg-qgyV_MdHKGKgu-LaOpoW-YX-oDNdrVaxUT0v0q6FldxmMtl67RloydV3kpEbwjVpkaz0T1xNpj-76JRlxRV2c-r
+_pf-ABRM-5tdJmlxz0UYitvMLZ-8MkltJ6FzAgJZ2xIpV_U7_HU4Q9mVctmmblEZSNvTAP_WNv-VOLVyo_Cpunny5_8W-MXYDF97mV3pR0L16_chsAVF-riV
+u4x-dEWSSySGqMx-hFnTJJtmm055EtzN_N1W0Fkh5BAbVcZNBxjDqG3Rb_gbNpzDTGPPwwT-_HPfEB2CfNxh4YhvQdncYaP-3_VyVVdFVtu
+}
+
+AWSEntityColoring(Artifact)
+!define Artifact(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, Artifact, Artifact)
+!define Artifact(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, Artifact, Artifact)
+!define ArtifactParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, Artifact, Artifact)
+!define ArtifactParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, Artifact, Artifact)

--- a/awslib/SecurityIdentityAndCompliance/CertificateManager.puml
+++ b/awslib/SecurityIdentityAndCompliance/CertificateManager.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CertificateManager [64x64/16z] {
+xPO5WaCX30KV986alVzzDrcf2wJhPRxBuBPn5ek5CGt2Tibl6APTziM6Q5TyVps4NlMt8_hsgayo1A5zKVdf42sL_pqwKVv4v-_wkD-1_eXV0Nh0xwWLFU-x
+x45aVDCkNCFr4qjNc_C9GV6qzuAWplaCYDf7MWIGoVmpoYx9MY3JvISekjSJvIyVUQwk9tpR-vRn5UmdZQBGZE_FnW2RtsHyHWLAWLyuuuVT_7M4aF6fYCNL
+f536DzlV9Vmplizd8bAlUpg61tqhGDnt75DiC7uBuhf30njD__lFfZkcycyuIxzDbPyuKNwourVLlsRMBvjtRgrVRa3xNkcqwVNRhWHbjtvRB1Ol
+}
+
+AWSEntityColoring(CertificateManager)
+!define CertificateManager(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, CertificateManager, CertificateManager)
+!define CertificateManager(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, CertificateManager, CertificateManager)
+!define CertificateManagerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, CertificateManager, CertificateManager)
+!define CertificateManagerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, CertificateManager, CertificateManager)

--- a/awslib/SecurityIdentityAndCompliance/CertificateManagerResource.puml
+++ b/awslib/SecurityIdentityAndCompliance/CertificateManagerResource.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CertificateManagerResource [64x64/16z] {
+vTTdejmW30HWIwWmS_y3vzcBDsmgA3rl_hX-hjJZtSSYYmbxuy9w89T7BmNawK4_Id7YuUqVzscbvEtBkJrAUNgNKk9l_t-YvcugDQy1Na7elfVWb91DBvra
+DnLHkrPboml8tkwjrad8Zkzapjj9zWtlDvyluCjUGCWNTgrwu-ikyx5lqUVhlHePXu2vwi6SEQvR9x7e1OpF-164B7i_trhF3SNuyhxfZT2RR_dn_a5211pl
+il7-uzGWCVYPZU_lznVZHswaRvI_FWhjyvvze_mTCUxh_h9dsSluwlCRGLRz-Elv198aTAlzQI0HUXxNEDVRPlkddIJn5fBikj_-MkT8jrhxhnQPOLfg_rNd
+zMtVo3QllrFl_YDUaaofUjLEabsrvWDa9eae-JCnMg6YlmvOrMEWXeANJ9tMvLUEtxpez-OlCL6PvYzS2_habO_8-lmjVF8ICUPlxpqV
+}
+
+AWSEntityColoring(CertificateManagerResource)
+!define CertificateManagerResource(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, CertificateManagerResource, CertificateManagerResource)
+!define CertificateManagerResource(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, CertificateManagerResource, CertificateManagerResource)
+!define CertificateManagerResourceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, CertificateManagerResource, CertificateManagerResource)
+!define CertificateManagerResourceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, CertificateManagerResource, CertificateManagerResource)

--- a/awslib/SecurityIdentityAndCompliance/CloudDirectory.puml
+++ b/awslib/SecurityIdentityAndCompliance/CloudDirectory.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CloudDirectory [64x64/16z] {
+xPO74jKm34HNijewzxylANJ8eFZJuKr9VRE9g-PloN_-mwgCdQpYOpTD1UyHjMJVhd5Am_p4Xc1dL3FR0FaiZsa263l-WEJy2YdGXXuODp4SY6_xXfmt9ApZ
+wrs-mZi-9FWLEmGzN-_QlvbVPN8D6lCTkuQIM6NJlnj_RV-4hCo8pEBrBtt_XWMVVCKF1JIMVGDK0Llq0xgVbYBMVBdE2hBa5yPrCb2_mYU4vr6mDduCzlwm
+ubCXxWBbcZzfs36kZr-AyANnBpBNV5w8yEAXx_YCUEORT1m0vq5XJ_tQFlp_Ll0d_lkbld2rXcFmWKy1O8UmaySzGDZsDuEbegOW0Z8BcWRRsla3t1n1wDmK
+tBsD6FrynmX1JOKxT1Oa1hoVJmMETrEk_tS0slx_NM3uDGeZU1pBezV-hzSFK-_hb_43wwT-_RPUFwxNhxyb__dF6m
+}
+
+AWSEntityColoring(CloudDirectory)
+!define CloudDirectory(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, CloudDirectory, CloudDirectory)
+!define CloudDirectory(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, CloudDirectory, CloudDirectory)
+!define CloudDirectoryParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, CloudDirectory, CloudDirectory)
+!define CloudDirectoryParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, CloudDirectory, CloudDirectory)

--- a/awslib/SecurityIdentityAndCompliance/CloudHSM.puml
+++ b/awslib/SecurityIdentityAndCompliance/CloudHSM.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $CloudHSM [64x64/16z] {
+xTK5hkq638JXCTkJ_U-t2hHz60L45px1mT_XX9_6js-bSiQ6vmIYVoS8dXfHdgYNVIDuxbK_Cs_w5W7qvtbpeq-8_j2N2G3nljxd_zi_1eYP2c1pls-1rjfD
+ANJkzlFZcUBGkTQBOEyDGKweQ6wV_EB-F_g6Rfi00NGuWZxwQ-UV8zV8PzgWP5hVElyKmuGVcr8B5zvP_eYiNNDLKD_qzHwwzdCiyv2NUugGZZgEYlTcxcn_
+io2pdqZDkNJyfwgmzOaW7H8LG91swVWLWBqVh440sFA2pANppm9wlDKXEoE7747nwFtYzMFGvgxalsggB_PqmAgdqu3WX8fOyLGY6if32dPQImaW0jYSzy3M
+7ohCB8fim8TiXV74X3kKlrCaCuSqv8FxTyDeW0mR-k3vaSY1RUUpOkxtWQ90qCU9UDfB_ug9M5erIGg6fmo_4ZQ4kuOCJqtuB-AuVsuCDhnj19hTiOtI9mCC
+6tywW1tk0Pcd0pO2-9i1OO9QNWnO4XP9G_6P0e1891_gBe4W-LohIFDJ-FRj7m
+}
+
+AWSEntityColoring(CloudHSM)
+!define CloudHSM(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, CloudHSM, CloudHSM)
+!define CloudHSM(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, CloudHSM, CloudHSM)
+!define CloudHSMParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, CloudHSM, CloudHSM)
+!define CloudHSMParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, CloudHSM, CloudHSM)

--- a/awslib/SecurityIdentityAndCompliance/Cognito.puml
+++ b/awslib/SecurityIdentityAndCompliance/Cognito.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Cognito [64x64/16z] {
+xTHRSeCm38NX8yd2Fkh-zzknubmP1vndlfTSu1ygTwAukLmkhHvfCKV5CMNC6CoF63Gc28rZYZOR7XRl-2aYod4_FmzRwm5z0-5QRz5LzriZl_HD0C2OVVnz
+wyNqJUyfA7NBjo5GaozzsfsNzukAsljktXlVv40AvXcWH8WqskBy8jatb37_Oc-e_Nt1zjlvDqWb7S8pVT6XZ9uEG038gUSR1hlrL4WnaLA0SgBdG_QgC8wh
+YY9Od1yepqyYPd7GRzwrSA_P2-E1-Nuh_D8hkes0PUznMlQjTenQM_RjOvr4jp1_PPTNNG6eSwL__Y-znwe0_7GVnP9754W-cGwKetxFdskVEliB2E5qipol
+SBf17D2TDdvyGwr_stG25-pK28hmdWCa96QuytOm5TWY38mLkNjA6Ndlss9lGO6FVBdFWPjWvBa6bkGER3Bo2eir5HeHR94KDHOPRFT-1HNQnXg3CfRH02rU
+5336BwgYqng_OcwcfylbyWy
+}
+
+AWSEntityColoring(Cognito)
+!define Cognito(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, Cognito, Cognito)
+!define Cognito(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, Cognito, Cognito)
+!define CognitoParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, Cognito, Cognito)
+!define CognitoParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, Cognito, Cognito)

--- a/awslib/SecurityIdentityAndCompliance/DirectoryService.puml
+++ b/awslib/SecurityIdentityAndCompliance/DirectoryService.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $DirectoryService [64x64/16z] {
+xT5fZiCW38RXpnYyvVxt7PbqRu7axoXFzoQlB8lu5owNYzjQZ2bXZJq67AXjfO27uz6sM6eQ0mB93v-By5dlbR10REE-Wie2WNpKUrvRgT1npx4aaCDzum_r
+N4_uvETwycIgvecN_VRHzoq8e9RV6BvD-o9la7q5QYLmxvlmhF-GlVP3zP8P8ytcwnkYntaRE7lHUd9_XkLNHpcmFyURx_aUPti3MTzV3_NQTlBe2M06ZlKR
+OqUtNW2Y_LMFp3UzsNj1_c_ceOHwUdy05ZTEmBftI_c-zn8F1XpTNmfAxqkygEi-f2QJAhrlyK8dlO9_xI_nmYQz4_H7J-NLf0zZ--gP2A-e3FlqrOT_Y9Zt
+9LQs1esH0cuB_Gn7h629D2PioUDVk5mkVm
+}
+
+AWSEntityColoring(DirectoryService)
+!define DirectoryService(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, DirectoryService, DirectoryService)
+!define DirectoryService(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, DirectoryService, DirectoryService)
+!define DirectoryServiceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, DirectoryService, DirectoryService)
+!define DirectoryServiceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, DirectoryService, DirectoryService)

--- a/awslib/SecurityIdentityAndCompliance/FirewallManager.puml
+++ b/awslib/SecurityIdentityAndCompliance/FirewallManager.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $FirewallManager [64x64/16z] {
+xPO5aiKe440V3Qrp__Ekf8OYmoxVIbRVo9Uq2qdzxVYV_yc8hC_n1iqgtStyVKi1VO0xNCY8UeUELJazXvhf443iZIWQMLMjrJVf7I9LH5-o8aHL8hK8omOW
+pmse6yrSqBhnDHYP7Qqd3AG6mDYIQha5TLBFgb3rslNh1Nsb7JAyGX-CPvq_jJeQhUtMTmGxs-wjZNIlCqQlYNVTGycgGEf8DfQA0ZrgfsF7-FYHNWVGtAMG
+E9Hkgqys1hGjNmV4J_rHnhsNve3jgzd1QoV_E1-1b6u61hRAV9vFqxY-gcn0t1kSKtPZq3FcVZJeUGaFEhAl9grg9mMWJsCWAMGPTc-P8Rwlvgftjoc63gIr
+B6Vyc9cnlEm8kKhNgrzomIWXrjZUl9_r4wbiQ9MZNuerR1qaSThGMBb8bKbSG_3bT21siHt5x_wNT022t4xNFyNHU_uNLwi2Y4vifdTkTLPilj5BNyg-hJlZ
+qRazlUPjensyubklutL0Pm9Zlb76T1dqcT21wNQMQBs9MPBbOsFvNQBhpNgVa4yFi63yBEEgsvCRa25JVn-LorQAr4Cw_TPY8RVfpAo7f31c8zSvSQZxmK1y
+6UDRVo_jSzAkljbF_qxBzvw0z9w_WR_x12PHWvXt5glto0wzOvNUGQBUnWLerp-hZ_0EoF3wc8Yilo__yp-_0W
+}
+
+AWSEntityColoring(FirewallManager)
+!define FirewallManager(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, FirewallManager, FirewallManager)
+!define FirewallManager(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, FirewallManager, FirewallManager)
+!define FirewallManagerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, FirewallManager, FirewallManager)
+!define FirewallManagerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, FirewallManager, FirewallManager)

--- a/awslib/SecurityIdentityAndCompliance/GuardDuty.puml
+++ b/awslib/SecurityIdentityAndCompliance/GuardDuty.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $GuardDuty [64x64/16z] {
+xPQ50Xmn24GVCSBa_x-taZlgtMnTvrpUCZ50lwV-wx_cU6f-5Hx6KnRw6XbZ2_jIuq_Utd-zEunAbpGRRDy1RKhgr9iu32z0qrO3YW-WtiAh0rGFFHLU0RnI
+R-0bv5O_6Eoivef2lODBaLXhCqr8vmjKwaRJTWua5TT3cE3AzzsWZ570UfgGmzKozhp03jscrj9isqJYNLSQ45BieA4bTot5jX9ImD2bdF9uTgqzX6r-oSis
+Ll5hlZ0ttvUyihNDhxx9IJc4hthmgb1wc4KlKBNvQmCXDJnvm_FiE9QyqwJu93xD32BvJIgVamymi_cPgJUghdar3CQd-Q7GYLTeV9xNcTVVpCTRlX391-NM
+_66qvpckgxsxVzggpCFwvVvv1dHAyWLN8Gxx9_Tl7gF2UF23aWSdz-_X_6ZGrmINcHpcwWpb-JcVNuLPQ40pQp0KHkXuVjD05fjX03Qo96NuO_xQHcgiyDuz
+LjGTzaR-wcI0A5YF_QuR9T8U_MR-ZWPOAGQqU3T_twqVinS3AtrUr8_h-gK87UhNDzJFRwhVv_x1id-mB-aVShFuk_sBvvRwflxf6_gtR-mVlxL__JtrN__r
+4W
+}
+
+AWSEntityColoring(GuardDuty)
+!define GuardDuty(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, GuardDuty, GuardDuty)
+!define GuardDuty(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, GuardDuty, GuardDuty)
+!define GuardDutyParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, GuardDuty, GuardDuty)
+!define GuardDutyParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, GuardDuty, GuardDuty)

--- a/awslib/SecurityIdentityAndCompliance/IAMAWSSTS.puml
+++ b/awslib/SecurityIdentityAndCompliance/IAMAWSSTS.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IAMAWSSTS [64x64/16z] {
+xPO7bjqW34KbGEtjVy4vm6yu-acCqsVkAQwN3X9zQ3xvXEistFt0Dj6hnmMOY0DQjr34z1jjqNw5pwNMMdRzPe5EMDtmc-E9rvC-swXOQcqocg6dV7OWX6d2
+2i3E-0PueIV5dmKmBJUPhu0lNqU3PFuOynDxr3T-mNXOu9Zl6W3dMmzhxXjGamv2fmuuTns8claCs9n-rvT1S202WDnkLD1ll1tzDget76i8TDfe-gX2C935
+5z9-Aq2OBmEXPgQzF1QpAPbP0BhMxt2YG9HHWz2tAG4Ol_e1epB5SP-pherzVwwMhFqyfak-ltCGvNNy3BVnKrl6JpG5YFfs_h3ENqwZnI-tzUCHTbW_APAi
+t_BL1gk0SagsVvpI_PEHxr-ZPF_-g4yE61_NoDdpgp5DM09mFdz-QgkrpcFS-Epv7NWIxNpyu6VyQ9VY5__c-BdlNyyVS06-c3zTpjy-D9zyyWK
+}
+
+AWSEntityColoring(IAMAWSSTS)
+!define IAMAWSSTS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMAWSSTS, IAMAWSSTS)
+!define IAMAWSSTS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMAWSSTS, IAMAWSSTS)
+!define IAMAWSSTSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMAWSSTS, IAMAWSSTS)
+!define IAMAWSSTSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMAWSSTS, IAMAWSSTS)

--- a/awslib/SecurityIdentityAndCompliance/IAMAWSSTSAlternate.puml
+++ b/awslib/SecurityIdentityAndCompliance/IAMAWSSTSAlternate.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IAMAWSSTSAlternate [64x64/16z] {
+xTS55XuX30JWX0ZCtF--jLGeMmclBlExVEi93_b-qNO-fGCNYIVdLUBq8CAR2H07Lp2adI3quLqUqM4sL1xnJ_auSIoG95PeO_s7r-IMr4jl88bqCq-GX5tu
+ukiziKN2BhoHzL7TjG1fRQyWlHRqZZcBj7oI8Pilmcnw9PUSNXQfFH-53czazFmYvEa5N2slO7xA9w4TF_YX5CRcdHmTRsNqTNppzNtN3xp9uVlRFrZ1iVtT
+uwVkyJgkn_5hdxypuBgvViuO6JVNxvb5watz70aoh-ktSjPlltziWBIVrx_k--Utz-zl7p-wurVVL_uv_z-hwWEfThqcI8Ju0jRhnnG9a9WzFvdkcMAP2SxC
+aC1qZvuVdF8-ixeUbbHQFa-lVL_lzLZ_H8wkbx70QHzvdUJoVl-RPEvUn99OslEr3RRvsWP4suiX3Y_AsVS1FxqnErvNkYUNRlxrLm6CbfyWCRN-Mgy9adDy
+G_sewe-jN-zx_zxhlv-_VVlyyTldhzy-V_xsl0G
+}
+
+AWSEntityColoring(IAMAWSSTSAlternate)
+!define IAMAWSSTSAlternate(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMAWSSTSAlternate, IAMAWSSTSAlternate)
+!define IAMAWSSTSAlternate(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMAWSSTSAlternate, IAMAWSSTSAlternate)
+!define IAMAWSSTSAlternateParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMAWSSTSAlternate, IAMAWSSTSAlternate)
+!define IAMAWSSTSAlternateParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMAWSSTSAlternate, IAMAWSSTSAlternate)

--- a/awslib/SecurityIdentityAndCompliance/IAMAddon.puml
+++ b/awslib/SecurityIdentityAndCompliance/IAMAddon.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IAMAddon [64x64/16z] {
+xPK7TiGW44Cpb87H_GyS8lUEpSkh_5tRD8aEFwJJwNIS3y4x-IRsQY2MexnNPwmmVUSWYaAEtZaVs0uBR-GPWBfjO-8hUQPw9XYWjVeYJuUfC23C4Pb39tAb
+_CJ0nj9n3YLaEIjuDjg1jfHZD4Z0te29VWoUPL1E0yeF1c98_8OOmoRB0LcrYCmhOCfHpapKi6wc7mTyF-i9SzKwLIqPH9T29dI16JZcCzx-66PMIoX92KWo
+5cI4avVO2KIHYDrGIc49BY5sGyRkAwkFur27wYN7EH4g5RQurP40Qz47wh-qdtY3-PhnEuVResh-pW4GQzVFELgtVg-8bVldbFhzUqhz-T5uVZMUdutdT-Fz
+qNX_jTsV_tr_TpgTpYy
+}
+
+AWSEntityColoring(IAMAddon)
+!define IAMAddon(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMAddon, IAMAddon)
+!define IAMAddon(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMAddon, IAMAddon)
+!define IAMAddonParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMAddon, IAMAddon)
+!define IAMAddonParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMAddon, IAMAddon)

--- a/awslib/SecurityIdentityAndCompliance/IAMDataEncryptionKey.puml
+++ b/awslib/SecurityIdentityAndCompliance/IAMDataEncryptionKey.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IAMDataEncryptionKey [64x64/16z] {
+nTS5hkmm341Hnv3OT_yB_gfIJHzKyvfykeB1KwR8dwizxav7BHJVEKl5LrzK-2pyXwAeBxmL8OyBgdtpVhxpaJcwlVD-v-FSZCnIb-O_VKkWScH1-RfFI8-H
+tJfWgpvWj02evb1jpRUYca8bT0c8DU_Wuc2If4YHQtvGxV2XTT00NV0-vzgAym0ri4K_HCGA6BBiGmOvZy0ud3Zeak-VmQ3QabSOycf-Ml6IuAzl4dJHQxsE
+6KleikZ5W0eH7S2GPIzMG9E3TzdmqiRqfRBbnK_VDdqSlaCsUMKHtbQy3AxDvyNHQ6i-PJOuAttiurh-3XNQR33H8tzjFttDjqD_xWcPwZg9Swed_ZgGYvGp
+1tle9Q3Ex_jrGk8FlHNuzVsiGJpqu-IYRFfy6Ryy_iYRrk6RcZbqjTdvNdyyVsgk_U0-VUkbSvxyoNtstakSvqwIzgt-inTrcNx8j-o1FxkyZH5jtmT0jbsl
+K0Mnwnsi5Rdh3SAAiUjRSUIxNgo0BjjUj2RVzQtmt_JnFxsq9jj-jkptpz_Bt_NS3suhVJj-kMfsczwFN_R7JzVuxM5Hr1yTFwwFN__m-7c_Nm
+}
+
+AWSEntityColoring(IAMDataEncryptionKey)
+!define IAMDataEncryptionKey(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMDataEncryptionKey, IAMDataEncryptionKey)
+!define IAMDataEncryptionKey(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMDataEncryptionKey, IAMDataEncryptionKey)
+!define IAMDataEncryptionKeyParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMDataEncryptionKey, IAMDataEncryptionKey)
+!define IAMDataEncryptionKeyParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMDataEncryptionKey, IAMDataEncryptionKey)

--- a/awslib/SecurityIdentityAndCompliance/IAMEncryptedData.puml
+++ b/awslib/SecurityIdentityAndCompliance/IAMEncryptedData.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IAMEncryptedData [64x64/16z] {
+pTLNeXin24PXa40CP__xJK_SCQEqUvxSlbzwyiYVI-kaplDDKNFULWreacv51n2bTwbQ055vAtsG1yJs-S6XnK37Ip7GyiL0onS3BLyCj7mnqFB5GCiN0mtF
+yQC4ekNdYbZpkqzkqlVUVf0q4HdhggFZrpUR04jkyuPVaAuYwWb-sa_88TyQ2VEiFs1SjeYJVjoG03tdxURA4-Ovxp1kRcEdlTvuF-lp0ta5QtlpBntWbnQ4
+VyaQtdXTsdll57dBp_6qsVKgJzFpNkVKfpvRtXFIjxtnBTlrIPebkUaL_F9-ouT8RFdBCmD2Dlr8W1oxNaP03DdsCk0Bt_SJvd_rcR_bTItTyvV-lH_F_UZw
+V57BMpR-VmklArwsjFIDFh2tlhU_SNwwDVDyyEASoX_lb2ToUPAsap_NPm
+}
+
+AWSEntityColoring(IAMEncryptedData)
+!define IAMEncryptedData(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMEncryptedData, IAMEncryptedData)
+!define IAMEncryptedData(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMEncryptedData, IAMEncryptedData)
+!define IAMEncryptedDataParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMEncryptedData, IAMEncryptedData)
+!define IAMEncryptedDataParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMEncryptedData, IAMEncryptedData)

--- a/awslib/SecurityIdentityAndCompliance/IAMLongtermSecurityCredential.puml
+++ b/awslib/SecurityIdentityAndCompliance/IAMLongtermSecurityCredential.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IAMLongtermSecurityCredential [64x64/16z] {
+xPQ9UXiX38HN0btp_W_S8BmktnhiulHk_voi9MKq2EBZv_4VAg9cMkczR0rqmif-UerCZSYVkgj10RWmjIwi_KwxwL7lAtOWQ4Sy47ofvnlMHQQF651trDT9
+IPg5neHHB5la_ibKW61Ao1bG0Wrf0cpgaqsGGJRC0F1XY6jw0QAysWZ9E3tqqG1lpvzn9ZdiaCTyoIbPan6SNKppqpvXvcoLEL_dnjrzm4jne6R_a_uIwKP7
+twVH5KNYnn7J2Jptfw3d2H8R1gGjgNaeyqkYrbiDxJLgTO37WBQmyzbAX7JjmRbV_j1eQbeNaEvdFpTstTZouW3JJHjJNthsVAV6nl4xvpRaLg4O9kPn_Q0i
+HAK2XAc81Hx7Z2IGXArqzOYEqlerE2yaLFFumEKIGDQof31nrS0pQuWc3VhO3oaslTNBRLu3AFqtfLvIZZKbqw_3aQxqL-ZvjU28gs5odruujVGd1Kh6ihZ9
+LnM1S0UYVGNWxSkjBhgdVc067NAkhMlWm4g4mtCwFOOZGURkngsyUnjyDcy1HfF1rbk_-cBVs2V_Tgcb6k8izOmyXUly_FKf1kX2ln9R7viEJSX1M_YN-BtL
+c83fdQC0fpMZkuefmHDNkoT5f8nDXKpWXIbb_UWr_A1BTjxSP7YKovgF3NIyqOgVvROK84nAgUhOJyy_sjb_RrehPmKBD5o_jNMkDOS-v7nG2jD6qm7AKQd7
+MrJ4xv7lzXRUy_49A2_8jz7Za_pd2m
+}
+
+AWSEntityColoring(IAMLongtermSecurityCredential)
+!define IAMLongtermSecurityCredential(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMLongtermSecurityCredential, IAMLongtermSecurityCredential)
+!define IAMLongtermSecurityCredential(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMLongtermSecurityCredential, IAMLongtermSecurityCredential)
+!define IAMLongtermSecurityCredentialParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMLongtermSecurityCredential, IAMLongtermSecurityCredential)
+!define IAMLongtermSecurityCredentialParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMLongtermSecurityCredential, IAMLongtermSecurityCredential)

--- a/awslib/SecurityIdentityAndCompliance/IAMMFAToken.puml
+++ b/awslib/SecurityIdentityAndCompliance/IAMMFAToken.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IAMMFAToken [64x64/16z] {
+xPTPckCW38Gj48Yg-nzuOXCbPhmnew_VkdeDuXSIEyjFwLUIjRoaMVw3LGC_Wka_-SZ6WopFqjfwcqNJ9YqzbgOpT6eRF2OjUNFHqYDUGAASP2lTSa-BaQno
+OQmaJUxmHYBVz2l89dUuc-ThZ4PR7cJN3kmCdwzLoBPCg97bRDn1o0ml8DAfspmvkyy2LR8kawga7fhtwESoQCUOoZAjSiZLlFdP06mie1VCoSYXENq7b7B-
+P9JJkcwxKY_v6aaz2z_WvGhKRS5WLUinKYuIy8-LX9TmvKchBvNUQIox1iVqY_FKdj2Rnsw4wtVOYiSofbE9Je1uyrujiGcOnWxxVagTHp7echrLZEqNrDNy
+yKOzvzEAWEdDixwaorRaxWvysV5BWofiSVxT_NdB7SmVlbpmUKMIyz0-_1LLH0prZDSzlzWsz6F-0dP17l9_sSp4UQ-lXAq2yu7tyNE-Q-Gzy0eRns-SF_Ot
+ZywB1-WE2obdytVFbvNlcxMY-Io4-lmzM_uxf-A_nd8vhXzFPrwPrEZ-4To_eljdSF-Ed1z6Ql3yYfwVmVCxU7-8tb-2zwVW_IruVupUN-Ftv_ZzFVv-YBzV
+uk-dk7xr1m
+}
+
+AWSEntityColoring(IAMMFAToken)
+!define IAMMFAToken(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMMFAToken, IAMMFAToken)
+!define IAMMFAToken(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMMFAToken, IAMMFAToken)
+!define IAMMFATokenParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMMFAToken, IAMMFAToken)
+!define IAMMFATokenParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMMFAToken, IAMMFAToken)

--- a/awslib/SecurityIdentityAndCompliance/IAMPermissions.puml
+++ b/awslib/SecurityIdentityAndCompliance/IAMPermissions.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IAMPermissions [64x64/16z] {
+xTS7TWCn20HGeu0GS_y3vw7qDcj3Ui8hBhjVlPxUB-JiU4rRN13sakEYU95084pF30l4Coxn8aaIXf0NNi_tkdq_V-wrvpsyunrOKlMSSyyvzwQ47ti3b7Fk
+5O0oplrj0fHplnFWdFkJSivzXiQIrlYNxlpv9NwiqV4Z45BsoM6b_3ddNXW_zhASy6C_0yxuSVw0KyxzJc1HplrEW7FkTmBM6RyozSVEltzlTsU6wSNzo-_U
+cCNnx_i5n5Lr_Bia7_Nn7vHpdmampdt61B3g_M_8yA9F7fgDMFF9nsw3wlY9STk8jV6J_EvBPVpSAHcVD_z-_lsbVd-htn_xzzV-_RaVrm
+}
+
+AWSEntityColoring(IAMPermissions)
+!define IAMPermissions(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMPermissions, IAMPermissions)
+!define IAMPermissions(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMPermissions, IAMPermissions)
+!define IAMPermissionsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMPermissions, IAMPermissions)
+!define IAMPermissionsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMPermissions, IAMPermissions)

--- a/awslib/SecurityIdentityAndCompliance/IAMResource.puml
+++ b/awslib/SecurityIdentityAndCompliance/IAMResource.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IAMResource [64x64/16z] {
+xTK5ejim54JH4JmQxt-_jS8SMMq_weHZNpEGdAPfijp9-8W3gGlWV40XZ0uKwEDUsKNVzIPLB4PxosYIZlK653MhW8pqaOwB0VX0RoZS4zI1_ZpGlqXlvI18
+BRwbNxWI77Zx_heF5uZl6Ke4oTWxVEVBFkE6Rrl_X7efjTwbSJ9q_OpNVUPgON1fdtM_paqb0olhw3qZ6LUjPrZZ9DjdTFGPcbF4uoj5Hv_Ael1Z7tuIVNr1
+JIdEwtzI-leeICuGoQstUg9zFHsoq871zQT1o30hWpqZoBR-c_labyhc_Y-FVvLwHM9R_q97Fth_6hz_Zj-_fscQ_W
+}
+
+AWSEntityColoring(IAMResource)
+!define IAMResource(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMResource, IAMResource)
+!define IAMResource(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMResource, IAMResource)
+!define IAMResourceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMResource, IAMResource)
+!define IAMResourceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMResource, IAMResource)

--- a/awslib/SecurityIdentityAndCompliance/IAMRole.puml
+++ b/awslib/SecurityIdentityAndCompliance/IAMRole.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IAMRole [64x64/16z] {
+xLNNmlCw20iR-luFVE9mOfpzzUfVKNTjWH0Uqs-95ozU08gwHuIRCdxB9elFY33w8hLuajnCpJn3EV-Gph4a58GgnNuS0Qon1GwQMbI3ny9ZPZDCGDn029i8
+yM23j2J45eDpl8R09esVwBwI2zrykG_0bLG86qWocbDvUnc0UZeOdSkreB3wS-K1HBBnEA9D0guQuxmBjYW_LuUUtgS7TbdyTN-q3ywXpcOjwkcsDu6BblZu
+HNgvP8-Lww47gQh2NfPW_nljfxt3MtfLhiUfsbhyGE-Lut5kFAOVA_Tz0NXQFG0WrWwiocMVZ3SR0v15pIFwRi2SrRQm2aoqxu2EyjkiFK9nilKxmAxLRIYc
+3J_SJKMOMIpZUGyclE-WZ-MZCG5ix94aAm3qNRhZsqFlD58qhYfWREmflzaFCFGe6cOPX5AxE4D_VEmJSlS_N3c7VCZCdKzM5YSvZy_ZzGDgglEBfkBZmdP2
+ptcwagFPtw1v_pYNlk9p7Q_iGph6iHgshY-hGxBqhvc1rRSwhNT0IH5cdhRaMG3jgbfImNfKsyKk6lNLGQdBrmNFboogpp1JgNkDVUVorq3MrXSXdFuTl7Zn
+uZy
+}
+
+AWSEntityColoring(IAMRole)
+!define IAMRole(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMRole, IAMRole)
+!define IAMRole(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMRole, IAMRole)
+!define IAMRoleParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMRole, IAMRole)
+!define IAMRoleParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMRole, IAMRole)

--- a/awslib/SecurityIdentityAndCompliance/IAMTemporarySecurityCredential.puml
+++ b/awslib/SecurityIdentityAndCompliance/IAMTemporarySecurityCredential.puml
@@ -1,0 +1,18 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $IAMTemporarySecurityCredential [64x64/16z] {
+rPO9qXmX28K7GRRx7pWbXLFOmooTsf8l-NSV0ihhVlnF0B6eo1n_fHvidYZTby-bDbMDA08tvR94k5GGYTYuApTyR41k1fZkUcJCxdgZyUQMyX9WzciRs9tg
+YZva8DPGaqKrM-T79MPDgyMUIya3NWb8roUR3LGwuSpcZWznkyhnwx7Co1hD-S6l3T2Ls4TIf2wFMVIbkFbjVumgYhv0gpn4Z7b1Z5eGrpV9MBqaTQTIVm4j
+snkv6EqJmVE0LkjB_mj3VJ790tgkhtDe7BtkInsOIT2CBuOeaK02OqGBe_oUOKkUDK1KhTT6VZogOKRHJrF8gizYAGA_1-3ygkuwwkvHKMLC4HKcwEEfkwLn
+0caSJONK4vFH1f0mJc5MYwPU_bZCqVfpGVMDCLpRRJmY4agSTWkocfbArbZarO_HCa3B8Usd3ZIl5eXYH5I5ZoF5hLs2HfyY8OLltWfmt0w6eT6glCqwe0sH
+FaXgfbXA2cHwm1AXf3LSDzXJUN59YUAYF2b_Fp6Ny3rUCU0PO9icvbUQKxalFwnmnARpSHTO8d7DK5zV7rGcdlk7tg0uIiiGyyGclDIlDCrz51Dw4gVBTKBS
+gFO_srlk4NgIumIQhmynw9fBYwEp7NCdfnxiOXyM0NO3TBjYsLvg_hedYbHXZnprRm8vGEES4DaR6-oPjLm2ErRDdjktZ_BCeeoPpPhd4qHVdxbLdvkC4a0f
+4-ENQTKCL_LvMwgrcJABlhuSZhAmw8_d7qppZUBBW6Edp-Ul24O4aZ17hkg0oc5Gw6iiQEswCcEi1o_qLM-DApJxKnPuNuzHFrfIwy_vXGyy-m_9CRZX7_Q9
+KS-_WXdM_2DZtxzAlN_87u7sLRdU_-_COssPlr_H6g3C_pUg8IXU_US6f_zP3FmjhlwBDxIj_z-cFd_-7Vu
+}
+
+AWSEntityColoring(IAMTemporarySecurityCredential)
+!define IAMTemporarySecurityCredential(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMTemporarySecurityCredential, IAMTemporarySecurityCredential)
+!define IAMTemporarySecurityCredential(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMTemporarySecurityCredential, IAMTemporarySecurityCredential)
+!define IAMTemporarySecurityCredentialParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMTemporarySecurityCredential, IAMTemporarySecurityCredential)
+!define IAMTemporarySecurityCredentialParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMTemporarySecurityCredential, IAMTemporarySecurityCredential)

--- a/awslib/SecurityIdentityAndCompliance/Inspector.puml
+++ b/awslib/SecurityIdentityAndCompliance/Inspector.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Inspector [64x64/16z] {
+xPK5iiCy38HNOC7s_kVzGSwamyxhu8ElND7AScB-GFxueokpglaHwOf1BBwU8dGYtKq5W1U_GYcWqHowN835vmIWkMExvsC1ri_3frg72I3gkHLfFmvFiXq0
+H0IN67kOe2Oy1V3iaQ5RlC7u0CKQ3Jx1opoP0css89weLpAnNLi085uzuWlIFD22sfMQfCCgW17lf9-dcB3jh4fIq7mvyifR41umvEZSoo2e-MlwCb9HH_dD
+XKKsb5pGS4ZpiiIfWOBogY8oRGEIOt842tPgtzaGydhdklTjRDDfUcjheCD9ll9MN33sY3h66qCn4mz7lEDd88_gAqoX1aoQv_MdVn5MiGtG28MzKpVqyVep
+jxCYkhctKHuleJr_tqkVkouWQWjZESn_fjn0pzVSCaG50Foy_oxH3hjsxBMZkmEewUw48jaoErZWLJunFPU38SWd0WfOP8riAR9c2WauZnXyNAt8S0--EW0R
+FNA-2r_YIm6BwkvS0gpTGZ-v2-UuCmGN8wMdXQS9HcOkKrMF8fa2kzgJue4II3JVb05O71n87cW7n7DIT8K1ikx5NpYFSLU4gAe0aDKikQ-aSuBx-BiFG4w2
+VX-GJ-Z_8I_UYvypuo_Jz-8NKFo0Eu4Z-07tzDQ7yTVqMb3yZ03C1SvFIG4c_6Cgcp-5F_xu5m
+}
+
+AWSEntityColoring(Inspector)
+!define Inspector(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, Inspector, Inspector)
+!define Inspector(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, Inspector, Inspector)
+!define InspectorParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, Inspector, Inspector)
+!define InspectorParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, Inspector, Inspector)

--- a/awslib/SecurityIdentityAndCompliance/InspectorAgent.puml
+++ b/awslib/SecurityIdentityAndCompliance/InspectorAgent.puml
@@ -1,0 +1,19 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $InspectorAgent [64x64/16z] {
+tLPPTiGm22kRWTp_m8sZCQbVwP9-LZ-JnGWX4pDl_n34QYTK-0_1F2AFXNIbHz4Q1r38mR-FJYGruHEY0spZTnh8vs8Nh0RO9aNgBy9b9c_4ocJm7oNOkIfu
+RO2eAeIiL_Hp-42m-jg0688gpWVvBO6Ug_MA7WXUY8k1ObFGrgwr0ncc8cBGuVGYyA-TFnVQl1WpskZczVb0NWJM1YFCrmOYUdTVu45o7yulTtpcQiX1O7q5
+Y5Cid1ce19WojWRq0PukVKob1mHwQSWCAAW5tbOFte0AWbpmZlcBL_Zf7CWZqG6E1ZZcFVBffb3RBP0h3SX9_T9ZOcQET2LnRdEqdIipnKnlUVXL0L0zon3d
+JHVZuMHHD59M-zS7DTNbArLJVjpKZDWqPXcJZAi0XYDDx_gL873x8OgyIj0haXi32VQ1vVOASBnSaPIuNTZU-5PgYKlgLdqTNqgMRZVJFdxN7vkV9M2wcOZ7
+sjw_Kaq1oSLs8gOEwVo3yxL1Yk6Zs-uoKxz_vJ6j3Sgzx_0DWIOhITk_T7qYdkdcwwn4XDxVo5xQdi8d3J4gEa8MTxuqSdq56ufLfe2oS9xzDcOvWlGEDkr7
+Xo67tPCGmEIZ14rsyj5a-BdfnJ_Cxa25Edyw36JM6hIGR5nYOkFl130AgH8aKs1l790zrYXf7GZyblCyBkrawtFMygEV05xZpxMEBRlkry4Y0xtPLW1l6Bw5
+3nkUE8hM1BTLOGC60Pmlr32LN0AFTXEm8XXSveanFeIMFmX7XTuhW5Q09jORN-6Lg6iZTAr-uXqeHEe121hOfTeW6fnwkH4EuojHdUjzhXYcQkPHUmxZYm1w
+MeOyDgoATkCTh1r8wWzqfclft8slJkf1BC9CdtROwn4AUeGolWZa6S5klAAUnmIo3Vw7WF5L0JyCB-DhS3n66IyOb0-1Jd9XImXv3aLxbVsF8L47qnyXPafl
+_m7l
+}
+
+AWSEntityColoring(InspectorAgent)
+!define InspectorAgent(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, InspectorAgent, InspectorAgent)
+!define InspectorAgent(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, InspectorAgent, InspectorAgent)
+!define InspectorAgentParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, InspectorAgent, InspectorAgent)
+!define InspectorAgentParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, InspectorAgent, InspectorAgent)

--- a/awslib/SecurityIdentityAndCompliance/KeyManagementService.puml
+++ b/awslib/SecurityIdentityAndCompliance/KeyManagementService.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $KeyManagementService [64x64/16z] {
+xP57egGm34HBacMvwj__l9FSBEXes4pYTGJqhAG_Z8iBKgTX3pFpLjGPqW0p0s1TXw43EIYn6X0yhWUt_eSZT8n0arGE-90uBzVf24a5kCCeqL1QXuOXoT6b
+d9N0jKxzSWYJn6awXfPfirepIcFEBj6rZ8Fpc1ZbKooqmpuTmCqR9tofjrOwxiVZi3fIooJwiv6EUc3e6GEkFOHHZaVoHGDTEnfIgdm0_g80srLMCEePBtpb
+xe02Ii_WAry996_5DA3heAzki9ojmqg7VR719158VecQaAk-PDFtMKoNn022Ypwn-Hrme4I76NpH3yGjn31KS7KqAL1BVi0vGsQKcHAbhuw-uYUCMuYZr14g
+1Ebh-OSXjv0231XI042izJyCVGkfi1YIcEwfDLy3zZPaVN-SIFjVllNfQ3U_uISf6W0ObVX9c_uxVVezVb9Y_8Ag-4d_iB-55jVolsAr_-wlM9j_sdDWLczy
+stpn5T8x7vG4rqaIJkLvNmtHO4EdSS2fyz23-X-ukFWE
+}
+
+AWSEntityColoring(KeyManagementService)
+!define KeyManagementService(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, KeyManagementService, KeyManagementService)
+!define KeyManagementService(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, KeyManagementService, KeyManagementService)
+!define KeyManagementServiceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, KeyManagementService, KeyManagementService)
+!define KeyManagementServiceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, KeyManagementService, KeyManagementService)

--- a/awslib/SecurityIdentityAndCompliance/Macie.puml
+++ b/awslib/SecurityIdentityAndCompliance/Macie.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Macie [64x64/16z] {
+xP85bZGn20OB8WJc_kVz9Sthh6HzdwV6fU6Jn2znE1mE1xUVNQxKsDAbniTKOAl0W18VOQWXlj4bME531O8zAcsdgprS-22SHfshHjoOfQw864lQ5hz-xvIr
+5zGYzDhSte-WqEUhOhSWhT3kYOgz6zwhD-9X0epxYzYpXYyX6PWhz9LZx5YsVGLLgJa6iZe7ZnqPkrVfkMPEoPr3KByhUgSx1KOEctvoZ1V4rfhjUeyXr8vU
+PhAirHqjRUxNjuS9BKBfywfqskyoXE9l2N0HDsYNtlbCUw5tA3eYEdMxlaDV7UMmx22fqAVJZViAjexnx6pa2LfqgD7ehxi76KjCAJIxnkJGvK4s5HQkVXC5
+ZQYel3fkNW5zjL_RyorpMc5tMatpsu-n4JiyViRXS3WS_W8
+}
+
+AWSEntityColoring(Macie)
+!define Macie(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, Macie, Macie)
+!define Macie(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, Macie, Macie)
+!define MacieParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, Macie, Macie)
+!define MacieParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, Macie, Macie)

--- a/awslib/SecurityIdentityAndCompliance/ResourceAccessManager.puml
+++ b/awslib/SecurityIdentityAndCompliance/ResourceAccessManager.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ResourceAccessManager [64x64/16z] {
+xTM5hgr038NXrKwTzt_V6p9xWACqHAwTFxAb-N2fFwAVVagtPfwVUKSx_ymRn5e9x7DlMpNQx4jVgynwNzRgtYTJVfYElXTWl1y2qlKEObXTKi0PqlD9y03o
+oYcs94ZB3-XEHgq457Evsl06tZyOUWmereRPhGyWzi-Sd_F2zENrrlFhCjeSl2Pp0K6GklCAoAlh6QFO9h_pZ4jypiW8MlS-ur9UBu39R_oNAMazzREjxNqG
+3Q-Zi5Lsl014rpk8iTA6Lv1dEaDERxwd7H-WV5riSVZv6HrlvsdMmsVVAtojJHxvDVLdtjU17_0dVjtu2gfttbi-22p2e3WzpI0DNpa0O4Ijb6d6tdp-ksTj
+zKaDFmjJYyS-67CVdda7Xhan44zy4cpRNk-DNFMzGjDytifde-qPJlFXcp9M16dw10kKt-rx4hpl8OIiQuvRJxodnN2UpweSpAuyN1cmKjwZpttGR9H2ocCU
+oIEoSdeLzMavc-_9RRxuqdcaa-Gvpxeh2AIc37WzAWVsEEffwUPHVtO__VGB
+}
+
+AWSEntityColoring(ResourceAccessManager)
+!define ResourceAccessManager(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, ResourceAccessManager, ResourceAccessManager)
+!define ResourceAccessManager(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, ResourceAccessManager, ResourceAccessManager)
+!define ResourceAccessManagerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, ResourceAccessManager, ResourceAccessManager)
+!define ResourceAccessManagerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, ResourceAccessManager, ResourceAccessManager)

--- a/awslib/SecurityIdentityAndCompliance/SecIdentityAndCompliance.puml
+++ b/awslib/SecurityIdentityAndCompliance/SecIdentityAndCompliance.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SecIdentityAndCompliance [64x64/16z] {
+xTO7pjum20PWXWs6tF--DHPIHXT9T_-ytyZYiK4pyAVo1Y6F22ntqm5ezxBvpTZP-o_mhpSX4dlgbG4uVlh0MqV0Rll97M-nTLFVt6p-QOichEf7Go2PCCwm
+ZLX62EAiu8spSfcPM2jNPVk-7z3t9fpPzwqxZ8AF8aqJFjVIUQnwXTLp-fn5x_ZGwRF-O_ZNlruV-opSlkArvYLwk7hDiRxh7LlyhhwXUyUAPuhgtU-hDlA2
+5x0OuEpNwDWgVbcYioTQ3ohUYMC_ENe9si5ANgAEmNPl40TiNl8MXOPewVDSO9HyLWv4zOrvSqKSkMhDEyL-Ha129FEmEa4hUyD5b140MNscWNhPH_DZLSsi
+8mUl-sY-3S-C1gXUzHb1GEupVFlz8wEDS8QQsgzzVtjzjxiP9_yWFyy3yPFGlYq-2lmF-GG
+}
+
+AWSEntityColoring(SecIdentityAndCompliance)
+!define SecIdentityAndCompliance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, SecIdentityAndCompliance, SecIdentityAndCompliance)
+!define SecIdentityAndCompliance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, SecIdentityAndCompliance, SecIdentityAndCompliance)
+!define SecIdentityAndComplianceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, SecIdentityAndCompliance, SecIdentityAndCompliance)
+!define SecIdentityAndComplianceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, SecIdentityAndCompliance, SecIdentityAndCompliance)

--- a/awslib/SecurityIdentityAndCompliance/SecretsManager.puml
+++ b/awslib/SecurityIdentityAndCompliance/SecretsManager.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SecretsManager [64x64/16z] {
+xPO5jYGn24KV48Bq_jSxaXPQYvmvClRlbzRxAa1P_hbyyOLPRZCaNo3QzmMF0MuwWA7cln3WohZ1Uei8smbmMTOq8fihIVpwbJuW1i0prXihC2O38zONEDeI
+36JvX16iz2uWyeKelGruJvI-6J25MURjrOOUNW7EMB3d8ZJIcuG1Mm6H6GJn21VGJJACGzsnlYlmdr6Q2oqf27vSkrsh2AAuIlSBaCFDStMYdZCYwxaVLJyx
+VnvrW12T7w23vKiMu5CkJemiv7C14thRp5JGl43GULk1Odxo5LQTU6BK1FHp-xoUwlo9sNhGylrJ0uq0aeewrVdpL98GGBRZPsOmm97Xi_Dhvx_t5QhG4p_M
+Fzh-bMy6JHtIzw_cLxu3W5VzpVmSyZGAN_fWBb_WtVvRVX8jfUeFK7_yb2_oqubgsiHeZz-Q_wBgxuxVPDZL7wh5kFe6pWFiUefLFA4PaHbh0_q9BCEUY23f
+Jb_BovYHRuYwCXqZqER2qkWSsGGq-i7rKxPqiEKJncW2wWeR0eZTtp-O019LGZT-Ou1acXEvJI60RQS7DJeRX1iqRBU9HVWS0iYO7fjJsBj_bB7lc-MVonTV
+V0S
+}
+
+AWSEntityColoring(SecretsManager)
+!define SecretsManager(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, SecretsManager, SecretsManager)
+!define SecretsManager(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, SecretsManager, SecretsManager)
+!define SecretsManagerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, SecretsManager, SecretsManager)
+!define SecretsManagerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, SecretsManager, SecretsManager)

--- a/awslib/SecurityIdentityAndCompliance/SecurityHub.puml
+++ b/awslib/SecurityIdentityAndCompliance/SecurityHub.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SecurityHub [64x64/16z] {
+xPO5jYH120G3AMpkVzwLRxNIe-kI8wtH0ho4-NtrN_zLzIrqAcW-Z1UOGJtA6p4JsAEyq3EDFiehDLEFyu54274xqQwMUzC1V6_NMda9B_a2IAJsLW1eNmhu
+wX9oxn7PwmMHXi-nNaET-36_YDDJKcxbSocevppfvDHJKlf2mc9QiRVYHGIGUDcscK8kr3i8WDQCWsLdL3fOfmAeSJ6TPQAh7PQXDMaWgye0BDj0Oguh1AoM
+WBg0XK4-HQXwRj0fq0IykZiKJ8axAp-nhYLeTgA5zEruOPEinPEaHCV9MyXTASbImfw-efFuxRnHyyIFquiKlSy6bFwI7v6VnE_dDzfftyz_N_nyiPmKAUwC
+Ns7JI0k2i18_tPM_KNACJ00RfGhw9h9xPahHAQHwhMp7Ha7hglzD6LW523e15h44RSCC_9h_bQ0A46refGBWQMXFSCt_nbap2wcdTImYrWe7woV_kk9_eoyD
+wz2_PllVjOPrw9yJL_qlq4mbZlsxzQh_6O3DCJyt-5-wvnpthzlzxxX_Fjw_VytyiEUNNpC_xVdjLyoFUtxzVVLV__KU
+}
+
+AWSEntityColoring(SecurityHub)
+!define SecurityHub(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, SecurityHub, SecurityHub)
+!define SecurityHub(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, SecurityHub, SecurityHub)
+!define SecurityHubParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, SecurityHub, SecurityHub)
+!define SecurityHubParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, SecurityHub, SecurityHub)

--- a/awslib/SecurityIdentityAndCompliance/Shield.puml
+++ b/awslib/SecurityIdentityAndCompliance/Shield.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Shield [64x64/16z] {
+xPQ7ZgKm34MlxRZk___lyaAMZ8ODq_iSIK0idUJQhzRRyCilaI-GKnaGo-V99W2ORXUB9-Tk1B1kNYXZF3wMhb0xZEKMwzpYkJyFAOm1q8DR-9uxZnu0jhox
+yRNUSyyU1CmzpRzie4lVqExsK8bMeJIJ4p_WMrNC7gBlbowZZyVuEMVV_P6S0Nsaprar_JcRzaXVwdz-VBJ_w__we9VvBC_tsLVQjJy9KxMuz7Nj6wDpaSFN
+VWeWQgOCI2xykBc4FFl9u1X51YysI71LWvzzcKdcuWmZoo4dty3zhZh2B6RGpoR4VPz72JJc9Ai1ReAYJV-OIuVuoBaO06qNGXp-yRfMHWHek-ISqGc17zrE
+N_Vgm6y5MpN0Oy0dFqG4s2vnuHV3UmVjb7_sVv6_79IRI93e_f_DZi3mYCOTMGiQsluIGzmXeGGzNZ_YwzTlDxLd9WnQRC8kPlOh8LRwRBvSHQHPLmIIymIq
+kY3u_cSqisRD2LANP1j_5pePIfHrgpNLHfYdBt46GD9Q4oO0BRUQe2Fnw3-17Jh-mgQRUTPZoRYHzPRyyijV
+}
+
+AWSEntityColoring(Shield)
+!define Shield(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, Shield, Shield)
+!define Shield(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, Shield, Shield)
+!define ShieldParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, Shield, Shield)
+!define ShieldParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, Shield, Shield)

--- a/awslib/SecurityIdentityAndCompliance/ShieldShieldAdvanced.puml
+++ b/awslib/SecurityIdentityAndCompliance/ShieldShieldAdvanced.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ShieldShieldAdvanced [64x64/16z] {
+xPQ7SiCm34FDJUB_FxW-9JmFgRkz6NHNUI88Ihvi_oLr-JdCLW3Iw4Uq19wg-BO9iiIe_V20LFgESHzGoCb8EN-nj8xIPJpjfryjtNxdJUazS6rrtTHQD4Ur
+3dLjGcinAkAbmPK76-rDbijuFbIsvlaQsQWrjyplydHBgtKrGP_oFIsNH4eyXq-Vrv-EG28wznxh9pnTNZluNV8SFdtASvTk_j8JVuNlrUPRzaLUt-4LB_x5
+l_WNhpzw_lYYmhJxLiWrtojI9GkU0NbMuINVpaYD5ZpLOra0c_dUUDBiDL6quAaR8r5JcIq4geEm1U-Fs2JgdJTbsluAHHFFepm53iNL0tLT1MBY4v2D2wXG
+9jO0a7GBeFeNs8rt83Og8BWDvNq31QIzGY-y0KLR03vUQ6CrskSjuJ53-C6J0yL7NrLvz7IIeV_M0b9fyAG9bFHWJwwu9WETlDIOKOql87cSFx-b4iUaxicJ
+5rfbrF4qVqki5QUpGnfLg0gbuu9QH0nNktH-551T_qDq-7FKNk3aollEdCJLNRREF6sMku3ANLFz3YvbnIl0j_vbyIZXNBtB7lclJYLDTSYnArseMV74FFy-
+SBCuC3Iwp1g_xeHsD5NHqz9jAVR4MMbykbVcZnzObs_Nvf6PuIPq6ixpzxuKtv8KKCQq4Ni19T-YUpYeAZmlnRTbsP7ezZEnkhlozeTw0m
+}
+
+AWSEntityColoring(ShieldShieldAdvanced)
+!define ShieldShieldAdvanced(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, ShieldShieldAdvanced, ShieldShieldAdvanced)
+!define ShieldShieldAdvanced(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, ShieldShieldAdvanced, ShieldShieldAdvanced)
+!define ShieldShieldAdvancedParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, ShieldShieldAdvanced, ShieldShieldAdvanced)
+!define ShieldShieldAdvancedParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, ShieldShieldAdvanced, ShieldShieldAdvanced)

--- a/awslib/SecurityIdentityAndCompliance/SingleSignOn.puml
+++ b/awslib/SecurityIdentityAndCompliance/SingleSignOn.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SingleSignOn [64x64/16z] {
+xPQ5aiCm34HNihZ__xr7lf83axX31s-ej2kmjvFwZVppJxXxJek5y0bfJAYp0MYYmW0aJnSdi7LL6e7pj5oUUg5p1WojHmHyHgvezKo3LfWUEuqavFAZ1W3a
+1_GEMMa9R2x00GE1h_GatVh09XahlychjqtfnzcsYOOTVGAakNjs8Arjh04xCmZ8QYJ3FUxl55YhiBLVPtp2zdYzVMjriH94xZdal9VXzTs1Hpc3eovzhvIR
+TJg-6AoXLRdda29T7y1Weo5N443UpUocjqFr6xmOt5llu-tfOmXk4bM2woBmfvifYAtzZtu9xdtqP6qbl6FW7FiHS0C_hKqtKo3W6FGfGCl7PEjEYWLe5fqg
+-lfXvaCoKtdtRyW8LsA8Uu2o76XHUxXA-oAxuccwJ8iwZe97Wpf50zcd93tc31G0DoPGpXc4401YwCG8dOoiW5oc3Nfur5um202G5mpSdQSDEWcwdghL34Gz
+5pQhnoTscTMRV018xtyI1m1_yRcoVWV__FCE
+}
+
+AWSEntityColoring(SingleSignOn)
+!define SingleSignOn(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, SingleSignOn, SingleSignOn)
+!define SingleSignOn(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, SingleSignOn, SingleSignOn)
+!define SingleSignOnParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, SingleSignOn, SingleSignOn)
+!define SingleSignOnParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, SingleSignOn, SingleSignOn)

--- a/awslib/SecurityIdentityAndCompliance/WAF.puml
+++ b/awslib/SecurityIdentityAndCompliance/WAF.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $WAF [64x64/16z] {
+xLO54Xmn39DZlll_UmkUkNKAvsmxKDJ0ecH5mSVlY__u3_Vx_yhARzuHtUSplXG8Km54BNv288HmWUIIIByZu0i0gmTHk3A0vQzVpWB9mB9IOgwYjW3E-g4k
+iu1VrHg-u4M_au5d9U1xgMpwlH0L8Ds_PDFl2EJgs0fsWvxU0W4m8FtDgcM7ufk0m1bO6yKF5XoKfHAPdvyqWPsI19_u2_Kvmpvd5-2d0B2zm1heSNqr0FoP
+xn12xXLYc85NgGGjBCWZ80hTEq7UyxTAYs81-Wn8OeLc2m_sEof61X0FXpmMjfd9xnjWPRH_C_dypYh3oxR2tl4LlkMKBvsd0dGrpQ7lu-jb0jHN1Umg6-y2
+T0A8BolQLm7bYyO4a9_u2Sg-CgooRVx9lq6tQtZtJVkVyXFu5wEj-LD-1cqddMBJflxh6bs_NpID4OVnsquSii-RjZJDdywzJVUyDSYT-IkGvlUwqJx6zQC8
+aizNNyM2j8_J-bN81RAelrDh3Oiyhb_xzfO242YCKIjOKErCV5g_Qvak1AD0jNXaxqmpk0T8w6AzA2KmOzXXRmhK7kSvxqmpVTg_Pu4i-dH-c0MywFFvPHQO
+pqzdWUdyrW8Jwtn-PFcXy-llY__uZuy
+}
+
+AWSEntityColoring(WAF)
+!define WAF(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, WAF, WAF)
+!define WAF(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, WAF, WAF)
+!define WAFParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, WAF, WAF)
+!define WAFParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, WAF, WAF)

--- a/awslib/SecurityIdentityAndCompliance/WAFFilteringrule.puml
+++ b/awslib/SecurityIdentityAndCompliance/WAFFilteringrule.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $WAFFilteringRule [64x64/16z] {
+jLU9jfqW32pPYFx_1nUUvgBfQBdbD6z_CjbcuWc__gUL7_idA8bLttxCgmbz1pRVaxbDkv03tEDgivx7uKBcqQvygRkm-fm7yXxP2DNKi_3tAhIZjJomeTs3
+lj1LstChBmUi7QZbwQctuFnU7xSK73iWz0W78VIWmMs686iE2l0BuDWCvLbROoQmu6mGv_FwzamZfPeA4RE8QBFsWvcef5vHSiWVgVQvs_-mFeSVKVCzNOc2
+g0uajArIj406VZkpv-qpU3tdi5xB64C-AzYkuJMyxYxq_4xnFJBLIm8UpPCn-Brf7D5PBl4bMkYZ-JQO_PlLeIAw_nOYjgV-MqZt7jKlNEZntrA8cqctevBI
+SNPc7x1mf5a9sH3hUgOjDmIz2DblgkCp6RjBrxAsSsr3nCUVTGGCPH1aFrGsqgdn8rLP7wQMqpyyqWZBsWOp4XQ5botNMrAYJ__KX0UD2Wlgyx641oA0rEFu
+G0I0Ue0tz8fLK17et-0FYm1J7_m1_GmH8Eg1VaA_K0IPUg3Vc1_CDwO-vYVDBswPFHwWzFu08i3K1opy4vutE_i37qT-yHliB-OdekRtzpm-tj_1ZtwBr-iy
+3O8m7jEBtWqOZ-K5k9h18qu9xKJUQU4QH_7-WFUN4CYnzXhQN-1Eb4zrgupsfudzpJUmIiFz3U-F949F--FY_hguFo_kxsltX_Nxo_hzQVt-jdv_NB-_hj-V
+r-qt
+}
+
+AWSEntityColoring(WAFFilteringRule)
+!define WAFFilteringRule(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, WAFFilteringRule, WAFFilteringRule)
+!define WAFFilteringRule(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, WAFFilteringRule, WAFFilteringRule)
+!define WAFFilteringRuleParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, WAFFilteringRule, WAFFilteringRule)
+!define WAFFilteringRuleParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, WAFFilteringRule, WAFFilteringRule)

--- a/awslib/SecurityIdentityAndCompliance/all.puml
+++ b/awslib/SecurityIdentityAndCompliance/all.puml
@@ -1,0 +1,470 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $Artifact [64x64/16z] {
+xPQ7hgD034Ml1tV-_tyNJInb2A3dVIfRJtevPhgTlod_-K-OgPh5jrpT20Lj6lbJE4-DvO1d8FPi4moGU6GHBWHmP0ybq6U3OtwP7HYGtFE20DpGDv1dw8hb
+n0bRGn-HgJWXEOdnPG2UUYhOjB0n6ru1E1-P7iNhLVSiTiOx047pcI1ubh-sIGaLm46HZp0axtoFWVf5mFc4W_BjwuiPLUUaJWZ-V7bTVBo8P4pAqyS612WM
+trvandmTvGSXdWPVSl7Fx5n-2lHfwVZg-qgyV_MdHKGKgu-LaOpoW-YX-oDNdrVaxUT0v0q6FldxmMtl67RloydV3kpEbwjVpkaz0T1xNpj-76JRlxRV2c-r
+_pf-ABRM-5tdJmlxz0UYitvMLZ-8MkltJ6FzAgJZ2xIpV_U7_HU4Q9mVctmmblEZSNvTAP_WNv-VOLVyo_Cpunny5_8W-MXYDF97mV3pR0L16_chsAVF-riV
+u4x-dEWSSySGqMx-hFnTJJtmm055EtzN_N1W0Fkh5BAbVcZNBxjDqG3Rb_gbNpzDTGPPwwT-_HPfEB2CfNxh4YhvQdncYaP-3_VyVVdFVtu
+}
+
+AWSEntityColoring(Artifact)
+!define Artifact(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, Artifact, Artifact)
+!define Artifact(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, Artifact, Artifact)
+!define ArtifactParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, Artifact, Artifact)
+!define ArtifactParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, Artifact, Artifact)
+
+sprite $CertificateManager [64x64/16z] {
+xPO5WaCX30KV986alVzzDrcf2wJhPRxBuBPn5ek5CGt2Tibl6APTziM6Q5TyVps4NlMt8_hsgayo1A5zKVdf42sL_pqwKVv4v-_wkD-1_eXV0Nh0xwWLFU-x
+x45aVDCkNCFr4qjNc_C9GV6qzuAWplaCYDf7MWIGoVmpoYx9MY3JvISekjSJvIyVUQwk9tpR-vRn5UmdZQBGZE_FnW2RtsHyHWLAWLyuuuVT_7M4aF6fYCNL
+f536DzlV9Vmplizd8bAlUpg61tqhGDnt75DiC7uBuhf30njD__lFfZkcycyuIxzDbPyuKNwourVLlsRMBvjtRgrVRa3xNkcqwVNRhWHbjtvRB1Ol
+}
+
+AWSEntityColoring(CertificateManager)
+!define CertificateManager(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, CertificateManager, CertificateManager)
+!define CertificateManager(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, CertificateManager, CertificateManager)
+!define CertificateManagerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, CertificateManager, CertificateManager)
+!define CertificateManagerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, CertificateManager, CertificateManager)
+
+sprite $CertificateManagerResource [64x64/16z] {
+vTTdejmW30HWIwWmS_y3vzcBDsmgA3rl_hX-hjJZtSSYYmbxuy9w89T7BmNawK4_Id7YuUqVzscbvEtBkJrAUNgNKk9l_t-YvcugDQy1Na7elfVWb91DBvra
+DnLHkrPboml8tkwjrad8Zkzapjj9zWtlDvyluCjUGCWNTgrwu-ikyx5lqUVhlHePXu2vwi6SEQvR9x7e1OpF-164B7i_trhF3SNuyhxfZT2RR_dn_a5211pl
+il7-uzGWCVYPZU_lznVZHswaRvI_FWhjyvvze_mTCUxh_h9dsSluwlCRGLRz-Elv198aTAlzQI0HUXxNEDVRPlkddIJn5fBikj_-MkT8jrhxhnQPOLfg_rNd
+zMtVo3QllrFl_YDUaaofUjLEabsrvWDa9eae-JCnMg6YlmvOrMEWXeANJ9tMvLUEtxpez-OlCL6PvYzS2_habO_8-lmjVF8ICUPlxpqV
+}
+
+AWSEntityColoring(CertificateManagerResource)
+!define CertificateManagerResource(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, CertificateManagerResource, CertificateManagerResource)
+!define CertificateManagerResource(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, CertificateManagerResource, CertificateManagerResource)
+!define CertificateManagerResourceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, CertificateManagerResource, CertificateManagerResource)
+!define CertificateManagerResourceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, CertificateManagerResource, CertificateManagerResource)
+
+sprite $CloudDirectory [64x64/16z] {
+xPO74jKm34HNijewzxylANJ8eFZJuKr9VRE9g-PloN_-mwgCdQpYOpTD1UyHjMJVhd5Am_p4Xc1dL3FR0FaiZsa263l-WEJy2YdGXXuODp4SY6_xXfmt9ApZ
+wrs-mZi-9FWLEmGzN-_QlvbVPN8D6lCTkuQIM6NJlnj_RV-4hCo8pEBrBtt_XWMVVCKF1JIMVGDK0Llq0xgVbYBMVBdE2hBa5yPrCb2_mYU4vr6mDduCzlwm
+ubCXxWBbcZzfs36kZr-AyANnBpBNV5w8yEAXx_YCUEORT1m0vq5XJ_tQFlp_Ll0d_lkbld2rXcFmWKy1O8UmaySzGDZsDuEbegOW0Z8BcWRRsla3t1n1wDmK
+tBsD6FrynmX1JOKxT1Oa1hoVJmMETrEk_tS0slx_NM3uDGeZU1pBezV-hzSFK-_hb_43wwT-_RPUFwxNhxyb__dF6m
+}
+
+AWSEntityColoring(CloudDirectory)
+!define CloudDirectory(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, CloudDirectory, CloudDirectory)
+!define CloudDirectory(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, CloudDirectory, CloudDirectory)
+!define CloudDirectoryParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, CloudDirectory, CloudDirectory)
+!define CloudDirectoryParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, CloudDirectory, CloudDirectory)
+
+sprite $CloudHSM [64x64/16z] {
+xTK5hkq638JXCTkJ_U-t2hHz60L45px1mT_XX9_6js-bSiQ6vmIYVoS8dXfHdgYNVIDuxbK_Cs_w5W7qvtbpeq-8_j2N2G3nljxd_zi_1eYP2c1pls-1rjfD
+ANJkzlFZcUBGkTQBOEyDGKweQ6wV_EB-F_g6Rfi00NGuWZxwQ-UV8zV8PzgWP5hVElyKmuGVcr8B5zvP_eYiNNDLKD_qzHwwzdCiyv2NUugGZZgEYlTcxcn_
+io2pdqZDkNJyfwgmzOaW7H8LG91swVWLWBqVh440sFA2pANppm9wlDKXEoE7747nwFtYzMFGvgxalsggB_PqmAgdqu3WX8fOyLGY6if32dPQImaW0jYSzy3M
+7ohCB8fim8TiXV74X3kKlrCaCuSqv8FxTyDeW0mR-k3vaSY1RUUpOkxtWQ90qCU9UDfB_ug9M5erIGg6fmo_4ZQ4kuOCJqtuB-AuVsuCDhnj19hTiOtI9mCC
+6tywW1tk0Pcd0pO2-9i1OO9QNWnO4XP9G_6P0e1891_gBe4W-LohIFDJ-FRj7m
+}
+
+AWSEntityColoring(CloudHSM)
+!define CloudHSM(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, CloudHSM, CloudHSM)
+!define CloudHSM(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, CloudHSM, CloudHSM)
+!define CloudHSMParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, CloudHSM, CloudHSM)
+!define CloudHSMParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, CloudHSM, CloudHSM)
+
+sprite $Cognito [64x64/16z] {
+xTHRSeCm38NX8yd2Fkh-zzknubmP1vndlfTSu1ygTwAukLmkhHvfCKV5CMNC6CoF63Gc28rZYZOR7XRl-2aYod4_FmzRwm5z0-5QRz5LzriZl_HD0C2OVVnz
+wyNqJUyfA7NBjo5GaozzsfsNzukAsljktXlVv40AvXcWH8WqskBy8jatb37_Oc-e_Nt1zjlvDqWb7S8pVT6XZ9uEG038gUSR1hlrL4WnaLA0SgBdG_QgC8wh
+YY9Od1yepqyYPd7GRzwrSA_P2-E1-Nuh_D8hkes0PUznMlQjTenQM_RjOvr4jp1_PPTNNG6eSwL__Y-znwe0_7GVnP9754W-cGwKetxFdskVEliB2E5qipol
+SBf17D2TDdvyGwr_stG25-pK28hmdWCa96QuytOm5TWY38mLkNjA6Ndlss9lGO6FVBdFWPjWvBa6bkGER3Bo2eir5HeHR94KDHOPRFT-1HNQnXg3CfRH02rU
+5336BwgYqng_OcwcfylbyWy
+}
+
+AWSEntityColoring(Cognito)
+!define Cognito(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, Cognito, Cognito)
+!define Cognito(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, Cognito, Cognito)
+!define CognitoParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, Cognito, Cognito)
+!define CognitoParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, Cognito, Cognito)
+
+sprite $DirectoryService [64x64/16z] {
+xT5fZiCW38RXpnYyvVxt7PbqRu7axoXFzoQlB8lu5owNYzjQZ2bXZJq67AXjfO27uz6sM6eQ0mB93v-By5dlbR10REE-Wie2WNpKUrvRgT1npx4aaCDzum_r
+N4_uvETwycIgvecN_VRHzoq8e9RV6BvD-o9la7q5QYLmxvlmhF-GlVP3zP8P8ytcwnkYntaRE7lHUd9_XkLNHpcmFyURx_aUPti3MTzV3_NQTlBe2M06ZlKR
+OqUtNW2Y_LMFp3UzsNj1_c_ceOHwUdy05ZTEmBftI_c-zn8F1XpTNmfAxqkygEi-f2QJAhrlyK8dlO9_xI_nmYQz4_H7J-NLf0zZ--gP2A-e3FlqrOT_Y9Zt
+9LQs1esH0cuB_Gn7h629D2PioUDVk5mkVm
+}
+
+AWSEntityColoring(DirectoryService)
+!define DirectoryService(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, DirectoryService, DirectoryService)
+!define DirectoryService(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, DirectoryService, DirectoryService)
+!define DirectoryServiceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, DirectoryService, DirectoryService)
+!define DirectoryServiceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, DirectoryService, DirectoryService)
+
+sprite $FirewallManager [64x64/16z] {
+xPO5aiKe440V3Qrp__Ekf8OYmoxVIbRVo9Uq2qdzxVYV_yc8hC_n1iqgtStyVKi1VO0xNCY8UeUELJazXvhf443iZIWQMLMjrJVf7I9LH5-o8aHL8hK8omOW
+pmse6yrSqBhnDHYP7Qqd3AG6mDYIQha5TLBFgb3rslNh1Nsb7JAyGX-CPvq_jJeQhUtMTmGxs-wjZNIlCqQlYNVTGycgGEf8DfQA0ZrgfsF7-FYHNWVGtAMG
+E9Hkgqys1hGjNmV4J_rHnhsNve3jgzd1QoV_E1-1b6u61hRAV9vFqxY-gcn0t1kSKtPZq3FcVZJeUGaFEhAl9grg9mMWJsCWAMGPTc-P8Rwlvgftjoc63gIr
+B6Vyc9cnlEm8kKhNgrzomIWXrjZUl9_r4wbiQ9MZNuerR1qaSThGMBb8bKbSG_3bT21siHt5x_wNT022t4xNFyNHU_uNLwi2Y4vifdTkTLPilj5BNyg-hJlZ
+qRazlUPjensyubklutL0Pm9Zlb76T1dqcT21wNQMQBs9MPBbOsFvNQBhpNgVa4yFi63yBEEgsvCRa25JVn-LorQAr4Cw_TPY8RVfpAo7f31c8zSvSQZxmK1y
+6UDRVo_jSzAkljbF_qxBzvw0z9w_WR_x12PHWvXt5glto0wzOvNUGQBUnWLerp-hZ_0EoF3wc8Yilo__yp-_0W
+}
+
+AWSEntityColoring(FirewallManager)
+!define FirewallManager(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, FirewallManager, FirewallManager)
+!define FirewallManager(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, FirewallManager, FirewallManager)
+!define FirewallManagerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, FirewallManager, FirewallManager)
+!define FirewallManagerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, FirewallManager, FirewallManager)
+
+sprite $GuardDuty [64x64/16z] {
+xPQ50Xmn24GVCSBa_x-taZlgtMnTvrpUCZ50lwV-wx_cU6f-5Hx6KnRw6XbZ2_jIuq_Utd-zEunAbpGRRDy1RKhgr9iu32z0qrO3YW-WtiAh0rGFFHLU0RnI
+R-0bv5O_6Eoivef2lODBaLXhCqr8vmjKwaRJTWua5TT3cE3AzzsWZ570UfgGmzKozhp03jscrj9isqJYNLSQ45BieA4bTot5jX9ImD2bdF9uTgqzX6r-oSis
+Ll5hlZ0ttvUyihNDhxx9IJc4hthmgb1wc4KlKBNvQmCXDJnvm_FiE9QyqwJu93xD32BvJIgVamymi_cPgJUghdar3CQd-Q7GYLTeV9xNcTVVpCTRlX391-NM
+_66qvpckgxsxVzggpCFwvVvv1dHAyWLN8Gxx9_Tl7gF2UF23aWSdz-_X_6ZGrmINcHpcwWpb-JcVNuLPQ40pQp0KHkXuVjD05fjX03Qo96NuO_xQHcgiyDuz
+LjGTzaR-wcI0A5YF_QuR9T8U_MR-ZWPOAGQqU3T_twqVinS3AtrUr8_h-gK87UhNDzJFRwhVv_x1id-mB-aVShFuk_sBvvRwflxf6_gtR-mVlxL__JtrN__r
+4W
+}
+
+AWSEntityColoring(GuardDuty)
+!define GuardDuty(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, GuardDuty, GuardDuty)
+!define GuardDuty(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, GuardDuty, GuardDuty)
+!define GuardDutyParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, GuardDuty, GuardDuty)
+!define GuardDutyParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, GuardDuty, GuardDuty)
+
+sprite $IAMAWSSTS [64x64/16z] {
+xPO7bjqW34KbGEtjVy4vm6yu-acCqsVkAQwN3X9zQ3xvXEistFt0Dj6hnmMOY0DQjr34z1jjqNw5pwNMMdRzPe5EMDtmc-E9rvC-swXOQcqocg6dV7OWX6d2
+2i3E-0PueIV5dmKmBJUPhu0lNqU3PFuOynDxr3T-mNXOu9Zl6W3dMmzhxXjGamv2fmuuTns8claCs9n-rvT1S202WDnkLD1ll1tzDget76i8TDfe-gX2C935
+5z9-Aq2OBmEXPgQzF1QpAPbP0BhMxt2YG9HHWz2tAG4Ol_e1epB5SP-pherzVwwMhFqyfak-ltCGvNNy3BVnKrl6JpG5YFfs_h3ENqwZnI-tzUCHTbW_APAi
+t_BL1gk0SagsVvpI_PEHxr-ZPF_-g4yE61_NoDdpgp5DM09mFdz-QgkrpcFS-Epv7NWIxNpyu6VyQ9VY5__c-BdlNyyVS06-c3zTpjy-D9zyyWK
+}
+
+AWSEntityColoring(IAMAWSSTS)
+!define IAMAWSSTS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMAWSSTS, IAMAWSSTS)
+!define IAMAWSSTS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMAWSSTS, IAMAWSSTS)
+!define IAMAWSSTSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMAWSSTS, IAMAWSSTS)
+!define IAMAWSSTSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMAWSSTS, IAMAWSSTS)
+
+sprite $IAMAWSSTSAlternate [64x64/16z] {
+xTS55XuX30JWX0ZCtF--jLGeMmclBlExVEi93_b-qNO-fGCNYIVdLUBq8CAR2H07Lp2adI3quLqUqM4sL1xnJ_auSIoG95PeO_s7r-IMr4jl88bqCq-GX5tu
+ukiziKN2BhoHzL7TjG1fRQyWlHRqZZcBj7oI8Pilmcnw9PUSNXQfFH-53czazFmYvEa5N2slO7xA9w4TF_YX5CRcdHmTRsNqTNppzNtN3xp9uVlRFrZ1iVtT
+uwVkyJgkn_5hdxypuBgvViuO6JVNxvb5watz70aoh-ktSjPlltziWBIVrx_k--Utz-zl7p-wurVVL_uv_z-hwWEfThqcI8Ju0jRhnnG9a9WzFvdkcMAP2SxC
+aC1qZvuVdF8-ixeUbbHQFa-lVL_lzLZ_H8wkbx70QHzvdUJoVl-RPEvUn99OslEr3RRvsWP4suiX3Y_AsVS1FxqnErvNkYUNRlxrLm6CbfyWCRN-Mgy9adDy
+G_sewe-jN-zx_zxhlv-_VVlyyTldhzy-V_xsl0G
+}
+
+AWSEntityColoring(IAMAWSSTSAlternate)
+!define IAMAWSSTSAlternate(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMAWSSTSAlternate, IAMAWSSTSAlternate)
+!define IAMAWSSTSAlternate(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMAWSSTSAlternate, IAMAWSSTSAlternate)
+!define IAMAWSSTSAlternateParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMAWSSTSAlternate, IAMAWSSTSAlternate)
+!define IAMAWSSTSAlternateParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMAWSSTSAlternate, IAMAWSSTSAlternate)
+
+sprite $IAMAddon [64x64/16z] {
+xPK7TiGW44Cpb87H_GyS8lUEpSkh_5tRD8aEFwJJwNIS3y4x-IRsQY2MexnNPwmmVUSWYaAEtZaVs0uBR-GPWBfjO-8hUQPw9XYWjVeYJuUfC23C4Pb39tAb
+_CJ0nj9n3YLaEIjuDjg1jfHZD4Z0te29VWoUPL1E0yeF1c98_8OOmoRB0LcrYCmhOCfHpapKi6wc7mTyF-i9SzKwLIqPH9T29dI16JZcCzx-66PMIoX92KWo
+5cI4avVO2KIHYDrGIc49BY5sGyRkAwkFur27wYN7EH4g5RQurP40Qz47wh-qdtY3-PhnEuVResh-pW4GQzVFELgtVg-8bVldbFhzUqhz-T5uVZMUdutdT-Fz
+qNX_jTsV_tr_TpgTpYy
+}
+
+AWSEntityColoring(IAMAddon)
+!define IAMAddon(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMAddon, IAMAddon)
+!define IAMAddon(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMAddon, IAMAddon)
+!define IAMAddonParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMAddon, IAMAddon)
+!define IAMAddonParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMAddon, IAMAddon)
+
+sprite $IAMDataEncryptionKey [64x64/16z] {
+nTS5hkmm341Hnv3OT_yB_gfIJHzKyvfykeB1KwR8dwizxav7BHJVEKl5LrzK-2pyXwAeBxmL8OyBgdtpVhxpaJcwlVD-v-FSZCnIb-O_VKkWScH1-RfFI8-H
+tJfWgpvWj02evb1jpRUYca8bT0c8DU_Wuc2If4YHQtvGxV2XTT00NV0-vzgAym0ri4K_HCGA6BBiGmOvZy0ud3Zeak-VmQ3QabSOycf-Ml6IuAzl4dJHQxsE
+6KleikZ5W0eH7S2GPIzMG9E3TzdmqiRqfRBbnK_VDdqSlaCsUMKHtbQy3AxDvyNHQ6i-PJOuAttiurh-3XNQR33H8tzjFttDjqD_xWcPwZg9Swed_ZgGYvGp
+1tle9Q3Ex_jrGk8FlHNuzVsiGJpqu-IYRFfy6Ryy_iYRrk6RcZbqjTdvNdyyVsgk_U0-VUkbSvxyoNtstakSvqwIzgt-inTrcNx8j-o1FxkyZH5jtmT0jbsl
+K0Mnwnsi5Rdh3SAAiUjRSUIxNgo0BjjUj2RVzQtmt_JnFxsq9jj-jkptpz_Bt_NS3suhVJj-kMfsczwFN_R7JzVuxM5Hr1yTFwwFN__m-7c_Nm
+}
+
+AWSEntityColoring(IAMDataEncryptionKey)
+!define IAMDataEncryptionKey(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMDataEncryptionKey, IAMDataEncryptionKey)
+!define IAMDataEncryptionKey(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMDataEncryptionKey, IAMDataEncryptionKey)
+!define IAMDataEncryptionKeyParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMDataEncryptionKey, IAMDataEncryptionKey)
+!define IAMDataEncryptionKeyParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMDataEncryptionKey, IAMDataEncryptionKey)
+
+sprite $IAMEncryptedData [64x64/16z] {
+pTLNeXin24PXa40CP__xJK_SCQEqUvxSlbzwyiYVI-kaplDDKNFULWreacv51n2bTwbQ055vAtsG1yJs-S6XnK37Ip7GyiL0onS3BLyCj7mnqFB5GCiN0mtF
+yQC4ekNdYbZpkqzkqlVUVf0q4HdhggFZrpUR04jkyuPVaAuYwWb-sa_88TyQ2VEiFs1SjeYJVjoG03tdxURA4-Ovxp1kRcEdlTvuF-lp0ta5QtlpBntWbnQ4
+VyaQtdXTsdll57dBp_6qsVKgJzFpNkVKfpvRtXFIjxtnBTlrIPebkUaL_F9-ouT8RFdBCmD2Dlr8W1oxNaP03DdsCk0Bt_SJvd_rcR_bTItTyvV-lH_F_UZw
+V57BMpR-VmklArwsjFIDFh2tlhU_SNwwDVDyyEASoX_lb2ToUPAsap_NPm
+}
+
+AWSEntityColoring(IAMEncryptedData)
+!define IAMEncryptedData(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMEncryptedData, IAMEncryptedData)
+!define IAMEncryptedData(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMEncryptedData, IAMEncryptedData)
+!define IAMEncryptedDataParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMEncryptedData, IAMEncryptedData)
+!define IAMEncryptedDataParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMEncryptedData, IAMEncryptedData)
+
+sprite $IAMLongtermSecurityCredential [64x64/16z] {
+xPQ9UXiX38HN0btp_W_S8BmktnhiulHk_voi9MKq2EBZv_4VAg9cMkczR0rqmif-UerCZSYVkgj10RWmjIwi_KwxwL7lAtOWQ4Sy47ofvnlMHQQF651trDT9
+IPg5neHHB5la_ibKW61Ao1bG0Wrf0cpgaqsGGJRC0F1XY6jw0QAysWZ9E3tqqG1lpvzn9ZdiaCTyoIbPan6SNKppqpvXvcoLEL_dnjrzm4jne6R_a_uIwKP7
+twVH5KNYnn7J2Jptfw3d2H8R1gGjgNaeyqkYrbiDxJLgTO37WBQmyzbAX7JjmRbV_j1eQbeNaEvdFpTstTZouW3JJHjJNthsVAV6nl4xvpRaLg4O9kPn_Q0i
+HAK2XAc81Hx7Z2IGXArqzOYEqlerE2yaLFFumEKIGDQof31nrS0pQuWc3VhO3oaslTNBRLu3AFqtfLvIZZKbqw_3aQxqL-ZvjU28gs5odruujVGd1Kh6ihZ9
+LnM1S0UYVGNWxSkjBhgdVc067NAkhMlWm4g4mtCwFOOZGURkngsyUnjyDcy1HfF1rbk_-cBVs2V_Tgcb6k8izOmyXUly_FKf1kX2ln9R7viEJSX1M_YN-BtL
+c83fdQC0fpMZkuefmHDNkoT5f8nDXKpWXIbb_UWr_A1BTjxSP7YKovgF3NIyqOgVvROK84nAgUhOJyy_sjb_RrehPmKBD5o_jNMkDOS-v7nG2jD6qm7AKQd7
+MrJ4xv7lzXRUy_49A2_8jz7Za_pd2m
+}
+
+AWSEntityColoring(IAMLongtermSecurityCredential)
+!define IAMLongtermSecurityCredential(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMLongtermSecurityCredential, IAMLongtermSecurityCredential)
+!define IAMLongtermSecurityCredential(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMLongtermSecurityCredential, IAMLongtermSecurityCredential)
+!define IAMLongtermSecurityCredentialParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMLongtermSecurityCredential, IAMLongtermSecurityCredential)
+!define IAMLongtermSecurityCredentialParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMLongtermSecurityCredential, IAMLongtermSecurityCredential)
+
+sprite $IAMMFAToken [64x64/16z] {
+xPTPckCW38Gj48Yg-nzuOXCbPhmnew_VkdeDuXSIEyjFwLUIjRoaMVw3LGC_Wka_-SZ6WopFqjfwcqNJ9YqzbgOpT6eRF2OjUNFHqYDUGAASP2lTSa-BaQno
+OQmaJUxmHYBVz2l89dUuc-ThZ4PR7cJN3kmCdwzLoBPCg97bRDn1o0ml8DAfspmvkyy2LR8kawga7fhtwESoQCUOoZAjSiZLlFdP06mie1VCoSYXENq7b7B-
+P9JJkcwxKY_v6aaz2z_WvGhKRS5WLUinKYuIy8-LX9TmvKchBvNUQIox1iVqY_FKdj2Rnsw4wtVOYiSofbE9Je1uyrujiGcOnWxxVagTHp7echrLZEqNrDNy
+yKOzvzEAWEdDixwaorRaxWvysV5BWofiSVxT_NdB7SmVlbpmUKMIyz0-_1LLH0prZDSzlzWsz6F-0dP17l9_sSp4UQ-lXAq2yu7tyNE-Q-Gzy0eRns-SF_Ot
+ZywB1-WE2obdytVFbvNlcxMY-Io4-lmzM_uxf-A_nd8vhXzFPrwPrEZ-4To_eljdSF-Ed1z6Ql3yYfwVmVCxU7-8tb-2zwVW_IruVupUN-Ftv_ZzFVv-YBzV
+uk-dk7xr1m
+}
+
+AWSEntityColoring(IAMMFAToken)
+!define IAMMFAToken(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMMFAToken, IAMMFAToken)
+!define IAMMFAToken(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMMFAToken, IAMMFAToken)
+!define IAMMFATokenParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMMFAToken, IAMMFAToken)
+!define IAMMFATokenParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMMFAToken, IAMMFAToken)
+
+sprite $IAMPermissions [64x64/16z] {
+xTS7TWCn20HGeu0GS_y3vw7qDcj3Ui8hBhjVlPxUB-JiU4rRN13sakEYU95084pF30l4Coxn8aaIXf0NNi_tkdq_V-wrvpsyunrOKlMSSyyvzwQ47ti3b7Fk
+5O0oplrj0fHplnFWdFkJSivzXiQIrlYNxlpv9NwiqV4Z45BsoM6b_3ddNXW_zhASy6C_0yxuSVw0KyxzJc1HplrEW7FkTmBM6RyozSVEltzlTsU6wSNzo-_U
+cCNnx_i5n5Lr_Bia7_Nn7vHpdmampdt61B3g_M_8yA9F7fgDMFF9nsw3wlY9STk8jV6J_EvBPVpSAHcVD_z-_lsbVd-htn_xzzV-_RaVrm
+}
+
+AWSEntityColoring(IAMPermissions)
+!define IAMPermissions(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMPermissions, IAMPermissions)
+!define IAMPermissions(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMPermissions, IAMPermissions)
+!define IAMPermissionsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMPermissions, IAMPermissions)
+!define IAMPermissionsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMPermissions, IAMPermissions)
+
+sprite $IAMResource [64x64/16z] {
+xTK5ejim54JH4JmQxt-_jS8SMMq_weHZNpEGdAPfijp9-8W3gGlWV40XZ0uKwEDUsKNVzIPLB4PxosYIZlK653MhW8pqaOwB0VX0RoZS4zI1_ZpGlqXlvI18
+BRwbNxWI77Zx_heF5uZl6Ke4oTWxVEVBFkE6Rrl_X7efjTwbSJ9q_OpNVUPgON1fdtM_paqb0olhw3qZ6LUjPrZZ9DjdTFGPcbF4uoj5Hv_Ael1Z7tuIVNr1
+JIdEwtzI-leeICuGoQstUg9zFHsoq871zQT1o30hWpqZoBR-c_labyhc_Y-FVvLwHM9R_q97Fth_6hz_Zj-_fscQ_W
+}
+
+AWSEntityColoring(IAMResource)
+!define IAMResource(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMResource, IAMResource)
+!define IAMResource(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMResource, IAMResource)
+!define IAMResourceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMResource, IAMResource)
+!define IAMResourceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMResource, IAMResource)
+
+sprite $IAMRole [64x64/16z] {
+xLNNmlCw20iR-luFVE9mOfpzzUfVKNTjWH0Uqs-95ozU08gwHuIRCdxB9elFY33w8hLuajnCpJn3EV-Gph4a58GgnNuS0Qon1GwQMbI3ny9ZPZDCGDn029i8
+yM23j2J45eDpl8R09esVwBwI2zrykG_0bLG86qWocbDvUnc0UZeOdSkreB3wS-K1HBBnEA9D0guQuxmBjYW_LuUUtgS7TbdyTN-q3ywXpcOjwkcsDu6BblZu
+HNgvP8-Lww47gQh2NfPW_nljfxt3MtfLhiUfsbhyGE-Lut5kFAOVA_Tz0NXQFG0WrWwiocMVZ3SR0v15pIFwRi2SrRQm2aoqxu2EyjkiFK9nilKxmAxLRIYc
+3J_SJKMOMIpZUGyclE-WZ-MZCG5ix94aAm3qNRhZsqFlD58qhYfWREmflzaFCFGe6cOPX5AxE4D_VEmJSlS_N3c7VCZCdKzM5YSvZy_ZzGDgglEBfkBZmdP2
+ptcwagFPtw1v_pYNlk9p7Q_iGph6iHgshY-hGxBqhvc1rRSwhNT0IH5cdhRaMG3jgbfImNfKsyKk6lNLGQdBrmNFboogpp1JgNkDVUVorq3MrXSXdFuTl7Zn
+uZy
+}
+
+AWSEntityColoring(IAMRole)
+!define IAMRole(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMRole, IAMRole)
+!define IAMRole(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMRole, IAMRole)
+!define IAMRoleParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMRole, IAMRole)
+!define IAMRoleParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMRole, IAMRole)
+
+sprite $IAMTemporarySecurityCredential [64x64/16z] {
+rPO9qXmX28K7GRRx7pWbXLFOmooTsf8l-NSV0ihhVlnF0B6eo1n_fHvidYZTby-bDbMDA08tvR94k5GGYTYuApTyR41k1fZkUcJCxdgZyUQMyX9WzciRs9tg
+YZva8DPGaqKrM-T79MPDgyMUIya3NWb8roUR3LGwuSpcZWznkyhnwx7Co1hD-S6l3T2Ls4TIf2wFMVIbkFbjVumgYhv0gpn4Z7b1Z5eGrpV9MBqaTQTIVm4j
+snkv6EqJmVE0LkjB_mj3VJ790tgkhtDe7BtkInsOIT2CBuOeaK02OqGBe_oUOKkUDK1KhTT6VZogOKRHJrF8gizYAGA_1-3ygkuwwkvHKMLC4HKcwEEfkwLn
+0caSJONK4vFH1f0mJc5MYwPU_bZCqVfpGVMDCLpRRJmY4agSTWkocfbArbZarO_HCa3B8Usd3ZIl5eXYH5I5ZoF5hLs2HfyY8OLltWfmt0w6eT6glCqwe0sH
+FaXgfbXA2cHwm1AXf3LSDzXJUN59YUAYF2b_Fp6Ny3rUCU0PO9icvbUQKxalFwnmnARpSHTO8d7DK5zV7rGcdlk7tg0uIiiGyyGclDIlDCrz51Dw4gVBTKBS
+gFO_srlk4NgIumIQhmynw9fBYwEp7NCdfnxiOXyM0NO3TBjYsLvg_hedYbHXZnprRm8vGEES4DaR6-oPjLm2ErRDdjktZ_BCeeoPpPhd4qHVdxbLdvkC4a0f
+4-ENQTKCL_LvMwgrcJABlhuSZhAmw8_d7qppZUBBW6Edp-Ul24O4aZ17hkg0oc5Gw6iiQEswCcEi1o_qLM-DApJxKnPuNuzHFrfIwy_vXGyy-m_9CRZX7_Q9
+KS-_WXdM_2DZtxzAlN_87u7sLRdU_-_COssPlr_H6g3C_pUg8IXU_US6f_zP3FmjhlwBDxIj_z-cFd_-7Vu
+}
+
+AWSEntityColoring(IAMTemporarySecurityCredential)
+!define IAMTemporarySecurityCredential(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, IAMTemporarySecurityCredential, IAMTemporarySecurityCredential)
+!define IAMTemporarySecurityCredential(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, IAMTemporarySecurityCredential, IAMTemporarySecurityCredential)
+!define IAMTemporarySecurityCredentialParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, IAMTemporarySecurityCredential, IAMTemporarySecurityCredential)
+!define IAMTemporarySecurityCredentialParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, IAMTemporarySecurityCredential, IAMTemporarySecurityCredential)
+
+sprite $Inspector [64x64/16z] {
+xPK5iiCy38HNOC7s_kVzGSwamyxhu8ElND7AScB-GFxueokpglaHwOf1BBwU8dGYtKq5W1U_GYcWqHowN835vmIWkMExvsC1ri_3frg72I3gkHLfFmvFiXq0
+H0IN67kOe2Oy1V3iaQ5RlC7u0CKQ3Jx1opoP0css89weLpAnNLi085uzuWlIFD22sfMQfCCgW17lf9-dcB3jh4fIq7mvyifR41umvEZSoo2e-MlwCb9HH_dD
+XKKsb5pGS4ZpiiIfWOBogY8oRGEIOt842tPgtzaGydhdklTjRDDfUcjheCD9ll9MN33sY3h66qCn4mz7lEDd88_gAqoX1aoQv_MdVn5MiGtG28MzKpVqyVep
+jxCYkhctKHuleJr_tqkVkouWQWjZESn_fjn0pzVSCaG50Foy_oxH3hjsxBMZkmEewUw48jaoErZWLJunFPU38SWd0WfOP8riAR9c2WauZnXyNAt8S0--EW0R
+FNA-2r_YIm6BwkvS0gpTGZ-v2-UuCmGN8wMdXQS9HcOkKrMF8fa2kzgJue4II3JVb05O71n87cW7n7DIT8K1ikx5NpYFSLU4gAe0aDKikQ-aSuBx-BiFG4w2
+VX-GJ-Z_8I_UYvypuo_Jz-8NKFo0Eu4Z-07tzDQ7yTVqMb3yZ03C1SvFIG4c_6Cgcp-5F_xu5m
+}
+
+AWSEntityColoring(Inspector)
+!define Inspector(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, Inspector, Inspector)
+!define Inspector(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, Inspector, Inspector)
+!define InspectorParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, Inspector, Inspector)
+!define InspectorParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, Inspector, Inspector)
+
+sprite $InspectorAgent [64x64/16z] {
+tLPPTiGm22kRWTp_m8sZCQbVwP9-LZ-JnGWX4pDl_n34QYTK-0_1F2AFXNIbHz4Q1r38mR-FJYGruHEY0spZTnh8vs8Nh0RO9aNgBy9b9c_4ocJm7oNOkIfu
+RO2eAeIiL_Hp-42m-jg0688gpWVvBO6Ug_MA7WXUY8k1ObFGrgwr0ncc8cBGuVGYyA-TFnVQl1WpskZczVb0NWJM1YFCrmOYUdTVu45o7yulTtpcQiX1O7q5
+Y5Cid1ce19WojWRq0PukVKob1mHwQSWCAAW5tbOFte0AWbpmZlcBL_Zf7CWZqG6E1ZZcFVBffb3RBP0h3SX9_T9ZOcQET2LnRdEqdIipnKnlUVXL0L0zon3d
+JHVZuMHHD59M-zS7DTNbArLJVjpKZDWqPXcJZAi0XYDDx_gL873x8OgyIj0haXi32VQ1vVOASBnSaPIuNTZU-5PgYKlgLdqTNqgMRZVJFdxN7vkV9M2wcOZ7
+sjw_Kaq1oSLs8gOEwVo3yxL1Yk6Zs-uoKxz_vJ6j3Sgzx_0DWIOhITk_T7qYdkdcwwn4XDxVo5xQdi8d3J4gEa8MTxuqSdq56ufLfe2oS9xzDcOvWlGEDkr7
+Xo67tPCGmEIZ14rsyj5a-BdfnJ_Cxa25Edyw36JM6hIGR5nYOkFl130AgH8aKs1l790zrYXf7GZyblCyBkrawtFMygEV05xZpxMEBRlkry4Y0xtPLW1l6Bw5
+3nkUE8hM1BTLOGC60Pmlr32LN0AFTXEm8XXSveanFeIMFmX7XTuhW5Q09jORN-6Lg6iZTAr-uXqeHEe121hOfTeW6fnwkH4EuojHdUjzhXYcQkPHUmxZYm1w
+MeOyDgoATkCTh1r8wWzqfclft8slJkf1BC9CdtROwn4AUeGolWZa6S5klAAUnmIo3Vw7WF5L0JyCB-DhS3n66IyOb0-1Jd9XImXv3aLxbVsF8L47qnyXPafl
+_m7l
+}
+
+AWSEntityColoring(InspectorAgent)
+!define InspectorAgent(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, InspectorAgent, InspectorAgent)
+!define InspectorAgent(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, InspectorAgent, InspectorAgent)
+!define InspectorAgentParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, InspectorAgent, InspectorAgent)
+!define InspectorAgentParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, InspectorAgent, InspectorAgent)
+
+sprite $KeyManagementService [64x64/16z] {
+xP57egGm34HBacMvwj__l9FSBEXes4pYTGJqhAG_Z8iBKgTX3pFpLjGPqW0p0s1TXw43EIYn6X0yhWUt_eSZT8n0arGE-90uBzVf24a5kCCeqL1QXuOXoT6b
+d9N0jKxzSWYJn6awXfPfirepIcFEBj6rZ8Fpc1ZbKooqmpuTmCqR9tofjrOwxiVZi3fIooJwiv6EUc3e6GEkFOHHZaVoHGDTEnfIgdm0_g80srLMCEePBtpb
+xe02Ii_WAry996_5DA3heAzki9ojmqg7VR719158VecQaAk-PDFtMKoNn022Ypwn-Hrme4I76NpH3yGjn31KS7KqAL1BVi0vGsQKcHAbhuw-uYUCMuYZr14g
+1Ebh-OSXjv0231XI042izJyCVGkfi1YIcEwfDLy3zZPaVN-SIFjVllNfQ3U_uISf6W0ObVX9c_uxVVezVb9Y_8Ag-4d_iB-55jVolsAr_-wlM9j_sdDWLczy
+stpn5T8x7vG4rqaIJkLvNmtHO4EdSS2fyz23-X-ukFWE
+}
+
+AWSEntityColoring(KeyManagementService)
+!define KeyManagementService(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, KeyManagementService, KeyManagementService)
+!define KeyManagementService(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, KeyManagementService, KeyManagementService)
+!define KeyManagementServiceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, KeyManagementService, KeyManagementService)
+!define KeyManagementServiceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, KeyManagementService, KeyManagementService)
+
+sprite $Macie [64x64/16z] {
+xP85bZGn20OB8WJc_kVz9Sthh6HzdwV6fU6Jn2znE1mE1xUVNQxKsDAbniTKOAl0W18VOQWXlj4bME531O8zAcsdgprS-22SHfshHjoOfQw864lQ5hz-xvIr
+5zGYzDhSte-WqEUhOhSWhT3kYOgz6zwhD-9X0epxYzYpXYyX6PWhz9LZx5YsVGLLgJa6iZe7ZnqPkrVfkMPEoPr3KByhUgSx1KOEctvoZ1V4rfhjUeyXr8vU
+PhAirHqjRUxNjuS9BKBfywfqskyoXE9l2N0HDsYNtlbCUw5tA3eYEdMxlaDV7UMmx22fqAVJZViAjexnx6pa2LfqgD7ehxi76KjCAJIxnkJGvK4s5HQkVXC5
+ZQYel3fkNW5zjL_RyorpMc5tMatpsu-n4JiyViRXS3WS_W8
+}
+
+AWSEntityColoring(Macie)
+!define Macie(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, Macie, Macie)
+!define Macie(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, Macie, Macie)
+!define MacieParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, Macie, Macie)
+!define MacieParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, Macie, Macie)
+
+sprite $ResourceAccessManager [64x64/16z] {
+xTM5hgr038NXrKwTzt_V6p9xWACqHAwTFxAb-N2fFwAVVagtPfwVUKSx_ymRn5e9x7DlMpNQx4jVgynwNzRgtYTJVfYElXTWl1y2qlKEObXTKi0PqlD9y03o
+oYcs94ZB3-XEHgq457Evsl06tZyOUWmereRPhGyWzi-Sd_F2zENrrlFhCjeSl2Pp0K6GklCAoAlh6QFO9h_pZ4jypiW8MlS-ur9UBu39R_oNAMazzREjxNqG
+3Q-Zi5Lsl014rpk8iTA6Lv1dEaDERxwd7H-WV5riSVZv6HrlvsdMmsVVAtojJHxvDVLdtjU17_0dVjtu2gfttbi-22p2e3WzpI0DNpa0O4Ijb6d6tdp-ksTj
+zKaDFmjJYyS-67CVdda7Xhan44zy4cpRNk-DNFMzGjDytifde-qPJlFXcp9M16dw10kKt-rx4hpl8OIiQuvRJxodnN2UpweSpAuyN1cmKjwZpttGR9H2ocCU
+oIEoSdeLzMavc-_9RRxuqdcaa-Gvpxeh2AIc37WzAWVsEEffwUPHVtO__VGB
+}
+
+AWSEntityColoring(ResourceAccessManager)
+!define ResourceAccessManager(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, ResourceAccessManager, ResourceAccessManager)
+!define ResourceAccessManager(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, ResourceAccessManager, ResourceAccessManager)
+!define ResourceAccessManagerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, ResourceAccessManager, ResourceAccessManager)
+!define ResourceAccessManagerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, ResourceAccessManager, ResourceAccessManager)
+
+sprite $SecIdentityAndCompliance [64x64/16z] {
+xTO7pjum20PWXWs6tF--DHPIHXT9T_-ytyZYiK4pyAVo1Y6F22ntqm5ezxBvpTZP-o_mhpSX4dlgbG4uVlh0MqV0Rll97M-nTLFVt6p-QOichEf7Go2PCCwm
+ZLX62EAiu8spSfcPM2jNPVk-7z3t9fpPzwqxZ8AF8aqJFjVIUQnwXTLp-fn5x_ZGwRF-O_ZNlruV-opSlkArvYLwk7hDiRxh7LlyhhwXUyUAPuhgtU-hDlA2
+5x0OuEpNwDWgVbcYioTQ3ohUYMC_ENe9si5ANgAEmNPl40TiNl8MXOPewVDSO9HyLWv4zOrvSqKSkMhDEyL-Ha129FEmEa4hUyD5b140MNscWNhPH_DZLSsi
+8mUl-sY-3S-C1gXUzHb1GEupVFlz8wEDS8QQsgzzVtjzjxiP9_yWFyy3yPFGlYq-2lmF-GG
+}
+
+AWSEntityColoring(SecIdentityAndCompliance)
+!define SecIdentityAndCompliance(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, SecIdentityAndCompliance, SecIdentityAndCompliance)
+!define SecIdentityAndCompliance(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, SecIdentityAndCompliance, SecIdentityAndCompliance)
+!define SecIdentityAndComplianceParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, SecIdentityAndCompliance, SecIdentityAndCompliance)
+!define SecIdentityAndComplianceParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, SecIdentityAndCompliance, SecIdentityAndCompliance)
+
+sprite $SecretsManager [64x64/16z] {
+xPO5jYGn24KV48Bq_jSxaXPQYvmvClRlbzRxAa1P_hbyyOLPRZCaNo3QzmMF0MuwWA7cln3WohZ1Uei8smbmMTOq8fihIVpwbJuW1i0prXihC2O38zONEDeI
+36JvX16iz2uWyeKelGruJvI-6J25MURjrOOUNW7EMB3d8ZJIcuG1Mm6H6GJn21VGJJACGzsnlYlmdr6Q2oqf27vSkrsh2AAuIlSBaCFDStMYdZCYwxaVLJyx
+VnvrW12T7w23vKiMu5CkJemiv7C14thRp5JGl43GULk1Odxo5LQTU6BK1FHp-xoUwlo9sNhGylrJ0uq0aeewrVdpL98GGBRZPsOmm97Xi_Dhvx_t5QhG4p_M
+Fzh-bMy6JHtIzw_cLxu3W5VzpVmSyZGAN_fWBb_WtVvRVX8jfUeFK7_yb2_oqubgsiHeZz-Q_wBgxuxVPDZL7wh5kFe6pWFiUefLFA4PaHbh0_q9BCEUY23f
+Jb_BovYHRuYwCXqZqER2qkWSsGGq-i7rKxPqiEKJncW2wWeR0eZTtp-O019LGZT-Ou1acXEvJI60RQS7DJeRX1iqRBU9HVWS0iYO7fjJsBj_bB7lc-MVonTV
+V0S
+}
+
+AWSEntityColoring(SecretsManager)
+!define SecretsManager(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, SecretsManager, SecretsManager)
+!define SecretsManager(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, SecretsManager, SecretsManager)
+!define SecretsManagerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, SecretsManager, SecretsManager)
+!define SecretsManagerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, SecretsManager, SecretsManager)
+
+sprite $SecurityHub [64x64/16z] {
+xPO5jYH120G3AMpkVzwLRxNIe-kI8wtH0ho4-NtrN_zLzIrqAcW-Z1UOGJtA6p4JsAEyq3EDFiehDLEFyu54274xqQwMUzC1V6_NMda9B_a2IAJsLW1eNmhu
+wX9oxn7PwmMHXi-nNaET-36_YDDJKcxbSocevppfvDHJKlf2mc9QiRVYHGIGUDcscK8kr3i8WDQCWsLdL3fOfmAeSJ6TPQAh7PQXDMaWgye0BDj0Oguh1AoM
+WBg0XK4-HQXwRj0fq0IykZiKJ8axAp-nhYLeTgA5zEruOPEinPEaHCV9MyXTASbImfw-efFuxRnHyyIFquiKlSy6bFwI7v6VnE_dDzfftyz_N_nyiPmKAUwC
+Ns7JI0k2i18_tPM_KNACJ00RfGhw9h9xPahHAQHwhMp7Ha7hglzD6LW523e15h44RSCC_9h_bQ0A46refGBWQMXFSCt_nbap2wcdTImYrWe7woV_kk9_eoyD
+wz2_PllVjOPrw9yJL_qlq4mbZlsxzQh_6O3DCJyt-5-wvnpthzlzxxX_Fjw_VytyiEUNNpC_xVdjLyoFUtxzVVLV__KU
+}
+
+AWSEntityColoring(SecurityHub)
+!define SecurityHub(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, SecurityHub, SecurityHub)
+!define SecurityHub(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, SecurityHub, SecurityHub)
+!define SecurityHubParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, SecurityHub, SecurityHub)
+!define SecurityHubParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, SecurityHub, SecurityHub)
+
+sprite $Shield [64x64/16z] {
+xPQ7ZgKm34MlxRZk___lyaAMZ8ODq_iSIK0idUJQhzRRyCilaI-GKnaGo-V99W2ORXUB9-Tk1B1kNYXZF3wMhb0xZEKMwzpYkJyFAOm1q8DR-9uxZnu0jhox
+yRNUSyyU1CmzpRzie4lVqExsK8bMeJIJ4p_WMrNC7gBlbowZZyVuEMVV_P6S0Nsaprar_JcRzaXVwdz-VBJ_w__we9VvBC_tsLVQjJy9KxMuz7Nj6wDpaSFN
+VWeWQgOCI2xykBc4FFl9u1X51YysI71LWvzzcKdcuWmZoo4dty3zhZh2B6RGpoR4VPz72JJc9Ai1ReAYJV-OIuVuoBaO06qNGXp-yRfMHWHek-ISqGc17zrE
+N_Vgm6y5MpN0Oy0dFqG4s2vnuHV3UmVjb7_sVv6_79IRI93e_f_DZi3mYCOTMGiQsluIGzmXeGGzNZ_YwzTlDxLd9WnQRC8kPlOh8LRwRBvSHQHPLmIIymIq
+kY3u_cSqisRD2LANP1j_5pePIfHrgpNLHfYdBt46GD9Q4oO0BRUQe2Fnw3-17Jh-mgQRUTPZoRYHzPRyyijV
+}
+
+AWSEntityColoring(Shield)
+!define Shield(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, Shield, Shield)
+!define Shield(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, Shield, Shield)
+!define ShieldParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, Shield, Shield)
+!define ShieldParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, Shield, Shield)
+
+sprite $ShieldShieldAdvanced [64x64/16z] {
+xPQ7SiCm34FDJUB_FxW-9JmFgRkz6NHNUI88Ihvi_oLr-JdCLW3Iw4Uq19wg-BO9iiIe_V20LFgESHzGoCb8EN-nj8xIPJpjfryjtNxdJUazS6rrtTHQD4Ur
+3dLjGcinAkAbmPK76-rDbijuFbIsvlaQsQWrjyplydHBgtKrGP_oFIsNH4eyXq-Vrv-EG28wznxh9pnTNZluNV8SFdtASvTk_j8JVuNlrUPRzaLUt-4LB_x5
+l_WNhpzw_lYYmhJxLiWrtojI9GkU0NbMuINVpaYD5ZpLOra0c_dUUDBiDL6quAaR8r5JcIq4geEm1U-Fs2JgdJTbsluAHHFFepm53iNL0tLT1MBY4v2D2wXG
+9jO0a7GBeFeNs8rt83Og8BWDvNq31QIzGY-y0KLR03vUQ6CrskSjuJ53-C6J0yL7NrLvz7IIeV_M0b9fyAG9bFHWJwwu9WETlDIOKOql87cSFx-b4iUaxicJ
+5rfbrF4qVqki5QUpGnfLg0gbuu9QH0nNktH-551T_qDq-7FKNk3aollEdCJLNRREF6sMku3ANLFz3YvbnIl0j_vbyIZXNBtB7lclJYLDTSYnArseMV74FFy-
+SBCuC3Iwp1g_xeHsD5NHqz9jAVR4MMbykbVcZnzObs_Nvf6PuIPq6ixpzxuKtv8KKCQq4Ni19T-YUpYeAZmlnRTbsP7ezZEnkhlozeTw0m
+}
+
+AWSEntityColoring(ShieldShieldAdvanced)
+!define ShieldShieldAdvanced(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, ShieldShieldAdvanced, ShieldShieldAdvanced)
+!define ShieldShieldAdvanced(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, ShieldShieldAdvanced, ShieldShieldAdvanced)
+!define ShieldShieldAdvancedParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, ShieldShieldAdvanced, ShieldShieldAdvanced)
+!define ShieldShieldAdvancedParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, ShieldShieldAdvanced, ShieldShieldAdvanced)
+
+sprite $SingleSignOn [64x64/16z] {
+xPQ5aiCm34HNihZ__xr7lf83axX31s-ej2kmjvFwZVppJxXxJek5y0bfJAYp0MYYmW0aJnSdi7LL6e7pj5oUUg5p1WojHmHyHgvezKo3LfWUEuqavFAZ1W3a
+1_GEMMa9R2x00GE1h_GatVh09XahlychjqtfnzcsYOOTVGAakNjs8Arjh04xCmZ8QYJ3FUxl55YhiBLVPtp2zdYzVMjriH94xZdal9VXzTs1Hpc3eovzhvIR
+TJg-6AoXLRdda29T7y1Weo5N443UpUocjqFr6xmOt5llu-tfOmXk4bM2woBmfvifYAtzZtu9xdtqP6qbl6FW7FiHS0C_hKqtKo3W6FGfGCl7PEjEYWLe5fqg
+-lfXvaCoKtdtRyW8LsA8Uu2o76XHUxXA-oAxuccwJ8iwZe97Wpf50zcd93tc31G0DoPGpXc4401YwCG8dOoiW5oc3Nfur5um202G5mpSdQSDEWcwdghL34Gz
+5pQhnoTscTMRV018xtyI1m1_yRcoVWV__FCE
+}
+
+AWSEntityColoring(SingleSignOn)
+!define SingleSignOn(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, SingleSignOn, SingleSignOn)
+!define SingleSignOn(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, SingleSignOn, SingleSignOn)
+!define SingleSignOnParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, SingleSignOn, SingleSignOn)
+!define SingleSignOnParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, SingleSignOn, SingleSignOn)
+
+sprite $WAF [64x64/16z] {
+xLO54Xmn39DZlll_UmkUkNKAvsmxKDJ0ecH5mSVlY__u3_Vx_yhARzuHtUSplXG8Km54BNv288HmWUIIIByZu0i0gmTHk3A0vQzVpWB9mB9IOgwYjW3E-g4k
+iu1VrHg-u4M_au5d9U1xgMpwlH0L8Ds_PDFl2EJgs0fsWvxU0W4m8FtDgcM7ufk0m1bO6yKF5XoKfHAPdvyqWPsI19_u2_Kvmpvd5-2d0B2zm1heSNqr0FoP
+xn12xXLYc85NgGGjBCWZ80hTEq7UyxTAYs81-Wn8OeLc2m_sEof61X0FXpmMjfd9xnjWPRH_C_dypYh3oxR2tl4LlkMKBvsd0dGrpQ7lu-jb0jHN1Umg6-y2
+T0A8BolQLm7bYyO4a9_u2Sg-CgooRVx9lq6tQtZtJVkVyXFu5wEj-LD-1cqddMBJflxh6bs_NpID4OVnsquSii-RjZJDdywzJVUyDSYT-IkGvlUwqJx6zQC8
+aizNNyM2j8_J-bN81RAelrDh3Oiyhb_xzfO242YCKIjOKErCV5g_Qvak1AD0jNXaxqmpk0T8w6AzA2KmOzXXRmhK7kSvxqmpVTg_Pu4i-dH-c0MywFFvPHQO
+pqzdWUdyrW8Jwtn-PFcXy-llY__uZuy
+}
+
+AWSEntityColoring(WAF)
+!define WAF(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, WAF, WAF)
+!define WAF(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, WAF, WAF)
+!define WAFParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, WAF, WAF)
+!define WAFParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, WAF, WAF)
+
+sprite $WAFFilteringRule [64x64/16z] {
+jLU9jfqW32pPYFx_1nUUvgBfQBdbD6z_CjbcuWc__gUL7_idA8bLttxCgmbz1pRVaxbDkv03tEDgivx7uKBcqQvygRkm-fm7yXxP2DNKi_3tAhIZjJomeTs3
+lj1LstChBmUi7QZbwQctuFnU7xSK73iWz0W78VIWmMs686iE2l0BuDWCvLbROoQmu6mGv_FwzamZfPeA4RE8QBFsWvcef5vHSiWVgVQvs_-mFeSVKVCzNOc2
+g0uajArIj406VZkpv-qpU3tdi5xB64C-AzYkuJMyxYxq_4xnFJBLIm8UpPCn-Brf7D5PBl4bMkYZ-JQO_PlLeIAw_nOYjgV-MqZt7jKlNEZntrA8cqctevBI
+SNPc7x1mf5a9sH3hUgOjDmIz2DblgkCp6RjBrxAsSsr3nCUVTGGCPH1aFrGsqgdn8rLP7wQMqpyyqWZBsWOp4XQ5botNMrAYJ__KX0UD2Wlgyx641oA0rEFu
+G0I0Ue0tz8fLK17et-0FYm1J7_m1_GmH8Eg1VaA_K0IPUg3Vc1_CDwO-vYVDBswPFHwWzFu08i3K1opy4vutE_i37qT-yHliB-OdekRtzpm-tj_1ZtwBr-iy
+3O8m7jEBtWqOZ-K5k9h18qu9xKJUQU4QH_7-WFUN4CYnzXhQN-1Eb4zrgupsfudzpJUmIiFz3U-F949F--FY_hguFo_kxsltX_Nxo_hzQVt-jdv_NB-_hj-V
+r-qt
+}
+
+AWSEntityColoring(WAFFilteringRule)
+!define WAFFilteringRule(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D6242D, WAFFilteringRule, WAFFilteringRule)
+!define WAFFilteringRule(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D6242D, WAFFilteringRule, WAFFilteringRule)
+!define WAFFilteringRuleParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D6242D, WAFFilteringRule, WAFFilteringRule)
+!define WAFFilteringRuleParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D6242D, WAFFilteringRule, WAFFilteringRule)
+

--- a/awslib/Storage/Backup.puml
+++ b/awslib/Storage/Backup.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Backup [64x64/16z] {
+xPI9aYCX240Vg23y___kONgAIkzsnkawvtYvLGfyIkBByiCFqsp6VGp0xcU7CU1k1JaOkTvknrkctOut43EvPo1dWmRhhSqFb-22UZXuk28U7wD3__ifKh-s
+oPKnApvNDHcR36YnMF6B1cDJd28M1-vnO8A-gt56s9FkpAS3iRNaYY68KdLcJFSPMVj21HdNsrRUnCqPimk0z9Noq8XUYX0y7Os5YWcqtXkK3brBvABRD4ku
+0cD6PinH6V_EfZAlyYzx_XPlUPGDQyoNGKUk-sKzrI8w9IeDZJ0zvY_xoPORK_GXi6XuAchBiSKbOpLxNPegeEVVqHmb_yBXMyZ_nvUxIshUnh_nzVdwB--K
+f-9g-X8_5lPdoKRFu_x4Q-IHs6dnxFzHXiHBAh7YMVhHAkCLbTWHpseRhp9UKWtmkFMPnxUQUqtbC92__ITWLTkxr1wh_qzkhYd7SmMvcTSlOSRk1aHc3KsH
+tV8ZZP7Pp-VVCmUMiRM1tZcP5dhVAp-c08myzGKWM_6TvXqzzsNtHeyDXCXKJcXc87lnCqFH9z38kHS_qD5evqDjGncnGmDqdgGgq68FDxyO_5hyyCDl
+}
+
+AWSEntityColoring(Backup)
+!define Backup(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, Backup, Backup)
+!define Backup(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, Backup, Backup)
+!define BackupParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, Backup, Backup)
+!define BackupParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, Backup, Backup)

--- a/awslib/Storage/EBSSnapshot.puml
+++ b/awslib/Storage/EBSSnapshot.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EBSSnapshot [64x64/16z] {
+nLVdmkqW22iRtl-1xx1dUehnpYz_5SGaO7ly4z05zgCvwm8fkuTdNOEtmrq_O5N9E-5HvLSBFnCGZc_2TnFuppBf6b4L884LGA3g0HAmfm1y_5im007wlvY_
+gE05V2D-xkF97kjuDHqiYdbatahES9CXd9XX1JIk-pysn2UDntPt6t1_90obTVavGbrddOdLppLTjtwbjLMoPQrQC4PwK61l8QboWWHvbJIvfvNs56rNKb6u
+PdiArKHVGs3nUkwdgz2i7yaGSA0ZAIij7_PvzS_TG6D3zlhbJuj7DGYJiyCQ-Aqq4druzk5b5ReLwIst4pL4OsBHHBBrqc83y68FVrX38gRTCjMuh8q_rRPU
+lazkTB3-bc0v0MTj-AQRz5kEPNBDZ27WO-xa58ylntwQckyzaWmCC8CixyFll942STknwbuLJG9aBgyJvbNPTh1lpFOc7h5xJkZb48z7vlu0OYOi8BWW4B03
+DmJlTZ3ZTTsl3ni0yuC5HDsB1KJTkty0a0zS4D03nYEG1mWCi-CAiNo3eN9kQXkD3o3dAoiqrINd39C3WUFvWDl0-NpFJm7uofWmVPaWaEZy_Kk__Hjz_4jy
+1m
+}
+
+AWSEntityColoring(EBSSnapshot)
+!define EBSSnapshot(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, EBSSnapshot, EBSSnapshot)
+!define EBSSnapshot(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, EBSSnapshot, EBSSnapshot)
+!define EBSSnapshotParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, EBSSnapshot, EBSSnapshot)
+!define EBSSnapshotParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, EBSSnapshot, EBSSnapshot)

--- a/awslib/Storage/EBSVolume.puml
+++ b/awslib/Storage/EBSVolume.puml
@@ -1,0 +1,12 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EBSVolume [64x64/16z] {
+xTOf6aGn20HXo5xtl_3esJhXUv7ylWIjiDjSskOJQPhMsUWohx2QiA2gsnSK4meibyStanfCTVomZG5T7E-xthycKCVh2VJnUW9zV7o22jHofF8zWHFaN-D5
+V4_e9SJjij92wcU_7kx7utxuiVwhxtQiFU-pppxxxBFFFlliiv_jsBp-FzeaPDed3x5RNW
+}
+
+AWSEntityColoring(EBSVolume)
+!define EBSVolume(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, EBSVolume, EBSVolume)
+!define EBSVolume(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, EBSVolume, EBSVolume)
+!define EBSVolumeParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, EBSVolume, EBSVolume)
+!define EBSVolumeParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, EBSVolume, EBSVolume)

--- a/awslib/Storage/EFSFilesystem.puml
+++ b/awslib/Storage/EFSFilesystem.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $EFSFilesystem [64x64/16z] {
+lPE9hjqW34Izs_F_Frm14HVU3ctVkMj6ET58DlHlO2PgRtuN_YXr54KbLJczo0eg60EwwEY9AC2RdqWgnEgZ-Rxxz84l2NYX74YPD-gJE10yKmCoW0XWT6MH
+meiIuPug5bBwSqKC2zxIcKoCYE9TAaHKxzB73nx4vXiFQlE5EpByqJze45j_eq6z-ZiWSn2zFwjklchpHMtpjOz0TVD3TVIV_jf_zTV-qs_ylK_CMt_cPwoh
+7oDbjjNtbehxwiEztQ3kgr_kJ4Jc0V3qqvt82a3A807KxEyosFkRTFJfhrLOgU4NiAVDptSfDH8laXwuyCBfGR6WDE10IQAaa4pB0rA1qAPFsfK1vbF_ylm2
+_eFpRvda6HJfDEbNcSQPYq-PofaYcKo_2KSDqg_yn2GkT0KoEWNmbI_KiIlVLb_e8oph2rQ_Ekcywe4lMVn9ybQmuYji3lAXjaaaYiz7kbua7UB3jzdc09u-
+uuRO_3e4gEbJekYG07Zw3l3vDciNrTqJ23-1YG5l_Xr9LCZk5suG2XGttm0dFaA068VG0IeK7P802s3TDy0EVGMS2j5z1f8EAHGdglbZY8U-0UO0Tr_k2XYW
+tQS0vFpWjlVm-ppEO20BESyF-Fpy01N0dCSPWaOD_sw76iE_sg7LvpeVOIx-tGvD_tA7fd-vGzE_tQ7ft-_GzFLyX3BzonsArJSWx8pDPronpkE2f1Ty0Vqj
+Vm
+}
+
+AWSEntityColoring(EFSFilesystem)
+!define EFSFilesystem(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, EFSFilesystem, EFSFilesystem)
+!define EFSFilesystem(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, EFSFilesystem, EFSFilesystem)
+!define EFSFilesystemParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, EFSFilesystem, EFSFilesystem)
+!define EFSFilesystemParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, EFSFilesystem, EFSFilesystem)

--- a/awslib/Storage/ElasticBlockStoreEBS.puml
+++ b/awslib/Storage/ElasticBlockStoreEBS.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ElasticBlockStoreEBS [64x64/16z] {
+xPO7OiCm202P0l7_1rU9b1tYqTtg4ayuRnlgps0oAHslALuwptNebCZqEATalYxlNr_vN2DgpY7AkQyCL1SWOCtyqgAqf5CjgH-7-98UgQ_HCmOHjzCHZEJu
+lNZFaRviAamD5hM-He0kYO_4o3f4NH2kmB7oadWXlPTgViGqkMSf3g1ZDsD_2k3hVGEqeOyD689jyG58RUpHJGbWcyyC3KGYH6WmR_CrlCZHHIGf7hhLxzVF
+lL-_FVw5h_IdF_tfoxqlMtm74B_-Vhfi-dvMGm2IOjwm8WI0oUwp-g44Lv0czIEjNz6MLRWXsWAHrg-yVjQ8CKxgvplgzxlwX_VsB-_jdzxVlxstVtnl__ep
+c4pU
+}
+
+AWSEntityColoring(ElasticBlockStoreEBS)
+!define ElasticBlockStoreEBS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, ElasticBlockStoreEBS, ElasticBlockStoreEBS)
+!define ElasticBlockStoreEBS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, ElasticBlockStoreEBS, ElasticBlockStoreEBS)
+!define ElasticBlockStoreEBSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, ElasticBlockStoreEBS, ElasticBlockStoreEBS)
+!define ElasticBlockStoreEBSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, ElasticBlockStoreEBS, ElasticBlockStoreEBS)

--- a/awslib/Storage/ElasticFileSystemEFS.puml
+++ b/awslib/Storage/ElasticFileSystemEFS.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ElasticFileSystemEFS [64x64/16z] {
+xTO7ajr020JG9WpGtF--Jghz6OzSplQ-IZ_GeopWd-7TkpWKHnM7rt4SeZdeImcVzGAmzjl_KjP3tjXDphffStuPb1iAMrC-gD1TN1bZlkyMw4zUn7lCh-Pr
+WGftN_KOlnG-gQYZnaccug392uTU2bzeVk55Eg0hCvS2pZVfTuKpXmJxIsK8ZDye8DKyT1q7r3oj1DdtNojMygHUyBw_w-NkJEuewl47U1YaU4P1UIyqkzlX
+F2EdEWZFk1p-8uKNTr81dnO6h3Pnm9A3Mh8vYIM8vgZfq9ENtkIJvyKKUUBILov0199lYbzqmZaJESw204XISHLFTyTyYGNcYsJQ1S3kRLw4HqqtxxJ3t6EN
+DqIJ1NlvTeUn0zuS9PHJFWpHc_DFWrOFUK6LmNOFB_9rtc4BK6ui6VA225dScizVaVoElF7xyj5yCFIFWlMZ1JpqZxb_5JGU6QmV-jVOFmklH5_wP_3h_JjU
+kUdVmStyqCzkvuVWzyqlmU-Pdxv_Velldn-_Vtxz_Twz-mW
+}
+
+AWSEntityColoring(ElasticFileSystemEFS)
+!define ElasticFileSystemEFS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, ElasticFileSystemEFS, ElasticFileSystemEFS)
+!define ElasticFileSystemEFS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, ElasticFileSystemEFS, ElasticFileSystemEFS)
+!define ElasticFileSystemEFSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, ElasticFileSystemEFS, ElasticFileSystemEFS)
+!define ElasticFileSystemEFSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, ElasticFileSystemEFS, ElasticFileSystemEFS)

--- a/awslib/Storage/FSx.puml
+++ b/awslib/Storage/FSx.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $FSx [64x64/16z] {
+xPHfaaGX28CJ557kV-0fwctqh4p_zkirMd4Zp_MPpMQpsVZvNMKyM6Xjf3IredtYeVao0YH3LFrCynkWCrgjb_tYZn8CJyVWJvVxZ_uik1BM-xnwph-_-or4
+WhTkaDByiZ86gCVY5PW5_oBCamoV7KKQNl4FG5-oqy0urgXcnHy3C9_K9DGx-5j-U3AFWmOWurg43ra6s6z-EPbdYmf0pOUYlehh3tnPV_9xhhxk3zm8pKKi
+-q_Sm3E3Im6h-JCy4YEm9U2RVk_HFO7-rlhzA9sFQlxkiY-1dkavOpWB_YdTPlmEGl9JDudsavz92VBrfS1CHVpf_ipAUXDIkeNGT8iErVzVt_xQiTbiDfiF
+}
+
+AWSEntityColoring(FSx)
+!define FSx(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, FSx, FSx)
+!define FSx(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, FSx, FSx)
+!define FSxParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, FSx, FSx)
+!define FSxParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, FSx, FSx)

--- a/awslib/Storage/FSxforLustre.puml
+++ b/awslib/Storage/FSxforLustre.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $FSxforLustre [64x64/16z] {
+xT55OWKn30DGcItV_xwVCcNkgf2t6eX2ug-tRTkspSB3y6l2bng6YgWtlqJ4ReeApt3rB-Pzrhu3FPmXlvUdsd0fMNjmxM_bQSZX989Vo0TgU13fQUZdzl-m
+gjLHNy56fJzJfqAkacGg97fj9WCvP5yx5IiMto1MUR5YvK3oOWe-P48yCXI2_k3yoz3Mo8Po4ivo3og47-SNn90UYMWu5QhcKF7FviLd4ZcMBbGfJa0wqP_A
+Jo6dOIHR8j0p0UGGCH_qdqqoHSbLNQFKs04uIRCt-ekxl404i9vL7Gibk1AIuyfNDUzLhZrq7--i2zVYHHV_kstRjkqC
+}
+
+AWSEntityColoring(FSxforLustre)
+!define FSxforLustre(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, FSxforLustre, FSxforLustre)
+!define FSxforLustre(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, FSxforLustre, FSxforLustre)
+!define FSxforLustreParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, FSxforLustre, FSxforLustre)
+!define FSxforLustreParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, FSxforLustre, FSxforLustre)

--- a/awslib/Storage/FSxforWindowsFileServer.puml
+++ b/awslib/Storage/FSxforWindowsFileServer.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $FSxforWindowsFileServer [64x64/16z] {
+xT47pYin20JW0MnWkFzzKnoohvUDoj_yIQZJ-QvisxPjrN62Fv6CeMepUORWGP83OgP0dCeVR1EJTv7dyeiFOiKMdi_j_Zi_CR_bGv9aEUob_ZLNOaBud_cz
+Vx4Pd3H4_JkVUSER0JcUboAhO1poh_-JjRO15bny9hGc3hD-ds--SCafiEGYo9gIJMRzTVzMd30kYgWfRF_ERpMHFR_mXNm6Wdmixo_tLmIfxgVownufofhh
+t1a3qJ3uMpZoLQU73qXMG7cNW40M27_BdCrL0CX8ScXo4T46uxzb9dyGfcqaFxfjsxRj2W
+}
+
+AWSEntityColoring(FSxforWindowsFileServer)
+!define FSxforWindowsFileServer(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, FSxforWindowsFileServer, FSxforWindowsFileServer)
+!define FSxforWindowsFileServer(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, FSxforWindowsFileServer, FSxforWindowsFileServer)
+!define FSxforWindowsFileServerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, FSxforWindowsFileServer, FSxforWindowsFileServer)
+!define FSxforWindowsFileServerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, FSxforWindowsFileServer, FSxforWindowsFileServer)

--- a/awslib/Storage/S3Bucket.puml
+++ b/awslib/Storage/S3Bucket.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $S3Bucket [64x64/16z] {
+lLS7akCm33iMaS3_7toDayXAp5Y-ifYsHUm0BNtxZv32RJCrZqo01I0pt5HsR6qas233zPEnZkIC6J4A4JCNOcWJsVCPnTwB5lMe0uIVLE8exoONrV4Nniif
+pPFKkY914hRy3PNL7YhNWmC16RV6F4Zgz4UEcnoneyaWRvCCpADzt3JteucHJBt3yE0nVotUs6xjGIu341OG9fVw2B2WnsQ4vSF7Q9IcvW_RjBNboInYFO2C
+YE7s2ruAugAW89xMypUf23qGhZFYAG54VKp17kGyNELOyJfDFTbTQh-W9pjCLiPgJMCVIdhZRWks1XHq15uoxmi6ypGC23_xHxmeBecpu23dmPFpZRzL5wDL
+RrzFGRfzAs3q_PmOJyhAgsDlvhb2NQLa4Rg4g-Dx193wDkGimzy-0LLG2yk7ycPTq6KWUS7Ou4mYI93qLS4Ng4OGOR-Z3PAsA7Xxyu7C8kS70bn_fL4nxofO
+VTuI_ap1HaO02BqSOATUQHInXI0QHVRep-uFiCzrVu3Lw-WtulxoxV-ultpl4g0ljHzWt-f-AFlZtrTmlols2T1JtHe2j9s-Fy1UwhtR_KJ1s1xVVblt1vN4
+pW04H4TB-7NrQFiKbs-GkYBcntS5aIStK97dxNDiR7UoURzXo0Kx-YieqZSPQZxY_Vtw1U_d-_W1
+}
+
+AWSEntityColoring(S3Bucket)
+!define S3Bucket(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, S3Bucket, S3Bucket)
+!define S3Bucket(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, S3Bucket, S3Bucket)
+!define S3BucketParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, S3Bucket, S3Bucket)
+!define S3BucketParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, S3Bucket, S3Bucket)

--- a/awslib/Storage/S3BucketwithObjects.puml
+++ b/awslib/Storage/S3BucketwithObjects.puml
@@ -1,0 +1,18 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $S3BucketwithObjects [64x64/16z] {
+lLS7jjim32k7IEB-5-vpF22dL4ON_lI024a47F_uTv0TNzFKHcHMOKTLnd3JJxZgKLYWSjXBCKPkPKQC7H7KWdHTg1vrLd6LNvV2BcLf3JlsIuFK1d8eB7zM
+Ne-pvAwXZo7oTgilLBsOQKq3A03_ZClP9WyJOF7F43EbEDYdK63yONsV3p3a2xOb0FRHm8RG3nVF4njOqB2ZsDyl_84TTLiCzxCvmqsMhYmSKdDUSW76pJse
+XtlSDlY8YEIrtDgq41UTHqltSbYJgo8ngn7raIn7Exkfp3E-xMPrsQMRVEqYp8xjumP-bt9EFW-_GDmBsgg1L-6RzmdBmh-Za8qmEexycEKOSu4thk_dU5mD
+-i9Qz_foFd8LjJPlkLxzUWQkE4liOB8kzil9Dw3gZ4TprTYjAVT-qPMW0jIvFdooXCroo_i5sQbvBo1Uf_CuhwGY-abswSfzOsHHHA4AABqvcBd8lpCqZf3I
+hPe4do5qi5rrTnrzyjLZy074iuCB27yWUNM6yYazW7foiE46cNYgCW-n8vuwGWiWE06lMy0745arzuGU3I34TL6kDhJMlTp07WcKc_EPGxUHpq1kp9B2rkfg
+SSo-lF0_DkigaPHWQz4bD4llu052gPOkQTEM9mE4SsQitwOzHGNAT8CVPm9Gph_RFcfZ9xCbx7JQ089UMJK0-LG4XFD3Mx_LXUZvN9BIrVPJrPtFy604yZn1
+NiVVVR4CNpguv_SthXxf0SG3sVDPW9ZB1OYEtsyVbzMoJZ2XPwoSoiX-2LibHNpo3Y2ZcnPZAbtVlRxqvMdT2ZUHvjDdCWGNO3HNJUzlcTFhsuBA8RBGey8f
+wnNKl7b_bV_n_lmzVW8
+}
+
+AWSEntityColoring(S3BucketwithObjects)
+!define S3BucketwithObjects(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, S3BucketwithObjects, S3BucketwithObjects)
+!define S3BucketwithObjects(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, S3BucketwithObjects, S3BucketwithObjects)
+!define S3BucketwithObjectsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, S3BucketwithObjects, S3BucketwithObjects)
+!define S3BucketwithObjectsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, S3BucketwithObjects, S3BucketwithObjects)

--- a/awslib/Storage/S3Glacier.puml
+++ b/awslib/Storage/S3Glacier.puml
@@ -1,0 +1,16 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $S3Glacier [64x64/16z] {
+xTO5iiH630JG5gjr__i6lFvaPyRPek1R1cbOPVxT_Ez_GxAhyb3TvBmHsnMc-4xKi_zSZWuzGypZuAPoVEFrcABi-6DMatDw3UP8Ay4jNxSox3H0Yci6oMqN
+su3YIa9xk3K9MVxcoE63KVJgfu3KqzewX2i5m8gSLN270CgLXYWWbaLolh8SIzZb2a1XctXbcG20caTc7JB3zVLjTC67Am8EMM62mtq7Jo3MyUVS3jbT6VuI
+yTgEvneL5wu_pYT-CVGwFf1ye6WkvNLoKktoTn6krMLn6e3FTOdM6dgBXpU_B9PlrJk72E3rROGnxynETuS0bkVo1OmRXkBLC1MGE3BlAyWuadV3ChmweJ0W
+bl7huRKB82x2abidRzExxWJK5J7R1LmB0DiPW72hggkQImAkT3OxkMVeNNKrr71jVRpBKj2JyB3czWJF7-S5z3mGnSSJV5SEz0GqYayd-2vVMxy5FTErFy5t
+ZfYXGi_NsfxWkn9OX07m28MzMzycy5qFLyPGl2aWiXn0P1hatH8SvxWDFaD3lRk0nPc0Kr0pRAuruCrRYZwwFGdnv5O9e76vVXe78C_xxn3wu_hDtM8gIj4J
+y78-67Qw2huOESVvysFypsQkrwzar_7uE_dV_tu5
+}
+
+AWSEntityColoring(S3Glacier)
+!define S3Glacier(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, S3Glacier, S3Glacier)
+!define S3Glacier(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, S3Glacier, S3Glacier)
+!define S3GlacierParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, S3Glacier, S3Glacier)
+!define S3GlacierParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, S3Glacier, S3Glacier)

--- a/awslib/Storage/S3GlacierArchive.puml
+++ b/awslib/Storage/S3GlacierArchive.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $S3GlacierArchive [64x64/16z] {
+xTO5ZaGn38DXfvJu_WTUfbJE3ehx2Gl_u2CycILYvd-3oG8M_ug1_nYp08APuHzEpl73FtiVFoRfgFMyl3xxbT-Wes91sl-zaM4eJ792z6AFqiZ0fHv1jlB7
+wx8Nlv4mo0NPxxCS-iSBqtsnKR-ixlK7pLyhRFFTsoR4GH1Kebx8Z983JicGjQ6qUk79h2bMBsoY_FuF_7xrxq_RUwwsyy_UsswfVW3ryPSDylIdF_tfJt_w
+qv_-z3vs_jch1Tfpd__WL1Qmg3XsfjGBp_8A
+}
+
+AWSEntityColoring(S3GlacierArchive)
+!define S3GlacierArchive(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, S3GlacierArchive, S3GlacierArchive)
+!define S3GlacierArchive(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, S3GlacierArchive, S3GlacierArchive)
+!define S3GlacierArchiveParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, S3GlacierArchive, S3GlacierArchive)
+!define S3GlacierArchiveParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, S3GlacierArchive, S3GlacierArchive)

--- a/awslib/Storage/S3GlacierVault.puml
+++ b/awslib/Storage/S3GlacierVault.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $S3GlacierVault [64x64/16z] {
+xPO5Ocin30J5qjx_m0M5oV0PEctOOxtT8FreUCXKJmp9YUwOu4DTWR811UWeUm520mGe7eOt6c90Zi87JGZ01-5vedT4dOQVLp0FFwzW7dwz0WMWieJYiGB6
+9lnGtWwF5R9imVI34Tj2x_twplxmtNxmClxCTrh6_XUVF_XcNw80e4A-nPV4cPHrNyfwINjkvhtFuRwIkPz0Qb-4d780IQG9vDotmgVAgNH6aoK0b2taPmS0
+vyzrMPLsVT_SFrLN9eMcnAfBNEzVJsh4wPgkFtyIoZtI-NZePQonFDy19WM2cW2q5wpwWUerf-Uld_v2xFfC3K_y7pw_yyjrVjdAhpqm-wxUBLlHLP_hqv3J
+yzz14iMBVe-qgnUHjk6qx3Dw9di1vTp70bxtoNfgUtfyEHkj-vq0pWUV-mPj-Rq1xDCtjBxfa-R5JwKzlz7WJv-ZxNt_qjz_wxEx_9hltoy_RPdyuRyVAR55
+qZsy1VqetW4
+}
+
+AWSEntityColoring(S3GlacierVault)
+!define S3GlacierVault(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, S3GlacierVault, S3GlacierVault)
+!define S3GlacierVault(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, S3GlacierVault, S3GlacierVault)
+!define S3GlacierVaultParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, S3GlacierVault, S3GlacierVault)
+!define S3GlacierVaultParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, S3GlacierVault, S3GlacierVault)

--- a/awslib/Storage/S3Object.puml
+++ b/awslib/Storage/S3Object.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $S3Object [64x64/16z] {
+x95LmiGW38IP12BtF_2wXstdT_sUAYGZj8_Y7qW_87Z5RBV82s7zHJlKi-1AJyTnOAW88ABZk2we3N8uR8gxE6g7bR8wFdB7GFs1uv-Lscol3Uvd1LvIbcOS
+pyVBxwa05dvQMy6UIrWPfq-TclT6uFDRa99ieIMPhjL6eJEZUeh5O1Efo0GxZyoeygFHZ6B0J_8SU6m0f_GizY3NsVAlSNlPHrFznYaFZT_T04xjyumxmrBY
+4mL8UIEfYfslxvgu_uxvj_VtzllRjb_d10008133_BkkYAp50byEvWVc5_T7zrVl1zullPzul_L_uF_I_ud_6_sWVa4_eT_GZ-fNzxFxtVE3vnVFJrvN
+}
+
+AWSEntityColoring(S3Object)
+!define S3Object(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, S3Object, S3Object)
+!define S3Object(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, S3Object, S3Object)
+!define S3ObjectParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, S3Object, S3Object)
+!define S3ObjectParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, S3Object, S3Object)

--- a/awslib/Storage/SimpleStorageServiceS3.puml
+++ b/awslib/Storage/SimpleStorageServiceS3.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SimpleStorageServiceS3 [64x64/16z] {
+xPO54bmn34DbYYtV_xw5fTcq6vUvRp2SMDAVpn_6V_xJNx-iCjU5h2AxFtzjhJ31CwA-afz5XLwNc7jSS5EvzYmsPz80oFMmVa1MBXD0WYCEIDJBK_gwkIJF
+66I-OXcGFB6WrHpf1JsE1LQJCoseytf9ZZG3CjmVi6IVZH42A4yaH2_g5NV3NHKC1Q0mdYWeb-4zQXuhRwpmcuEy4juy8NAH-SczcuEBFTTOKJUhLEKAlnAn
+icvHR1_qRzi6-m9xYvwXE1c0d95XFHUYzmwruWQ4PnAxE0N0-qE9TgRH102lhSURPqG-2kHrX_s5eu0RTVMivKC-vu0XNsL60OswJfWorlvIm6RQBLeA0s8m
+mEbvvGA8GvXoiE1Sthv5IqFFamh6YG0mLW32WKvuPTPaRmviwHqCS61AxpnXtlxpBoZWp1hpKH1kZ0cUvPqJFDjhJl2H7j8xL7Y8r_097kCz7l7ryiy2zbM-
+cH9uiL_bDnNEJv82M6IHVOTaBHV0-3c4082eUSIAyFl_cov-5iqCKpmZvgk-xV-Llo7_-SzR
+}
+
+AWSEntityColoring(SimpleStorageServiceS3)
+!define SimpleStorageServiceS3(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, SimpleStorageServiceS3, SimpleStorageServiceS3)
+!define SimpleStorageServiceS3(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, SimpleStorageServiceS3, SimpleStorageServiceS3)
+!define SimpleStorageServiceS3Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, SimpleStorageServiceS3, SimpleStorageServiceS3)
+!define SimpleStorageServiceS3Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, SimpleStorageServiceS3, SimpleStorageServiceS3)

--- a/awslib/Storage/SnowFamilyImportExport.puml
+++ b/awslib/Storage/SnowFamilyImportExport.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SnowFamilyImportExport [64x64/16z] {
+xPQ7ikmW243fol__y1lYU4dJ6JUltvofkt1GIGDUNf15rn26HFq3ga03Yt-6Dj_SA-CY57lcqCczm3hXLMY79m0GsnDdO-jWf1tYd6BnUjC3tEBvGwvdftQ0
+ugNbriHT0AHsCBAESQVmfVlL8wc3sPByno1XTptw4Kwi7IsHs6iI-JEVsswJwFM2Ztx1LdnWEuCB_e1_mATIDqfFr7gYu9P7UEVdFGi025lqZFJGm2yMnChN
+nyhAvb2riOzv2n6SQKvnjwaVM1Ou-rIZ09R24_zQ8FUCDMz89DhwcJ-c1I8n2ypHB70c2x2E4AsjWCWrPlsPAZwbTMS0jrDEqOaVXyCn78SSf5XRVioyoVAb
+Yog0AlTcJdKqewFUtlyzqzp7Uju_JIV2c_kF0-ewyG49l-dJvxT6r4RFhuL-wykN3pouE-BOnd3lz_qIDCxxpyZLNq6D7_d-rxs_Aoxe-Vs-p0zZXlD3NP_X
+Sdx9-Mc551_DRq_dnuVpwyFv-V7y_lBo0m
+}
+
+AWSEntityColoring(SnowFamilyImportExport)
+!define SnowFamilyImportExport(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, SnowFamilyImportExport, SnowFamilyImportExport)
+!define SnowFamilyImportExport(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, SnowFamilyImportExport, SnowFamilyImportExport)
+!define SnowFamilyImportExportParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, SnowFamilyImportExport, SnowFamilyImportExport)
+!define SnowFamilyImportExportParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, SnowFamilyImportExport, SnowFamilyImportExport)

--- a/awslib/Storage/Storage.puml
+++ b/awslib/Storage/Storage.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Storage [64x64/16z] {
+xTO5OWCn34JHqSYWwFu7hfqk1wqol33yPS9N-IVpgq1B7WLmxOkFibsV_JJeM_V_lSrYVSAC5kXTfPQk4cAHdZw_4R58tv_RGzL4gaVwd79xesv4zK2lrDwt
+ZqJnyVwizOsYUBJtlY0Iyd2VcDeRy0meettMr9zU9L6FhB-JJpZQ7uptTIFI4mj6UjiOwRrH-a7hcoVwMd8kb99tYh1_Nn_tX9o_Ef3-BVX4hwURzAb-Vk-p
+vOkXtjB28hs24sYab-HJbkIj_LTCloMT79RVnw-_ev_KAyfDqCUz4JVHxlKpk-ctNZ_zzpQgxlg0z-j1ZQ1W9Y7u3Lu
+}
+
+AWSEntityColoring(Storage)
+!define Storage(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, Storage, Storage)
+!define Storage(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, Storage, Storage)
+!define StorageParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, Storage, Storage)
+!define StorageParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, Storage, Storage)

--- a/awslib/Storage/StorageGateway.puml
+++ b/awslib/Storage/StorageGateway.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $StorageGateway [64x64/16z] {
+xPC7ZkCm34K_crZkV-0T0gCOMSUo4vGjuvTU7gkSVnytDvNX7f7rcHxAQDZYamZQggWG07i_EOCiiciF1JZUr0dogBg2mU_v0bbyFcNiyZ6iUXlNV8BdCmvI
+090h4NnVRMdBog3p0AKOkuq7EAhIhaoI4RdZktU1NsZ_kBO1hTFfuxZ907HPWHF0MxxT6rblOG3YMp0J9W8HwvXE30RvSNcZfgm40DG008zPYXskKM2LJOK0
+a9arN1cW6K6X1-df-vq1P55VPDElBjk5IAz7_DYE0fRjc7J_tNv_Ol0im7DFsIoVu9Lf162shvqHDFyuQkbJRt8EeDidjBBvLelwso_fFLTkGzVDLupb_DhN
+xc73fzymOhM_wUThlnnyV7vE_Gh2M9tVjUyAQ1xX3DZ2BmF8Si6GiSe_UgSdhFmpRl_sRn-YzBjFAbTzHXFFViFN_F0lOl7TtyBDpIy
+}
+
+AWSEntityColoring(StorageGateway)
+!define StorageGateway(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, StorageGateway, StorageGateway)
+!define StorageGateway(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, StorageGateway, StorageGateway)
+!define StorageGatewayParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, StorageGateway, StorageGateway)
+!define StorageGatewayParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, StorageGateway, StorageGateway)

--- a/awslib/Storage/StorageGatewayCachedVolume.puml
+++ b/awslib/Storage/StorageGatewayCachedVolume.puml
@@ -1,0 +1,13 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $StorageGatewayCachedVolume [64x64/16z] {
+xTTNWeCm34LHDKjF-z_m85BfJ6--wK47yAVfe-9NjU2Hhofe6kShuuKFErsiUQFJsG_sh39-yFMNCb7zKsyiG_lUCz7gD-gN8XEaDLrlaG1apriQypYTKlyw
+4p_vEBf_E8svHoDguzWhFDTx1JLGpR_EIofLaYp93u-Xw_hzZ3VKhJoygRRo8I9dxZyII2V7rTF9-xzES9f8IxAKrwsVD5tDHb1h0KmRFppCZFSyQG3Dd8R2
+Y1q8bc2YUcin93l-L7_ITzzzzzrttttt6fWL-XhlkSXVwNtIgpre4evyzs6FOkdZOFysRUbdyS7-rMcIvxGusZ-_ul2xUW4
+}
+
+AWSEntityColoring(StorageGatewayCachedVolume)
+!define StorageGatewayCachedVolume(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, StorageGatewayCachedVolume, StorageGatewayCachedVolume)
+!define StorageGatewayCachedVolume(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, StorageGatewayCachedVolume, StorageGatewayCachedVolume)
+!define StorageGatewayCachedVolumeParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, StorageGatewayCachedVolume, StorageGatewayCachedVolume)
+!define StorageGatewayCachedVolumeParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, StorageGatewayCachedVolume, StorageGatewayCachedVolume)

--- a/awslib/Storage/StorageGatewayNonCachedVolume.puml
+++ b/awslib/Storage/StorageGatewayNonCachedVolume.puml
@@ -1,0 +1,12 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $StorageGatewayNonCachedVolume [64x64/16z] {
+xTUt4GCn44DHUd3xRrYXPerqHnFYfvXN0DAjybAEGvQ2uLaMoywZlGwHR-brxPwdfwUdfwUdfwUdfw-O9jGLFyGr5lrGBVkfz_dawT6-mNizUw_ptfGV_klG
+yn0TdlxpmdpK1m
+}
+
+AWSEntityColoring(StorageGatewayNonCachedVolume)
+!define StorageGatewayNonCachedVolume(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, StorageGatewayNonCachedVolume, StorageGatewayNonCachedVolume)
+!define StorageGatewayNonCachedVolume(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, StorageGatewayNonCachedVolume, StorageGatewayNonCachedVolume)
+!define StorageGatewayNonCachedVolumeParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, StorageGatewayNonCachedVolume, StorageGatewayNonCachedVolume)
+!define StorageGatewayNonCachedVolumeParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, StorageGatewayNonCachedVolume, StorageGatewayNonCachedVolume)

--- a/awslib/Storage/StorageGatewayVirtualTapeLibrary.puml
+++ b/awslib/Storage/StorageGatewayVirtualTapeLibrary.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $StorageGatewayVirtualTapeLibrary [64x64/16z] {
+xTS7SXKx48NXqxdF_XVy7gYc1kH9bYyPVd1KVzLojl6jagKElBXKOKwuc1ny-RkhC-zuT_w7UoyPZxL7YOebRpG0rU9U33TqBdbX0i8OemAiUbG3HWKGwtxR
+6iI7lT9G-N6F3j1VyDb6US4Rg_225pA-zgLcik2HhHYZBG2gFnKB_f10Vekllt_UehhBPJhswgwmPw_5hS1USAlqmVkOgcgI9TjPaUog8ac_zKOonmuhiZ5g
+icpSBKdQZPSc3Lj9ndRvn9QHBTS-DhBlbN7Is1iJbxwtqNsPZrd3tXYvya86fja2wZEOBY1NNgTL6sqMvalfYzvklC--W9gzt-oNUPUG2UGyMsovy6DMiPUa
+ZGidzfHCN7ebUpzmiiP6qlUn9lNQ8yZMdLEtbNICjCd0ZKUHB3UB9fawIf8TRZuESUiHl2tmuA7PlAXJyUW1KJNJDvcPoW_w_ldFM_MRobPyyb0k-fnQzesf
+VlB_VFcNwkZduwEVE_gfWqTnBZ6LdAkdlvyNZb_gVm
+}
+
+AWSEntityColoring(StorageGatewayVirtualTapeLibrary)
+!define StorageGatewayVirtualTapeLibrary(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, StorageGatewayVirtualTapeLibrary, StorageGatewayVirtualTapeLibrary)
+!define StorageGatewayVirtualTapeLibrary(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, StorageGatewayVirtualTapeLibrary, StorageGatewayVirtualTapeLibrary)
+!define StorageGatewayVirtualTapeLibraryParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, StorageGatewayVirtualTapeLibrary, StorageGatewayVirtualTapeLibrary)
+!define StorageGatewayVirtualTapeLibraryParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, StorageGatewayVirtualTapeLibrary, StorageGatewayVirtualTapeLibrary)

--- a/awslib/Storage/all.puml
+++ b/awslib/Storage/all.puml
@@ -1,0 +1,297 @@
+'Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+'SPDX-License-Identifier: MIT (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+
+sprite $Backup [64x64/16z] {
+xPI9aYCX240Vg23y___kONgAIkzsnkawvtYvLGfyIkBByiCFqsp6VGp0xcU7CU1k1JaOkTvknrkctOut43EvPo1dWmRhhSqFb-22UZXuk28U7wD3__ifKh-s
+oPKnApvNDHcR36YnMF6B1cDJd28M1-vnO8A-gt56s9FkpAS3iRNaYY68KdLcJFSPMVj21HdNsrRUnCqPimk0z9Noq8XUYX0y7Os5YWcqtXkK3brBvABRD4ku
+0cD6PinH6V_EfZAlyYzx_XPlUPGDQyoNGKUk-sKzrI8w9IeDZJ0zvY_xoPORK_GXi6XuAchBiSKbOpLxNPegeEVVqHmb_yBXMyZ_nvUxIshUnh_nzVdwB--K
+f-9g-X8_5lPdoKRFu_x4Q-IHs6dnxFzHXiHBAh7YMVhHAkCLbTWHpseRhp9UKWtmkFMPnxUQUqtbC92__ITWLTkxr1wh_qzkhYd7SmMvcTSlOSRk1aHc3KsH
+tV8ZZP7Pp-VVCmUMiRM1tZcP5dhVAp-c08myzGKWM_6TvXqzzsNtHeyDXCXKJcXc87lnCqFH9z38kHS_qD5evqDjGncnGmDqdgGgq68FDxyO_5hyyCDl
+}
+
+AWSEntityColoring(Backup)
+!define Backup(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, Backup, Backup)
+!define Backup(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, Backup, Backup)
+!define BackupParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, Backup, Backup)
+!define BackupParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, Backup, Backup)
+
+sprite $EBSSnapshot [64x64/16z] {
+nLVdmkqW22iRtl-1xx1dUehnpYz_5SGaO7ly4z05zgCvwm8fkuTdNOEtmrq_O5N9E-5HvLSBFnCGZc_2TnFuppBf6b4L884LGA3g0HAmfm1y_5im007wlvY_
+gE05V2D-xkF97kjuDHqiYdbatahES9CXd9XX1JIk-pysn2UDntPt6t1_90obTVavGbrddOdLppLTjtwbjLMoPQrQC4PwK61l8QboWWHvbJIvfvNs56rNKb6u
+PdiArKHVGs3nUkwdgz2i7yaGSA0ZAIij7_PvzS_TG6D3zlhbJuj7DGYJiyCQ-Aqq4druzk5b5ReLwIst4pL4OsBHHBBrqc83y68FVrX38gRTCjMuh8q_rRPU
+lazkTB3-bc0v0MTj-AQRz5kEPNBDZ27WO-xa58ylntwQckyzaWmCC8CixyFll942STknwbuLJG9aBgyJvbNPTh1lpFOc7h5xJkZb48z7vlu0OYOi8BWW4B03
+DmJlTZ3ZTTsl3ni0yuC5HDsB1KJTkty0a0zS4D03nYEG1mWCi-CAiNo3eN9kQXkD3o3dAoiqrINd39C3WUFvWDl0-NpFJm7uofWmVPaWaEZy_Kk__Hjz_4jy
+1m
+}
+
+AWSEntityColoring(EBSSnapshot)
+!define EBSSnapshot(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, EBSSnapshot, EBSSnapshot)
+!define EBSSnapshot(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, EBSSnapshot, EBSSnapshot)
+!define EBSSnapshotParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, EBSSnapshot, EBSSnapshot)
+!define EBSSnapshotParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, EBSSnapshot, EBSSnapshot)
+
+sprite $EBSVolume [64x64/16z] {
+xTOf6aGn20HXo5xtl_3esJhXUv7ylWIjiDjSskOJQPhMsUWohx2QiA2gsnSK4meibyStanfCTVomZG5T7E-xthycKCVh2VJnUW9zV7o22jHofF8zWHFaN-D5
+V4_e9SJjij92wcU_7kx7utxuiVwhxtQiFU-pppxxxBFFFlliiv_jsBp-FzeaPDed3x5RNW
+}
+
+AWSEntityColoring(EBSVolume)
+!define EBSVolume(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, EBSVolume, EBSVolume)
+!define EBSVolume(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, EBSVolume, EBSVolume)
+!define EBSVolumeParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, EBSVolume, EBSVolume)
+!define EBSVolumeParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, EBSVolume, EBSVolume)
+
+sprite $EFSFilesystem [64x64/16z] {
+lPE9hjqW34Izs_F_Frm14HVU3ctVkMj6ET58DlHlO2PgRtuN_YXr54KbLJczo0eg60EwwEY9AC2RdqWgnEgZ-Rxxz84l2NYX74YPD-gJE10yKmCoW0XWT6MH
+meiIuPug5bBwSqKC2zxIcKoCYE9TAaHKxzB73nx4vXiFQlE5EpByqJze45j_eq6z-ZiWSn2zFwjklchpHMtpjOz0TVD3TVIV_jf_zTV-qs_ylK_CMt_cPwoh
+7oDbjjNtbehxwiEztQ3kgr_kJ4Jc0V3qqvt82a3A807KxEyosFkRTFJfhrLOgU4NiAVDptSfDH8laXwuyCBfGR6WDE10IQAaa4pB0rA1qAPFsfK1vbF_ylm2
+_eFpRvda6HJfDEbNcSQPYq-PofaYcKo_2KSDqg_yn2GkT0KoEWNmbI_KiIlVLb_e8oph2rQ_Ekcywe4lMVn9ybQmuYji3lAXjaaaYiz7kbua7UB3jzdc09u-
+uuRO_3e4gEbJekYG07Zw3l3vDciNrTqJ23-1YG5l_Xr9LCZk5suG2XGttm0dFaA068VG0IeK7P802s3TDy0EVGMS2j5z1f8EAHGdglbZY8U-0UO0Tr_k2XYW
+tQS0vFpWjlVm-ppEO20BESyF-Fpy01N0dCSPWaOD_sw76iE_sg7LvpeVOIx-tGvD_tA7fd-vGzE_tQ7ft-_GzFLyX3BzonsArJSWx8pDPronpkE2f1Ty0Vqj
+Vm
+}
+
+AWSEntityColoring(EFSFilesystem)
+!define EFSFilesystem(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, EFSFilesystem, EFSFilesystem)
+!define EFSFilesystem(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, EFSFilesystem, EFSFilesystem)
+!define EFSFilesystemParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, EFSFilesystem, EFSFilesystem)
+!define EFSFilesystemParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, EFSFilesystem, EFSFilesystem)
+
+sprite $ElasticBlockStoreEBS [64x64/16z] {
+xPO7OiCm202P0l7_1rU9b1tYqTtg4ayuRnlgps0oAHslALuwptNebCZqEATalYxlNr_vN2DgpY7AkQyCL1SWOCtyqgAqf5CjgH-7-98UgQ_HCmOHjzCHZEJu
+lNZFaRviAamD5hM-He0kYO_4o3f4NH2kmB7oadWXlPTgViGqkMSf3g1ZDsD_2k3hVGEqeOyD689jyG58RUpHJGbWcyyC3KGYH6WmR_CrlCZHHIGf7hhLxzVF
+lL-_FVw5h_IdF_tfoxqlMtm74B_-Vhfi-dvMGm2IOjwm8WI0oUwp-g44Lv0czIEjNz6MLRWXsWAHrg-yVjQ8CKxgvplgzxlwX_VsB-_jdzxVlxstVtnl__ep
+c4pU
+}
+
+AWSEntityColoring(ElasticBlockStoreEBS)
+!define ElasticBlockStoreEBS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, ElasticBlockStoreEBS, ElasticBlockStoreEBS)
+!define ElasticBlockStoreEBS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, ElasticBlockStoreEBS, ElasticBlockStoreEBS)
+!define ElasticBlockStoreEBSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, ElasticBlockStoreEBS, ElasticBlockStoreEBS)
+!define ElasticBlockStoreEBSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, ElasticBlockStoreEBS, ElasticBlockStoreEBS)
+
+sprite $ElasticFileSystemEFS [64x64/16z] {
+xTO7ajr020JG9WpGtF--Jghz6OzSplQ-IZ_GeopWd-7TkpWKHnM7rt4SeZdeImcVzGAmzjl_KjP3tjXDphffStuPb1iAMrC-gD1TN1bZlkyMw4zUn7lCh-Pr
+WGftN_KOlnG-gQYZnaccug392uTU2bzeVk55Eg0hCvS2pZVfTuKpXmJxIsK8ZDye8DKyT1q7r3oj1DdtNojMygHUyBw_w-NkJEuewl47U1YaU4P1UIyqkzlX
+F2EdEWZFk1p-8uKNTr81dnO6h3Pnm9A3Mh8vYIM8vgZfq9ENtkIJvyKKUUBILov0199lYbzqmZaJESw204XISHLFTyTyYGNcYsJQ1S3kRLw4HqqtxxJ3t6EN
+DqIJ1NlvTeUn0zuS9PHJFWpHc_DFWrOFUK6LmNOFB_9rtc4BK6ui6VA225dScizVaVoElF7xyj5yCFIFWlMZ1JpqZxb_5JGU6QmV-jVOFmklH5_wP_3h_JjU
+kUdVmStyqCzkvuVWzyqlmU-Pdxv_Velldn-_Vtxz_Twz-mW
+}
+
+AWSEntityColoring(ElasticFileSystemEFS)
+!define ElasticFileSystemEFS(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, ElasticFileSystemEFS, ElasticFileSystemEFS)
+!define ElasticFileSystemEFS(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, ElasticFileSystemEFS, ElasticFileSystemEFS)
+!define ElasticFileSystemEFSParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, ElasticFileSystemEFS, ElasticFileSystemEFS)
+!define ElasticFileSystemEFSParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, ElasticFileSystemEFS, ElasticFileSystemEFS)
+
+sprite $FSx [64x64/16z] {
+xPHfaaGX28CJ557kV-0fwctqh4p_zkirMd4Zp_MPpMQpsVZvNMKyM6Xjf3IredtYeVao0YH3LFrCynkWCrgjb_tYZn8CJyVWJvVxZ_uik1BM-xnwph-_-or4
+WhTkaDByiZ86gCVY5PW5_oBCamoV7KKQNl4FG5-oqy0urgXcnHy3C9_K9DGx-5j-U3AFWmOWurg43ra6s6z-EPbdYmf0pOUYlehh3tnPV_9xhhxk3zm8pKKi
+-q_Sm3E3Im6h-JCy4YEm9U2RVk_HFO7-rlhzA9sFQlxkiY-1dkavOpWB_YdTPlmEGl9JDudsavz92VBrfS1CHVpf_ipAUXDIkeNGT8iErVzVt_xQiTbiDfiF
+}
+
+AWSEntityColoring(FSx)
+!define FSx(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, FSx, FSx)
+!define FSx(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, FSx, FSx)
+!define FSxParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, FSx, FSx)
+!define FSxParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, FSx, FSx)
+
+sprite $FSxforLustre [64x64/16z] {
+xT55OWKn30DGcItV_xwVCcNkgf2t6eX2ug-tRTkspSB3y6l2bng6YgWtlqJ4ReeApt3rB-Pzrhu3FPmXlvUdsd0fMNjmxM_bQSZX989Vo0TgU13fQUZdzl-m
+gjLHNy56fJzJfqAkacGg97fj9WCvP5yx5IiMto1MUR5YvK3oOWe-P48yCXI2_k3yoz3Mo8Po4ivo3og47-SNn90UYMWu5QhcKF7FviLd4ZcMBbGfJa0wqP_A
+Jo6dOIHR8j0p0UGGCH_qdqqoHSbLNQFKs04uIRCt-ekxl404i9vL7Gibk1AIuyfNDUzLhZrq7--i2zVYHHV_kstRjkqC
+}
+
+AWSEntityColoring(FSxforLustre)
+!define FSxforLustre(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, FSxforLustre, FSxforLustre)
+!define FSxforLustre(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, FSxforLustre, FSxforLustre)
+!define FSxforLustreParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, FSxforLustre, FSxforLustre)
+!define FSxforLustreParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, FSxforLustre, FSxforLustre)
+
+sprite $FSxforWindowsFileServer [64x64/16z] {
+xT47pYin20JW0MnWkFzzKnoohvUDoj_yIQZJ-QvisxPjrN62Fv6CeMepUORWGP83OgP0dCeVR1EJTv7dyeiFOiKMdi_j_Zi_CR_bGv9aEUob_ZLNOaBud_cz
+Vx4Pd3H4_JkVUSER0JcUboAhO1poh_-JjRO15bny9hGc3hD-ds--SCafiEGYo9gIJMRzTVzMd30kYgWfRF_ERpMHFR_mXNm6Wdmixo_tLmIfxgVownufofhh
+t1a3qJ3uMpZoLQU73qXMG7cNW40M27_BdCrL0CX8ScXo4T46uxzb9dyGfcqaFxfjsxRj2W
+}
+
+AWSEntityColoring(FSxforWindowsFileServer)
+!define FSxforWindowsFileServer(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, FSxforWindowsFileServer, FSxforWindowsFileServer)
+!define FSxforWindowsFileServer(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, FSxforWindowsFileServer, FSxforWindowsFileServer)
+!define FSxforWindowsFileServerParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, FSxforWindowsFileServer, FSxforWindowsFileServer)
+!define FSxforWindowsFileServerParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, FSxforWindowsFileServer, FSxforWindowsFileServer)
+
+sprite $S3Bucket [64x64/16z] {
+lLS7akCm33iMaS3_7toDayXAp5Y-ifYsHUm0BNtxZv32RJCrZqo01I0pt5HsR6qas233zPEnZkIC6J4A4JCNOcWJsVCPnTwB5lMe0uIVLE8exoONrV4Nniif
+pPFKkY914hRy3PNL7YhNWmC16RV6F4Zgz4UEcnoneyaWRvCCpADzt3JteucHJBt3yE0nVotUs6xjGIu341OG9fVw2B2WnsQ4vSF7Q9IcvW_RjBNboInYFO2C
+YE7s2ruAugAW89xMypUf23qGhZFYAG54VKp17kGyNELOyJfDFTbTQh-W9pjCLiPgJMCVIdhZRWks1XHq15uoxmi6ypGC23_xHxmeBecpu23dmPFpZRzL5wDL
+RrzFGRfzAs3q_PmOJyhAgsDlvhb2NQLa4Rg4g-Dx193wDkGimzy-0LLG2yk7ycPTq6KWUS7Ou4mYI93qLS4Ng4OGOR-Z3PAsA7Xxyu7C8kS70bn_fL4nxofO
+VTuI_ap1HaO02BqSOATUQHInXI0QHVRep-uFiCzrVu3Lw-WtulxoxV-ultpl4g0ljHzWt-f-AFlZtrTmlols2T1JtHe2j9s-Fy1UwhtR_KJ1s1xVVblt1vN4
+pW04H4TB-7NrQFiKbs-GkYBcntS5aIStK97dxNDiR7UoURzXo0Kx-YieqZSPQZxY_Vtw1U_d-_W1
+}
+
+AWSEntityColoring(S3Bucket)
+!define S3Bucket(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, S3Bucket, S3Bucket)
+!define S3Bucket(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, S3Bucket, S3Bucket)
+!define S3BucketParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, S3Bucket, S3Bucket)
+!define S3BucketParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, S3Bucket, S3Bucket)
+
+sprite $S3BucketwithObjects [64x64/16z] {
+lLS7jjim32k7IEB-5-vpF22dL4ON_lI024a47F_uTv0TNzFKHcHMOKTLnd3JJxZgKLYWSjXBCKPkPKQC7H7KWdHTg1vrLd6LNvV2BcLf3JlsIuFK1d8eB7zM
+Ne-pvAwXZo7oTgilLBsOQKq3A03_ZClP9WyJOF7F43EbEDYdK63yONsV3p3a2xOb0FRHm8RG3nVF4njOqB2ZsDyl_84TTLiCzxCvmqsMhYmSKdDUSW76pJse
+XtlSDlY8YEIrtDgq41UTHqltSbYJgo8ngn7raIn7Exkfp3E-xMPrsQMRVEqYp8xjumP-bt9EFW-_GDmBsgg1L-6RzmdBmh-Za8qmEexycEKOSu4thk_dU5mD
+-i9Qz_foFd8LjJPlkLxzUWQkE4liOB8kzil9Dw3gZ4TprTYjAVT-qPMW0jIvFdooXCroo_i5sQbvBo1Uf_CuhwGY-abswSfzOsHHHA4AABqvcBd8lpCqZf3I
+hPe4do5qi5rrTnrzyjLZy074iuCB27yWUNM6yYazW7foiE46cNYgCW-n8vuwGWiWE06lMy0745arzuGU3I34TL6kDhJMlTp07WcKc_EPGxUHpq1kp9B2rkfg
+SSo-lF0_DkigaPHWQz4bD4llu052gPOkQTEM9mE4SsQitwOzHGNAT8CVPm9Gph_RFcfZ9xCbx7JQ089UMJK0-LG4XFD3Mx_LXUZvN9BIrVPJrPtFy604yZn1
+NiVVVR4CNpguv_SthXxf0SG3sVDPW9ZB1OYEtsyVbzMoJZ2XPwoSoiX-2LibHNpo3Y2ZcnPZAbtVlRxqvMdT2ZUHvjDdCWGNO3HNJUzlcTFhsuBA8RBGey8f
+wnNKl7b_bV_n_lmzVW8
+}
+
+AWSEntityColoring(S3BucketwithObjects)
+!define S3BucketwithObjects(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, S3BucketwithObjects, S3BucketwithObjects)
+!define S3BucketwithObjects(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, S3BucketwithObjects, S3BucketwithObjects)
+!define S3BucketwithObjectsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, S3BucketwithObjects, S3BucketwithObjects)
+!define S3BucketwithObjectsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, S3BucketwithObjects, S3BucketwithObjects)
+
+sprite $S3Glacier [64x64/16z] {
+xTO5iiH630JG5gjr__i6lFvaPyRPek1R1cbOPVxT_Ez_GxAhyb3TvBmHsnMc-4xKi_zSZWuzGypZuAPoVEFrcABi-6DMatDw3UP8Ay4jNxSox3H0Yci6oMqN
+su3YIa9xk3K9MVxcoE63KVJgfu3KqzewX2i5m8gSLN270CgLXYWWbaLolh8SIzZb2a1XctXbcG20caTc7JB3zVLjTC67Am8EMM62mtq7Jo3MyUVS3jbT6VuI
+yTgEvneL5wu_pYT-CVGwFf1ye6WkvNLoKktoTn6krMLn6e3FTOdM6dgBXpU_B9PlrJk72E3rROGnxynETuS0bkVo1OmRXkBLC1MGE3BlAyWuadV3ChmweJ0W
+bl7huRKB82x2abidRzExxWJK5J7R1LmB0DiPW72hggkQImAkT3OxkMVeNNKrr71jVRpBKj2JyB3czWJF7-S5z3mGnSSJV5SEz0GqYayd-2vVMxy5FTErFy5t
+ZfYXGi_NsfxWkn9OX07m28MzMzycy5qFLyPGl2aWiXn0P1hatH8SvxWDFaD3lRk0nPc0Kr0pRAuruCrRYZwwFGdnv5O9e76vVXe78C_xxn3wu_hDtM8gIj4J
+y78-67Qw2huOESVvysFypsQkrwzar_7uE_dV_tu5
+}
+
+AWSEntityColoring(S3Glacier)
+!define S3Glacier(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, S3Glacier, S3Glacier)
+!define S3Glacier(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, S3Glacier, S3Glacier)
+!define S3GlacierParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, S3Glacier, S3Glacier)
+!define S3GlacierParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, S3Glacier, S3Glacier)
+
+sprite $S3GlacierArchive [64x64/16z] {
+xTO5ZaGn38DXfvJu_WTUfbJE3ehx2Gl_u2CycILYvd-3oG8M_ug1_nYp08APuHzEpl73FtiVFoRfgFMyl3xxbT-Wes91sl-zaM4eJ792z6AFqiZ0fHv1jlB7
+wx8Nlv4mo0NPxxCS-iSBqtsnKR-ixlK7pLyhRFFTsoR4GH1Kebx8Z983JicGjQ6qUk79h2bMBsoY_FuF_7xrxq_RUwwsyy_UsswfVW3ryPSDylIdF_tfJt_w
+qv_-z3vs_jch1Tfpd__WL1Qmg3XsfjGBp_8A
+}
+
+AWSEntityColoring(S3GlacierArchive)
+!define S3GlacierArchive(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, S3GlacierArchive, S3GlacierArchive)
+!define S3GlacierArchive(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, S3GlacierArchive, S3GlacierArchive)
+!define S3GlacierArchiveParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, S3GlacierArchive, S3GlacierArchive)
+!define S3GlacierArchiveParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, S3GlacierArchive, S3GlacierArchive)
+
+sprite $S3GlacierVault [64x64/16z] {
+xPO5Ocin30J5qjx_m0M5oV0PEctOOxtT8FreUCXKJmp9YUwOu4DTWR811UWeUm520mGe7eOt6c90Zi87JGZ01-5vedT4dOQVLp0FFwzW7dwz0WMWieJYiGB6
+9lnGtWwF5R9imVI34Tj2x_twplxmtNxmClxCTrh6_XUVF_XcNw80e4A-nPV4cPHrNyfwINjkvhtFuRwIkPz0Qb-4d780IQG9vDotmgVAgNH6aoK0b2taPmS0
+vyzrMPLsVT_SFrLN9eMcnAfBNEzVJsh4wPgkFtyIoZtI-NZePQonFDy19WM2cW2q5wpwWUerf-Uld_v2xFfC3K_y7pw_yyjrVjdAhpqm-wxUBLlHLP_hqv3J
+yzz14iMBVe-qgnUHjk6qx3Dw9di1vTp70bxtoNfgUtfyEHkj-vq0pWUV-mPj-Rq1xDCtjBxfa-R5JwKzlz7WJv-ZxNt_qjz_wxEx_9hltoy_RPdyuRyVAR55
+qZsy1VqetW4
+}
+
+AWSEntityColoring(S3GlacierVault)
+!define S3GlacierVault(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, S3GlacierVault, S3GlacierVault)
+!define S3GlacierVault(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, S3GlacierVault, S3GlacierVault)
+!define S3GlacierVaultParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, S3GlacierVault, S3GlacierVault)
+!define S3GlacierVaultParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, S3GlacierVault, S3GlacierVault)
+
+sprite $S3Object [64x64/16z] {
+x95LmiGW38IP12BtF_2wXstdT_sUAYGZj8_Y7qW_87Z5RBV82s7zHJlKi-1AJyTnOAW88ABZk2we3N8uR8gxE6g7bR8wFdB7GFs1uv-Lscol3Uvd1LvIbcOS
+pyVBxwa05dvQMy6UIrWPfq-TclT6uFDRa99ieIMPhjL6eJEZUeh5O1Efo0GxZyoeygFHZ6B0J_8SU6m0f_GizY3NsVAlSNlPHrFznYaFZT_T04xjyumxmrBY
+4mL8UIEfYfslxvgu_uxvj_VtzllRjb_d10008133_BkkYAp50byEvWVc5_T7zrVl1zullPzul_L_uF_I_ud_6_sWVa4_eT_GZ-fNzxFxtVE3vnVFJrvN
+}
+
+AWSEntityColoring(S3Object)
+!define S3Object(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, S3Object, S3Object)
+!define S3Object(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, S3Object, S3Object)
+!define S3ObjectParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, S3Object, S3Object)
+!define S3ObjectParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, S3Object, S3Object)
+
+sprite $SimpleStorageServiceS3 [64x64/16z] {
+xPO54bmn34DbYYtV_xw5fTcq6vUvRp2SMDAVpn_6V_xJNx-iCjU5h2AxFtzjhJ31CwA-afz5XLwNc7jSS5EvzYmsPz80oFMmVa1MBXD0WYCEIDJBK_gwkIJF
+66I-OXcGFB6WrHpf1JsE1LQJCoseytf9ZZG3CjmVi6IVZH42A4yaH2_g5NV3NHKC1Q0mdYWeb-4zQXuhRwpmcuEy4juy8NAH-SczcuEBFTTOKJUhLEKAlnAn
+icvHR1_qRzi6-m9xYvwXE1c0d95XFHUYzmwruWQ4PnAxE0N0-qE9TgRH102lhSURPqG-2kHrX_s5eu0RTVMivKC-vu0XNsL60OswJfWorlvIm6RQBLeA0s8m
+mEbvvGA8GvXoiE1Sthv5IqFFamh6YG0mLW32WKvuPTPaRmviwHqCS61AxpnXtlxpBoZWp1hpKH1kZ0cUvPqJFDjhJl2H7j8xL7Y8r_097kCz7l7ryiy2zbM-
+cH9uiL_bDnNEJv82M6IHVOTaBHV0-3c4082eUSIAyFl_cov-5iqCKpmZvgk-xV-Llo7_-SzR
+}
+
+AWSEntityColoring(SimpleStorageServiceS3)
+!define SimpleStorageServiceS3(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, SimpleStorageServiceS3, SimpleStorageServiceS3)
+!define SimpleStorageServiceS3(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, SimpleStorageServiceS3, SimpleStorageServiceS3)
+!define SimpleStorageServiceS3Participant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, SimpleStorageServiceS3, SimpleStorageServiceS3)
+!define SimpleStorageServiceS3Participant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, SimpleStorageServiceS3, SimpleStorageServiceS3)
+
+sprite $SnowFamilyImportExport [64x64/16z] {
+xPQ7ikmW243fol__y1lYU4dJ6JUltvofkt1GIGDUNf15rn26HFq3ga03Yt-6Dj_SA-CY57lcqCczm3hXLMY79m0GsnDdO-jWf1tYd6BnUjC3tEBvGwvdftQ0
+ugNbriHT0AHsCBAESQVmfVlL8wc3sPByno1XTptw4Kwi7IsHs6iI-JEVsswJwFM2Ztx1LdnWEuCB_e1_mATIDqfFr7gYu9P7UEVdFGi025lqZFJGm2yMnChN
+nyhAvb2riOzv2n6SQKvnjwaVM1Ou-rIZ09R24_zQ8FUCDMz89DhwcJ-c1I8n2ypHB70c2x2E4AsjWCWrPlsPAZwbTMS0jrDEqOaVXyCn78SSf5XRVioyoVAb
+Yog0AlTcJdKqewFUtlyzqzp7Uju_JIV2c_kF0-ewyG49l-dJvxT6r4RFhuL-wykN3pouE-BOnd3lz_qIDCxxpyZLNq6D7_d-rxs_Aoxe-Vs-p0zZXlD3NP_X
+Sdx9-Mc551_DRq_dnuVpwyFv-V7y_lBo0m
+}
+
+AWSEntityColoring(SnowFamilyImportExport)
+!define SnowFamilyImportExport(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, SnowFamilyImportExport, SnowFamilyImportExport)
+!define SnowFamilyImportExport(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, SnowFamilyImportExport, SnowFamilyImportExport)
+!define SnowFamilyImportExportParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, SnowFamilyImportExport, SnowFamilyImportExport)
+!define SnowFamilyImportExportParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, SnowFamilyImportExport, SnowFamilyImportExport)
+
+sprite $Storage [64x64/16z] {
+xTO5OWCn34JHqSYWwFu7hfqk1wqol33yPS9N-IVpgq1B7WLmxOkFibsV_JJeM_V_lSrYVSAC5kXTfPQk4cAHdZw_4R58tv_RGzL4gaVwd79xesv4zK2lrDwt
+ZqJnyVwizOsYUBJtlY0Iyd2VcDeRy0meettMr9zU9L6FhB-JJpZQ7uptTIFI4mj6UjiOwRrH-a7hcoVwMd8kb99tYh1_Nn_tX9o_Ef3-BVX4hwURzAb-Vk-p
+vOkXtjB28hs24sYab-HJbkIj_LTCloMT79RVnw-_ev_KAyfDqCUz4JVHxlKpk-ctNZ_zzpQgxlg0z-j1ZQ1W9Y7u3Lu
+}
+
+AWSEntityColoring(Storage)
+!define Storage(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, Storage, Storage)
+!define Storage(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, Storage, Storage)
+!define StorageParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, Storage, Storage)
+!define StorageParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, Storage, Storage)
+
+sprite $StorageGateway [64x64/16z] {
+xPC7ZkCm34K_crZkV-0T0gCOMSUo4vGjuvTU7gkSVnytDvNX7f7rcHxAQDZYamZQggWG07i_EOCiiciF1JZUr0dogBg2mU_v0bbyFcNiyZ6iUXlNV8BdCmvI
+090h4NnVRMdBog3p0AKOkuq7EAhIhaoI4RdZktU1NsZ_kBO1hTFfuxZ907HPWHF0MxxT6rblOG3YMp0J9W8HwvXE30RvSNcZfgm40DG008zPYXskKM2LJOK0
+a9arN1cW6K6X1-df-vq1P55VPDElBjk5IAz7_DYE0fRjc7J_tNv_Ol0im7DFsIoVu9Lf162shvqHDFyuQkbJRt8EeDidjBBvLelwso_fFLTkGzVDLupb_DhN
+xc73fzymOhM_wUThlnnyV7vE_Gh2M9tVjUyAQ1xX3DZ2BmF8Si6GiSe_UgSdhFmpRl_sRn-YzBjFAbTzHXFFViFN_F0lOl7TtyBDpIy
+}
+
+AWSEntityColoring(StorageGateway)
+!define StorageGateway(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, StorageGateway, StorageGateway)
+!define StorageGateway(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, StorageGateway, StorageGateway)
+!define StorageGatewayParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, StorageGateway, StorageGateway)
+!define StorageGatewayParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, StorageGateway, StorageGateway)
+
+sprite $StorageGatewayCachedVolume [64x64/16z] {
+xTTNWeCm34LHDKjF-z_m85BfJ6--wK47yAVfe-9NjU2Hhofe6kShuuKFErsiUQFJsG_sh39-yFMNCb7zKsyiG_lUCz7gD-gN8XEaDLrlaG1apriQypYTKlyw
+4p_vEBf_E8svHoDguzWhFDTx1JLGpR_EIofLaYp93u-Xw_hzZ3VKhJoygRRo8I9dxZyII2V7rTF9-xzES9f8IxAKrwsVD5tDHb1h0KmRFppCZFSyQG3Dd8R2
+Y1q8bc2YUcin93l-L7_ITzzzzzrttttt6fWL-XhlkSXVwNtIgpre4evyzs6FOkdZOFysRUbdyS7-rMcIvxGusZ-_ul2xUW4
+}
+
+AWSEntityColoring(StorageGatewayCachedVolume)
+!define StorageGatewayCachedVolume(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, StorageGatewayCachedVolume, StorageGatewayCachedVolume)
+!define StorageGatewayCachedVolume(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, StorageGatewayCachedVolume, StorageGatewayCachedVolume)
+!define StorageGatewayCachedVolumeParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, StorageGatewayCachedVolume, StorageGatewayCachedVolume)
+!define StorageGatewayCachedVolumeParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, StorageGatewayCachedVolume, StorageGatewayCachedVolume)
+
+sprite $StorageGatewayNonCachedVolume [64x64/16z] {
+xTUt4GCn44DHUd3xRrYXPerqHnFYfvXN0DAjybAEGvQ2uLaMoywZlGwHR-brxPwdfwUdfwUdfwUdfw-O9jGLFyGr5lrGBVkfz_dawT6-mNizUw_ptfGV_klG
+yn0TdlxpmdpK1m
+}
+
+AWSEntityColoring(StorageGatewayNonCachedVolume)
+!define StorageGatewayNonCachedVolume(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, StorageGatewayNonCachedVolume, StorageGatewayNonCachedVolume)
+!define StorageGatewayNonCachedVolume(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, StorageGatewayNonCachedVolume, StorageGatewayNonCachedVolume)
+!define StorageGatewayNonCachedVolumeParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, StorageGatewayNonCachedVolume, StorageGatewayNonCachedVolume)
+!define StorageGatewayNonCachedVolumeParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, StorageGatewayNonCachedVolume, StorageGatewayNonCachedVolume)
+
+sprite $StorageGatewayVirtualTapeLibrary [64x64/16z] {
+xTS7SXKx48NXqxdF_XVy7gYc1kH9bYyPVd1KVzLojl6jagKElBXKOKwuc1ny-RkhC-zuT_w7UoyPZxL7YOebRpG0rU9U33TqBdbX0i8OemAiUbG3HWKGwtxR
+6iI7lT9G-N6F3j1VyDb6US4Rg_225pA-zgLcik2HhHYZBG2gFnKB_f10Vekllt_UehhBPJhswgwmPw_5hS1USAlqmVkOgcgI9TjPaUog8ac_zKOonmuhiZ5g
+icpSBKdQZPSc3Lj9ndRvn9QHBTS-DhBlbN7Is1iJbxwtqNsPZrd3tXYvya86fja2wZEOBY1NNgTL6sqMvalfYzvklC--W9gzt-oNUPUG2UGyMsovy6DMiPUa
+ZGidzfHCN7ebUpzmiiP6qlUn9lNQ8yZMdLEtbNICjCd0ZKUHB3UB9fawIf8TRZuESUiHl2tmuA7PlAXJyUW1KJNJDvcPoW_w_ldFM_MRobPyyb0k-fnQzesf
+VlB_VFcNwkZduwEVE_gfWqTnBZ6LdAkdlvyNZb_gVm
+}
+
+AWSEntityColoring(StorageGatewayVirtualTapeLibrary)
+!define StorageGatewayVirtualTapeLibrary(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, StorageGatewayVirtualTapeLibrary, StorageGatewayVirtualTapeLibrary)
+!define StorageGatewayVirtualTapeLibrary(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, StorageGatewayVirtualTapeLibrary, StorageGatewayVirtualTapeLibrary)
+!define StorageGatewayVirtualTapeLibraryParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, StorageGatewayVirtualTapeLibrary, StorageGatewayVirtualTapeLibrary)
+!define StorageGatewayVirtualTapeLibraryParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, StorageGatewayVirtualTapeLibrary, StorageGatewayVirtualTapeLibrary)
+


### PR DESCRIPTION
# Description

Update awslib icons shipped with plantuml to the latest available version of https://github.com/awslabs/aws-icons-for-plantuml


There is currently a version shipped, but it doesn't seem to be tracked here :|