### PR TITLE
Update awslib to version 7.0.0.

### DIFF
--- a/awslib/AWSCostManagement/SavingsPlans.puml
+++ b/awslib/AWSCostManagement/SavingsPlans.puml
@@ -1,0 +1,17 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $SavingsPlans [64x64/16z] {
+xPK7ZgOm38MVk-Fx7tWL80iPGOP_LBSy5Uhdk2RjRzP_LVsOR1dkPXxv4poCCKJY7zhm3hEOkPio0T3yW2Q0FRVegsSWbBg5Txb80IHRpSbm0lcRj0M1uowT
+1kZtk3_-LS6GRrS7_3bC0Q_vDTuDh3sWZfzzbsmZ-aCCgvLvhQr-h5lRCRPSPfZGld0IOk4zjox79cQ80apeqf5VVkHvs3R0b05kvGHYvPCI-0FkPt8KKgtb
+FaPzKSh9oSNourwdgiGvoFAGWPmC4wxo2ijXxRw6PLDfKlYKbG6KrKIxQPh0Ux_IBd85AJYaHrKF0Snc7REY503dwUWo_9O-gQyOvaS2z8OFoFJMc8POMrsw
+E6yJE5jD1cW8uBpnTC4dGIw8WgBUyntNemexPq2yvvD6XWqSOrlA1J-_bSDK2W1mNkVEidgc5_Kl6_bb44H0srlTGuAMm-vuHWxlSynZ_rMFtxVNfTGKST__
+NjSvA4K4h8vorpxU2MUqvlQu-upbIv2TRn7jye49xAC-avYdyUoEn2NKKlWMrTDfc5_6E0byuKU5QNaIrYKxGG3Prxh7-XmLJ8qBq6zxKz-yuIkWTdOUqQUy
+mygWzNBzEVwCrla4ptE_rkZEkN-w_6RVMSpHtByt--Rw61dpew1X-4NwfWCgUSnlbtG_taZEvZQmZsu6jvUYOQ3E_ZTGlkMJmT4sCFOpE1WKxRq4ODlGwaS9
+0vBj4uK086PX9g1duLEb2Q6BnABzGDMDP6Q_kzT__TSl
+}
+
+AWSEntityColoring(SavingsPlans)
+!define SavingsPlans(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, SavingsPlans, SavingsPlans)
+!define SavingsPlans(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, SavingsPlans, SavingsPlans)
+!define SavingsPlansParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, SavingsPlans, SavingsPlans)
+!define SavingsPlansParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, SavingsPlans, SavingsPlans)

--- a/awslib/AWSCostManagement/all.puml
+++ b/awslib/AWSCostManagement/all.puml
@@ -68,3 +68,19 @@ AWSEntityColoring(ReservedInstanceReporting)
 !define ReservedInstanceReportingParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, ReservedInstanceReporting, ReservedInstanceReporting)
 !define ReservedInstanceReportingParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, ReservedInstanceReporting, ReservedInstanceReporting)
 
