### PR TITLE
Update version of cloudinsight in INFO file

### DIFF
--- a/cloudinsight/INFO
+++ b/cloudinsight/INFO
@@ -1,2 +1,2 @@
-VERSION=0.0.1
+VERSION=1.0.0
 SOURCE=https://github.com/rabelenda/cicon-plantuml-sprites/


### PR DESCRIPTION
The INFO file states version 0.0.1 but the remote repositoy has
version 1.0.0 as latest version. As the contents of both is the
same, this commit only updates the version number.