### PR TITLE
Update version of gilbarbara/logos in INFO file.

### DIFF
--- a/logos/INFO
+++ b/logos/INFO
@@ -1,2 +1,2 @@
-VERSION=0.0.1
+VERSION=1.0.0
 SOURCE=https://github.com/rabelenda/gilbarbara-plantuml-sprites


### PR DESCRIPTION
The INFO file states version 0.0.1 but the remote repository has version 1.0.0 as the latest version.

As the contents of both are the same, this commit only updates the version number.