+sprite $SavingsPlans [64x64/16z] {
+xPK7ZgOm38MVk-Fx7tWL80iPGOP_LBSy5Uhdk2RjRzP_LVsOR1dkPXxv4poCCKJY7zhm3hEOkPio0T3yW2Q0FRVegsSWbBg5Txb80IHRpSbm0lcRj0M1uowT
+1kZtk3_-LS6GRrS7_3bC0Q_vDTuDh3sWZfzzbsmZ-aCCgvLvhQr-h5lRCRPSPfZGld0IOk4zjox79cQ80apeqf5VVkHvs3R0b05kvGHYvPCI-0FkPt8KKgtb
+FaPzKSh9oSNourwdgiGvoFAGWPmC4wxo2ijXxRw6PLDfKlYKbG6KrKIxQPh0Ux_IBd85AJYaHrKF0Snc7REY503dwUWo_9O-gQyOvaS2z8OFoFJMc8POMrsw
+E6yJE5jD1cW8uBpnTC4dGIw8WgBUyntNemexPq2yvvD6XWqSOrlA1J-_bSDK2W1mNkVEidgc5_Kl6_bb44H0srlTGuAMm-vuHWxlSynZ_rMFtxVNfTGKST__
+NjSvA4K4h8vorpxU2MUqvlQu-upbIv2TRn7jye49xAC-avYdyUoEn2NKKlWMrTDfc5_6E0byuKU5QNaIrYKxGG3Prxh7-XmLJ8qBq6zxKz-yuIkWTdOUqQUy
+mygWzNBzEVwCrla4ptE_rkZEkN-w_6RVMSpHtByt--Rw61dpew1X-4NwfWCgUSnlbtG_taZEvZQmZsu6jvUYOQ3E_ZTGlkMJmT4sCFOpE1WKxRq4ODlGwaS9
+0vBj4uK086PX9g1duLEb2Q6BnABzGDMDP6Q_kzT__TSl
+}
+
+AWSEntityColoring(SavingsPlans)
+!define SavingsPlans(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #3F8624, SavingsPlans, SavingsPlans)
+!define SavingsPlans(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #3F8624, SavingsPlans, SavingsPlans)
+!define SavingsPlansParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #3F8624, SavingsPlans, SavingsPlans)
+!define SavingsPlansParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #3F8624, SavingsPlans, SavingsPlans)
+

--- a/awslib/Compute/Bottlerocket.puml
+++ b/awslib/Compute/Bottlerocket.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $Bottlerocket [64x64/16z] {
+xTS5Ojj0443HFpptlt10KmfPktAv_G7Z4sFzulg-_lkJwhwFLUmURu1Vzuwa45TzGiw_Ixvcr87K5L_ApBgXjUk7zQJOfdyvsINufd-vs19YpvUy406vvL_F
+iYEruHsj33TzpZoo35ttmPi4VDKNm37QhAey9WGWLhrQrkltqZLN_EIlnXLxww-GVf58_H9VTPSFaRZkKm4qh_coPviALYtIEzwGDl1vZhNW6zuPZsOeuubb
+7umt0L0VJoxwX3XyjgFP-Umba5ho9KGnFl0UB-r8dVdXtkFzy6NZsz0wzuhruGF4y1285gaknKvz8JM-opYowfPvbphtskDd0vpDRtpBff_z_fgl5--Az9ON
+NdfqoxU-_6PYk-EFroV33L_20QPvhRNiIp13pBEVIhTvNOl-cS_68pNZdgrOQicBOCUpOBpCoSGGaNClu3q9DJCq6IpuWqzwIBNkoU3Kjttc6L_Adjoshf--
+z8Aj-Z3mfy3ZYf-TRdQTIxu4UOghlasExFUzV_dlVt7v2
+}
+
+AWSEntityColoring(Bottlerocket)
+!define Bottlerocket(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, Bottlerocket, Bottlerocket)
+!define Bottlerocket(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, Bottlerocket, Bottlerocket)
+!define BottlerocketParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, Bottlerocket, Bottlerocket)
+!define BottlerocketParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, Bottlerocket, Bottlerocket)

--- a/awslib/Compute/ParallelCluster.puml
+++ b/awslib/Compute/ParallelCluster.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $ParallelCluster [64x64/16z] {
+xTE5hjWm38NXOpn-_oTUOHubLQTql7x22tz8Rlr3NY-ohVMA5akzG4_mnRuEkTopTW5VUBedlGaG3tg1oBEUZzwlUpleOgzeQpspSQdVN8VStFO9Bt9imqG0
+qU1LxmVRUeTcVIaL6za04ZTVdX__Rgn60yIJh6BQnTDcj3qCWVO2AP1WjHH4tQ92pYRwB2q1ZjiFlp88ZtpOpiSR45gp1MPv4J9iF-dBeDdvV5RQnVUccEQb
+oE_g2MXDsD0dRBx_nRauFWcdz-y5xlxP4DFtdoxWuwCaX9EyFYz0Rpb_4-Lq_lBZA3kQNWpivu-EFV-zb7FhFMC7kPfuM72JBb_TcWx4rkV5zBKGDCklrtPM
+Ac_wOfYAg0M__NtZfBzdQBROU-mSkjZtrLVxhEuT3tiHVzAtlwkNqsBlWfDuBM6hFyZhzG4
+}
+
+AWSEntityColoring(ParallelCluster)
+!define ParallelCluster(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ParallelCluster, ParallelCluster)
+!define ParallelCluster(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ParallelCluster, ParallelCluster)
+!define ParallelClusterParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ParallelCluster, ParallelCluster)
+!define ParallelClusterParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ParallelCluster, ParallelCluster)

