### PR TITLE
Fix cloudogu version

### DIFF
--- a/cloudogu/INFO
+++ b/cloudogu/INFO
@@ -1,2 +1,2 @@
-VERSION=0.0.1
+VERSION=1.0.2
 SOURCE=https://github.com/cloudogu/plantuml-cloudogu-sprites


### PR DESCRIPTION
Cloudogu code is from 1.0.2, INFO says otherwise… This PR fixes the discrepancy.