### PR TITLE
🚑️ hot fix of `DomainStory` accroding to `material2.1.19`

### DIFF
--- a/stdlib/DomainStory/domainStory.puml
+++ b/stdlib/DomainStory/domainStory.puml
@@ -195,7 +195,7 @@
     !$variableName = $decideVariableName($kind, "", "IconName")
     !if $icon
         !if %not(%variable_exists($variableName))
-            !include <material/$icon>
+            !include <material2.1.19/$icon>
             %set_variable_value($variableName, "$ma_" + $icon)
         !endif
     !else


### PR DESCRIPTION
Hello PlantUML stdlib team, @arnaudroques,

Here is a hot fix in order to:
- fix `material` version on `DomainStory` to the old bitmap sprite version

Issue observed on:
- johthor/DomainStory-PlantUML/issues/27
- https://forum.plantuml.net/20104/material-stdlib-working-current-version-ioexception-stream

Ref.:
- #142

_FYI @johthor, @kirchsth, @arnaudroques_