--- a/awslib/Compute/all.puml
+++ b/awslib/Compute/all.puml
@@ -15,6 +15,20 @@ AWSEntityColoring(Batch)
 !define BatchParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, Batch, Batch)
 !define BatchParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, Batch, Batch)
 
+sprite $Bottlerocket [64x64/16z] {
+xTS5Ojj0443HFpptlt10KmfPktAv_G7Z4sFzulg-_lkJwhwFLUmURu1Vzuwa45TzGiw_Ixvcr87K5L_ApBgXjUk7zQJOfdyvsINufd-vs19YpvUy406vvL_F
+iYEruHsj33TzpZoo35ttmPi4VDKNm37QhAey9WGWLhrQrkltqZLN_EIlnXLxww-GVf58_H9VTPSFaRZkKm4qh_coPviALYtIEzwGDl1vZhNW6zuPZsOeuubb
+7umt0L0VJoxwX3XyjgFP-Umba5ho9KGnFl0UB-r8dVdXtkFzy6NZsz0wzuhruGF4y1285gaknKvz8JM-opYowfPvbphtskDd0vpDRtpBff_z_fgl5--Az9ON
+NdfqoxU-_6PYk-EFroV33L_20QPvhRNiIp13pBEVIhTvNOl-cS_68pNZdgrOQicBOCUpOBpCoSGGaNClu3q9DJCq6IpuWqzwIBNkoU3Kjttc6L_Adjoshf--
+z8Aj-Z3mfy3ZYf-TRdQTIxu4UOghlasExFUzV_dlVt7v2
+}
+
+AWSEntityColoring(Bottlerocket)
+!define Bottlerocket(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, Bottlerocket, Bottlerocket)
+!define Bottlerocket(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, Bottlerocket, Bottlerocket)
+!define BottlerocketParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, Bottlerocket, Bottlerocket)
+!define BottlerocketParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, Bottlerocket, Bottlerocket)
+
 sprite $Compute [64x64/16z] {
 xTO5SWKn30DGIN5Mll-5IvyvMPTRpMJuXGbVbVyGcv1GZza0ElYUi_69Zz_b_xrzKQPyfpEKsLgc8iq-wU4CPagPZ3Gcl2D2s1Go0jgKy90tmQi1FU83lZNb
 CUIPDyAFz-vTjxrwzmDFuCqlJKTfovi7-C2dlUc_q8uujEc_FJf-jJnAq-Zu8xJnElRQU4Ky73znsuFqIFyl_LZ_wzvDlEsfvgB_yl5Nrw-wVwhxjtf-gkUt
@@ -716,6 +730,19 @@ AWSEntityColoring(Outposts)
 !define Outposts(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, Outposts, Outposts)
 !define OutpostsParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, Outposts, Outposts)
 !define OutpostsParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, Outposts, Outposts)
