### PR TITLE
Update URLs in INFO files of projects under https://github.com/plantuml-stdlib

### DIFF
--- a/archimate/INFO
+++ b/archimate/INFO
@@ -1,2 +1,2 @@
-VERSION=0.0.1
-SOURCE=https://github.com/ebbypeter/Archimate-PlantUML
+VERSION=1.0.0
+SOURCE=https://github.com/plantuml-stdlib/Archimate-PlantUML

--- a/azure/INFO
+++ b/azure/INFO
@@ -1,2 +1,2 @@
 VERSION=2.1.0
-SOURCE=https://github.com/RicardoNiepel/Azure-PlantUML
+SOURCE=https://github.com/plantuml-stdlib/Azure-PlantUML

--- a/cloudinsight/INFO
+++ b/cloudinsight/INFO
@@ -1,2 +1,2 @@
 VERSION=1.0.0
-SOURCE=https://github.com/rabelenda/cicon-plantuml-sprites/
+SOURCE=https://github.com/plantuml-stdlib/cicon-plantuml-sprites

--- a/kubernetes/INFO
+++ b/kubernetes/INFO
@@ -1,2 +1,2 @@
 VERSION=5.3.45
-SOURCE=https://github.com/michiel/plantuml-kubernetes-sprites
+SOURCE=https://github.com/plantuml-stdlib/plantuml-kubernetes-sprites

--- a/logos/INFO
+++ b/logos/INFO
@@ -1,2 +1,2 @@
 VERSION=1.0.0
-SOURCE=https://github.com/rabelenda/gilbarbara-plantuml-sprites
+SOURCE=https://github.com/plantuml-stdlib/gilbarbara-plantuml-sprites


### PR DESCRIPTION
Some of the URLs of projects under the stdlib have changed.
```
@startuml
stdlib
@enduml
```

![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuIekISd9JE9oICrB0N41)

This MR fixes that for the projects that have migrated to https://github.com/plantuml-stdlib