### PR TITLE
📝 Add examples for `archimate`, `azure`, `material`, and fix `edgy/edgy2` examples

### DIFF
--- a/stdlib/archimate/_examples_/example.puml
+++ b/stdlib/archimate/_examples_/example.puml
@@ -1,0 +1,35 @@
+@startuml
+!include <archimate/Archimate>
+
+title Archimate Sample - Internet Browser
+
+' Elements
+Business_Object(businessObject, "A Business Object")
+Business_Process(someBusinessProcess,"Some Business Process")
+Business_Service(itSupportService, "IT Support for Business (Application Service)")
+
+Application_DataObject(dataObject, "Web Page Data \n 'on the fly'")
+Application_Function(webpageBehaviour, "Web page behaviour")
+Application_Component(ActivePartWebPage, "Active Part of the web page \n 'on the fly'")
+
+Technology_Artifact(inMemoryItem,"in memory / 'on the fly' html/javascript")
+Technology_Service(internetBrowser, "Internet Browser Generic & Plugin")
+Technology_Service(internetBrowserPlugin, "Some Internet Browser Plugin")
+Technology_Service(webServer, "Some web server")
+
+'Relationships
+Rel_Flow_Left(someBusinessProcess, businessObject, "")
+Rel_Serving_Up(itSupportService, someBusinessProcess, "")
+Rel_Specialization_Up(webpageBehaviour, itSupportService, "")
+Rel_Flow_Right(dataObject, webpageBehaviour, "")
+Rel_Specialization_Up(dataObject, businessObject, "")
+Rel_Assignment_Left(ActivePartWebPage, webpageBehaviour, "")
+Rel_Specialization_Up(inMemoryItem, dataObject, "")
+Rel_Realization_Up(inMemoryItem, ActivePartWebPage, "")
+Rel_Specialization_Right(inMemoryItem,internetBrowser, "")
+Rel_Serving_Up(internetBrowser, webpageBehaviour, "")
+Rel_Serving_Up(internetBrowserPlugin, webpageBehaviour, "")
+Rel_Aggregation_Right(internetBrowser, internetBrowserPlugin, "")
+Rel_Access_Up(webServer, inMemoryItem, "")
+Rel_Serving_Up(webServer, internetBrowser, "")
+@enduml

--- a/stdlib/azure/_examples_/example.puml
+++ b/stdlib/azure/_examples_/example.puml
@@ -1,0 +1,21 @@
+@startuml
+!include <azure/AzureCommon>
+!include <azure/Analytics/AzureEventHub>
+!include <azure/Analytics/AzureStreamAnalyticsJob>
+!include <azure/Databases/AzureCosmosDb>
+
+left to right direction
+
+agent "Device Simulator" as devices #fff
+
+AzureEventHub(fareDataEventHub, "Fare Data", "PK: Medallion HackLicense VendorId; 3 TUs")
+AzureEventHub(tripDataEventHub, "Trip Data", "PK: Medallion HackLicense VendorId; 3 TUs")
+AzureStreamAnalyticsJob(streamAnalytics, "Stream Processing", "6 SUs")
+AzureCosmosDb(outputCosmosDb, "Output Database", "1,000 RUs")
+
+devices --> fareDataEventHub
+devices --> tripDataEventHub
+fareDataEventHub --> streamAnalytics
+tripDataEventHub --> streamAnalytics
+streamAnalytics --> outputCosmosDb
+@enduml

--- a/stdlib/edgy/_examples_/example.puml
+++ b/stdlib/edgy/_examples_/example.puml
@@ -1,4 +1,4 @@
 @startuml
 !include <edgy/edgy>
-!include <edgy/docs/example_code>
+!include <edgy/_examples_/example_code>
 @enduml

--- a/stdlib/edgy/_examples_/example2.puml
+++ b/stdlib/edgy/_examples_/example2.puml
@@ -1,4 +1,4 @@
 @startuml
 !include <edgy/edgy2>
-!include <edgy/docs/example_code>
+!include <edgy/_examples_/example_code>
 @enduml

--- a/stdlib/material/_examples_/example.puml
+++ b/stdlib/material/_examples_/example.puml
@@ -1,0 +1,7 @@
+@startuml
+!include <material/common>
+' To import the sprite file you DON'T need to place a prefix!
+!include <material/folder_move>
+
+MA_FOLDER_MOVE(Red, 1, dir, rectangle, "A label")
+@enduml


### PR DESCRIPTION
Hello PlantUML team, and @arnaudroques

To continue:
- #123

Here is a PR with adding:
- [x] `archimate` example
- [x] `azure` example
- [x] `material` example
- [x] fix `edgy/edgy2` examples
- [ ] _TBC... for the other stdlib where the examples are still missing..._

Regards,
Th.