+
+sprite $ParallelCluster [64x64/16z] {
+xTE5hjWm38NXOpn-_oTUOHubLQTql7x22tz8Rlr3NY-ohVMA5akzG4_mnRuEkTopTW5VUBedlGaG3tg1oBEUZzwlUpleOgzeQpspSQdVN8VStFO9Bt9imqG0
+qU1LxmVRUeTcVIaL6za04ZTVdX__Rgn60yIJh6BQnTDcj3qCWVO2AP1WjHH4tQ92pYRwB2q1ZjiFlp88ZtpOpiSR45gp1MPv4J9iF-dBeDdvV5RQnVUccEQb
+oE_g2MXDsD0dRBx_nRauFWcdz-y5xlxP4DFtdoxWuwCaX9EyFYz0Rpb_4-Lq_lBZA3kQNWpivu-EFV-zb7FhFMC7kPfuM72JBb_TcWx4rkV5zBKGDCklrtPM
+Ac_wOfYAg0M__NtZfBzdQBROU-mSkjZtrLVxhEuT3tiHVzAtlwkNqsBlWfDuBM6hFyZhzG4
+}
+
+AWSEntityColoring(ParallelCluster)
+!define ParallelCluster(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #D86613, ParallelCluster, ParallelCluster)
+!define ParallelCluster(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #D86613, ParallelCluster, ParallelCluster)
+!define ParallelClusterParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #D86613, ParallelCluster, ParallelCluster)
+!define ParallelClusterParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #D86613, ParallelCluster, ParallelCluster)
 
 sprite $ServerlessApplicationRepository [64x64/16z] {
 xPHNOkGm34F1pljVU3VXDCOnFUKdJM-g2o0Hb9pVYyLYiGWJPbQBrzI2CwGlE1X0OXu21iZoIHJGEFsn4C2U7jqlHbQ7Jnb4oQ_wCdWc0u5cqzSFXpABFpOy

--- a/awslib/INFO
+++ b/awslib/INFO
@@ -1,2 +1,2 @@
-VERSION=6.0.0
+VERSION=7.0.0
 SOURCE=https://github.com/awslabs/aws-icons-for-plantuml

--- a/awslib/ManagementAndGovernance/AppConfig.puml
+++ b/awslib/ManagementAndGovernance/AppConfig.puml
@@ -1,0 +1,15 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $AppConfig [64x64/16z] {
+xPRbOkPQ24KtUe2-__DMSW-HEpEH_gkipsK1ErxVbLz-2Plavtp6P7pE5uYzGu_zOAkgPFZBCeP_V1AxhHFW8G1ynY0B1lIsJlX0B9VFkdmaG6_gd0fOrCfW
+80QWD_Lt8shFyjbl54Y2PFs30TXLUq3FPfEwm06fZSn3RSwwGa7hl494RB6D7vTw4dos4qmwDCCkVGTlcu55vX10Um0wbsD4zqZgiBl5Jl0nycnsT4PhVHzS
+bpHdFhFssr4hCgLWfdC_wszH1xWcTi_turO0ogU-7dmyydlY9jR-BnU-Ztt7ncQQT9Sp7rWrwG3xbU7dwwzCHASVWBSku2xA8b6dPFRCq9m77ugkcNM5KFnN
+nG2mAgFrNWndf03naLYoXk03iYrINEdBhCjBVXZ3VUnt0x-hSrjx5B3Fwhr_NH-wMn_vj_AtTTyFCLYkz68STMWNTWQWSgvNw4utmBQb1bAWzJFsUc-91FOi
+VwXxbPBdEun5ZBojA-1Nro_NUXbDuecUiZRCITs-RkY3nNEsOrp4OxUz7yKllxm1
+}
+
+AWSEntityColoring(AppConfig)
+!define AppConfig(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, AppConfig, AppConfig)
+!define AppConfig(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, AppConfig, AppConfig)
+!define AppConfigParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, AppConfig, AppConfig)
+!define AppConfigParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, AppConfig, AppConfig)

--- a/awslib/ManagementAndGovernance/all.puml
+++ b/awslib/ManagementAndGovernance/all.puml
@@ -13,6 +13,20 @@ AWSEntityColoring(AWSCLI)
 !define AWSCLIParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, AWSCLI, AWSCLI)
 !define AWSCLIParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, AWSCLI, AWSCLI)
 
+sprite $AppConfig [64x64/16z] {
+xPRbOkPQ24KtUe2-__DMSW-HEpEH_gkipsK1ErxVbLz-2Plavtp6P7pE5uYzGu_zOAkgPFZBCeP_V1AxhHFW8G1ynY0B1lIsJlX0B9VFkdmaG6_gd0fOrCfW
+80QWD_Lt8shFyjbl54Y2PFs30TXLUq3FPfEwm06fZSn3RSwwGa7hl494RB6D7vTw4dos4qmwDCCkVGTlcu55vX10Um0wbsD4zqZgiBl5Jl0nycnsT4PhVHzS
+bpHdFhFssr4hCgLWfdC_wszH1xWcTi_turO0ogU-7dmyydlY9jR-BnU-Ztt7ncQQT9Sp7rWrwG3xbU7dwwzCHASVWBSku2xA8b6dPFRCq9m77ugkcNM5KFnN
+nG2mAgFrNWndf03naLYoXk03iYrINEdBhCjBVXZ3VUnt0x-hSrjx5B3Fwhr_NH-wMn_vj_AtTTyFCLYkz68STMWNTWQWSgvNw4utmBQb1bAWzJFsUc-91FOi
+VwXxbPBdEun5ZBojA-1Nro_NUXbDuecUiZRCITs-RkY3nNEsOrp4OxUz7yKllxm1
+}
+
+AWSEntityColoring(AppConfig)
+!define AppConfig(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, AppConfig, AppConfig)
+!define AppConfig(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, AppConfig, AppConfig)
+!define AppConfigParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, AppConfig, AppConfig)
+!define AppConfigParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, AppConfig, AppConfig)
+
 sprite $AutoScaling [64x64/16z] {
 xPO5SiKm30MVP4Tq__iM77KycFfRvMR3i6QAdylDZLb9Lq1hEg0r7T1zNOW4q6qzY68t08P447a8UCStYTCFiTWY_G9r7pM_ju9Vnu_32xeGGB9hAmEz0wph
 Jk-HM0EQpUlyVe4pyWS1M6Sw97MmhmNGW9w_UWTuJPy1D118iX09lA3xm0Xz-7O0hCh0OU2Xa_dWQhGX0FtLzr5qe_0S_Ae3T34YAPzG-ZR7p_H1VABl5a3w
@@ -153,19 +167,6 @@ AWSEntityColoring(CloudWatchRule)
 !define CloudWatchRule(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CloudWatchRule, CloudWatchRule)
 !define CloudWatchRuleParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CloudWatchRule, CloudWatchRule)
 !define CloudWatchRuleParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CloudWatchRule, CloudWatchRule)
