### PR TITLE
Fix Elasticsearch documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This example renders the following image:
 The Elastic library consists of [Elastic](https://www.elastic.co) icons.
 It is similar in use to the AWS and Azure libraries (it used the same tool to create them).
 
-Use it by including the file that contains the sprite, eg: `!include <elastic/elastic_search/elastic_search.puml>`.
+Use it by including the file that contains the sprite, eg: `!include <elastic/elasticsearch/elasticsearch.puml>`.
 When imported, you can use the sprite as normally you would, using `<$sprite_name>`.
 
 You may also include the `common.puml` file, eg: `!include <elastic/common>`, which contains helper macros defined.
@@ -88,11 +88,11 @@ Example of usage:
 ```
 @startuml
     !include <elastic/common>
-    !include <elastic/elastic_search/elastic_search>
+    !include <elastic/elasticsearch/elasticsearch>
     !include <elastic/logstash/logstash>
     !include <elastic/kibana/kibana>
 
-    ELASTIC_SEARCH(ElasticSearch, "Search and Analyze",database)
+    ELASTICSEARCH(ElasticSearch, "Search and Analyze",database)
     LOGSTASH(Logstash, "Parse and Transform",node)
     KIBANA(Kibana, "Visualize",agent) 
     
@@ -101,6 +101,9 @@ Example of usage:
 
 @enduml
 ```
+
+This example renders the following image:
+![Example](http://www.plantuml.com/plantuml/png/TOxFQiCm38VlUGejfnHITYyZrEl2MXgsCOVUrLXBpFm7R8UnFVrI9oNa41yi6N-VVjhxW2xqMYKmd0Tf6jKBWYTIw8Di7XkhjJN5okzKFQ5hkkLhJL6szG5zTszMmMzvHODJAP98bHNZzUd0I_PvE6RbIFAObqCwDe1603EeVlyepGK6lAAdJVIhzrTUCtxCgYbyi3xGUOfIxT3uB-jqcXih9kLyUcPlB3l7DGRy8dsFIjvcOqicR21YyRfFXQsJRHUs1InMtCq99E050qPhmSpgcBYB70GB5qa_IR8d8tgj_W40)
 
 ## Tupadr3 library
 


### PR DESCRIPTION
Changes in README.md to reflect changes from #20 "Remove spacing from elasticsearch names" 4b61b3953fb5d1713e168c972c915d99f31a1279.
Fix elastic example.
Add image for example.

Closes https://github.com/plantuml/plantuml-stdlib/issues/22