### PR TITLE
 Update version of kubernetes-sprites in INFO file

### DIFF
--- a/kubernetes/INFO
+++ b/kubernetes/INFO
@@ -1,2 +1,2 @@
-VERSION=0.0.1
+VERSION=5.3.45
 SOURCE=https://github.com/michiel/plantuml-kubernetes-sprites


### PR DESCRIPTION
The INFO file states version 0.0.1 but the remote repository has version 5.3.45 as the latest version.

As the contents of both are the same, this commit only updates the version number.