-
-sprite $CodeGuru [64x64/16z] {
-xTA7ScuX20JWLIcoUV_dlUKm_Ea9tbxoJJl5HGRbd-l31pD-bp7-kdpm0LK-49tuN7p5cj783qWzkgcQLqWmUWra0Lz0MfxntBvHmCXOm11pDnd02j8otkC3
-ineFdnZE4mue7r30sHS3naSiPzUqe4onf3fOx7BCUjotnmbdJotTLod9XopQKNiwb3GO5PvLDriCcZDqNbdFsIcC3Pcf6Ixicfr3tqtEEProd-54LAqDeSyv
-bQyI09PvWP2CCVAxPDu025yLNr7WTOKsrktoE2GNzEQtWNrbygazlzgKUlLhf41Pe-oeaxR8emYhMz5aEQF7Uqgp_RewcH_1vCZ75iVOMQaoEqjsAORp0HzG
-db0WU1E0yinyd9_yx_A-R_nRyeySvtqzulpLmXy87bjuOF6O0I89C9wRy3kIlClJExOn_3Am-IqKICfl4gON2_wPFdpu3
-}
-
-AWSEntityColoring(CodeGuru)
-!define CodeGuru(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #CC2264, CodeGuru, CodeGuru)
-!define CodeGuru(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #CC2264, CodeGuru, CodeGuru)
-!define CodeGuruParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #CC2264, CodeGuru, CodeGuru)
-!define CodeGuruParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #CC2264, CodeGuru, CodeGuru)
 
 sprite $Config [64x64/16z] {
 xTP5ekGm34NH9yaMPV_xRKCn9Qv9qx-Zq0bJ_X7zz5EOxcVllU58_jOhYkubi0zUj_pSLZ_xJAUMP2-u3NBS3Uvw0p5e80SOc7uC-Y5Vay--R7BsqWRNVVBL

--- a/awslib/MigrationAndTransfer/TransferFamily.puml
+++ b/awslib/MigrationAndTransfer/TransferFamily.puml
@@ -1,0 +1,14 @@
+' Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+' SPDX-License-Identifier: CC-BY-ND-2.0 (For details, see https://github.com/awslabs/aws-icons-for-plantuml/blob/master/LICENSE)
+sprite $TransferFamily [64x64/16z] {
+xT5NaiCW48JX9ixqxFtlknXJLYeZ0w_wbSEdoBNKrkBZV-hnZBBa0o0BFi83EkqJF0LE9ts6OvkF-mgrFGKdl03w-GeSzhhxyX5XrAj3KcLTLVM8WzwZL1LT
+NPLldcbhEqbYgJwsmfNLn6y-OLUsNMm-_DckgyygBGSnacTlVQ_xV-PACkR5Feb_9IPQvR2_FFcwvmy-XKEw-HG2N0YfvvKu9lpSEU0T-pvmdssUjN3hRT_E
+lnlnp3cdvdrPbq4lA3N_oWrwY_0Yj99A1lAeDu-qNntsTCXM2uWsxaqTv7qes8mtWLEp3CyvNwXZlSYajmJl83RjBGBP5ZnZiXNVwll7FpuZ2GAxzJmTxkju
+qnXkItRnipt-yOlfFm
+}
+
+AWSEntityColoring(TransferFamily)
+!define TransferFamily(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, TransferFamily, TransferFamily)
+!define TransferFamily(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, TransferFamily, TransferFamily)
+!define TransferFamilyParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, TransferFamily, TransferFamily)
+!define TransferFamilyParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, TransferFamily, TransferFamily)

--- a/awslib/MigrationAndTransfer/all.puml
+++ b/awslib/MigrationAndTransfer/all.puml
@@ -150,16 +150,16 @@ AWSEntityColoring(Snowmobile)
 !define SnowmobileParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, Snowmobile, Snowmobile)
 !define SnowmobileParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, Snowmobile, Snowmobile)
 
-sprite $TransferforSFTP [64x64/16z] {
-xTG7hjim44NHDyFfV__x3IWJLW4YWtHwVDtBKIVhh-ZJfyYtkA6znm5PvmuuGzxXbGHTum5OVo7OWXvkUG6vgo3uD6UmMVHtveBf1IXwRPn3W2TzcfbkNY5c
-5lNTJ9_PUHbZ_LwtCVPaoNlu8uPuBqvUtUFM7u_wbhXczxnv07phSr-0Rdb3x5xqfSzHZPu-I-5bVklBw9pAy4O4W4XUU10Vsptt2FpAUntx6dwmdF8g8lJm
-92AQSpxHezo6O2_cV1bW4TkYmW6jILy6ojfAxdpMbu9oSAa5NmBk2sXejU370WPVyjtsPIpxQXXyokzZA7dm2HyCW6oWh4cV16O6eaQJFiPyPSjUCdFP9-CH
--P9luBO5oWMVHFlazvQNQQ_mhrhr3MfDD0xUzHpQZG-Y5C0E-s-un7LJHhXxCffiWT8lHRqkQ3__IsKyolgJ-_Jf6m
+sprite $TransferFamily [64x64/16z] {
+xT5NaiCW48JX9ixqxFtlknXJLYeZ0w_wbSEdoBNKrkBZV-hnZBBa0o0BFi83EkqJF0LE9ts6OvkF-mgrFGKdl03w-GeSzhhxyX5XrAj3KcLTLVM8WzwZL1LT
+NPLldcbhEqbYgJwsmfNLn6y-OLUsNMm-_DckgyygBGSnacTlVQ_xV-PACkR5Feb_9IPQvR2_FFcwvmy-XKEw-HG2N0YfvvKu9lpSEU0T-pvmdssUjN3hRT_E
+lnlnp3cdvdrPbq4lA3N_oWrwY_0Yj99A1lAeDu-qNntsTCXM2uWsxaqTv7qes8mtWLEp3CyvNwXZlSYajmJl83RjBGBP5ZnZiXNVwll7FpuZ2GAxzJmTxkju
+qnXkItRnipt-yOlfFm
 }
 
-AWSEntityColoring(TransferforSFTP)
-!define TransferforSFTP(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, TransferforSFTP, TransferforSFTP)
-!define TransferforSFTP(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, TransferforSFTP, TransferforSFTP)
-!define TransferforSFTPParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, TransferforSFTP, TransferforSFTP)
-!define TransferforSFTPParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, TransferforSFTP, TransferforSFTP)
+AWSEntityColoring(TransferFamily)
+!define TransferFamily(e_alias, e_label, e_techn) AWSEntity(e_alias, e_label, e_techn, #1C7B68, TransferFamily, TransferFamily)
+!define TransferFamily(e_alias, e_label, e_techn, e_descr) AWSEntity(e_alias, e_label, e_techn, e_descr, #1C7B68, TransferFamily, TransferFamily)
+!define TransferFamilyParticipant(p_alias, p_label, p_techn) AWSParticipant(p_alias, p_label, p_techn, #1C7B68, TransferFamily, TransferFamily)
+!define TransferFamilyParticipant(p_alias, p_label, p_techn, p_descr) AWSParticipant(p_alias, p_label, p_techn, p_descr, #1C7B68, TransferFamily, TransferFamily)
 


### PR DESCRIPTION
Adds new and updates existing `.puml` files from https://github.com/awslabs/aws-icons-for-plantuml/tree/main/dist to the `awslib/` folder in this repository.

Also updates the version in the awslib `INFO` file from 6.0.0 to the current 7.0.0.

Fixes #15

The update was created automatically with code linked to in other MRs. If anything is out of order, please let me know so I can bugfix the automation.