### PR TITLE
Patch C4 library to v2.12.1 (add handwritten fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,15 +122,19 @@ This example renders the following image:
 <!-- start C4 section -->
 ![name: C4](https://img.shields.io/badge/name-C4-black)
 ![display_name: C4 (C4-PlantUML)](https://img.shields.io/badge/display__name-C4_(C4--PlantUML)-black)
-[![version: 2.12.0][Version Badge]][Version Link]
+[![version: 2.12.1][Version Badge]][Version Link]
+![patched](https://img.shields.io/badge/patched-darkred)
 ![license: MIT](https://img.shields.io/badge/license-MIT-green)
 ![author: Ricardo Niepel, kirchsth and contributors](https://img.shields.io/badge/author-Ricardo_Niepel,_kirchsth_and_contributors-black)  
 [![all properties see: ./stdlib/C4/README.md][See Badge]][See Link]  
 
-[Version Badge]: https://img.shields.io/badge/version-2.12.0-blue
+[Version Badge]: https://img.shields.io/badge/version-2.12.1-blue
 [Version Link]: https://github.com/plantuml-stdlib/C4-PlantUML/tree/release/v2.12.0
 [See Badge]: https://img.shields.io/badge/all_stdlib_specific_properties_see-./stdlib/C4/README.md-blue
 [See Link]: ./stdlib/C4/README.md
+
+> [!INFORMATION]
+> **C4 library is patched to version 2.12.1:** This version contains the [Fix for "Use !option handwritten true" warning](https://github.com/plantuml-stdlib/C4-PlantUML/pull/397) too.
 <!-- end C4 section -->
 
 The C4 library enables a simple way of describing and communicate software architectures with an intuitive language.

--- a/stdlib/C4/C4.puml
+++ b/stdlib/C4/C4.puml
@@ -23,7 +23,7 @@
 ' ##################################
 !function C4Version()
   ' 2 spaces and ' are used as unique marker, that the release scripts makes the correct version update
-  !$c4Version  =  "2.12.0"
+  !$c4Version  =  "2.12.1"
   !return $c4Version
 !end function
 
@@ -1392,7 +1392,25 @@ hide stereotype
 !endprocedure
 
 !procedure LAYOUT_AS_SKETCH()
+!$counter=0
+!foreach $versionPart in %splitstr(%version(), ".")
+  !$counter=$counter+1
+
+  !if ($counter == 2)
+    !$year=$versionPart
+  !endif
+
+  !if ($counter == 3)
+    !$minor=$versionPart
+  !endif
+!endfor
+
+!if ($year < 2025) || ($year == 2025 && $minor == 0)
   skinparam handwritten true
+!else
+  !option handwritten true
+!endif
+
 !if $SKETCH_BG_COLOR > ""
   skinparam backgroundColor $SKETCH_BG_COLOR
 !endif

--- a/stdlib/C4/README.md
+++ b/stdlib/C4/README.md
@@ -3,7 +3,7 @@ name: C4
 display_name: C4 (C4-PlantUML)
 description: The C4 library enables a simple way of describing and communicate software architectures with an intuitive language.
 author: Ricardo Niepel, kirchsth and contributors
-version: 2.12.0
+version: 2.12.1
 release: https://github.com/plantuml-stdlib/C4-PlantUML/tree/release/v2.12.0
 license: MIT
 source: https://github.com/plantuml-stdlib/C4-PlantUML
@@ -12,8 +12,9 @@ origin: https://c4model.com
 **C4 specific stdlib properties:**  
 ![name: C4](https://img.shields.io/badge/name-C4-black)
 ![display_name: C4 (C4-PlantUML)](https://img.shields.io/badge/display__name-C4_(C4--PlantUML)-black)  
-![version: 2.12.0](https://img.shields.io/badge/version-2.12.0-black)
-[![release: https://github.com/plantuml-stdlib/C4-PlantUML/tree/release/v2.12.0][Release Badge]][Release Link]  
+![version: 2.12.1](https://img.shields.io/badge/version-2.12.1-black)
+[![release: https://github.com/plantuml-stdlib/C4-PlantUML/tree/release/v2.12.0][Release Badge]][Release Link]
+![patched](https://img.shields.io/badge/patched-darkred)  
 ![description: The C4 library enables a simple way of describing and communicate software architectures with an intuitive language.](https://img.shields.io/badge/description-The_C4_library_enables_a_simple_way_of_describing_and_communicate_software_architectures_with_an_intuitive_language.-black)  
 [![license: MIT][License Badge]][License Link]
 ![author: Ricardo Niepel, kirchsth and contributors](https://img.shields.io/badge/author-Ricardo_Niepel,_kirchsth_and_contributors-black)  
@@ -40,6 +41,9 @@ origin: https://c4model.com
 [Open Link]: https://github.com/plantuml-stdlib/C4-PlantUML/compare/v2.12.0...master
 [Discussions Badge]: https://img.shields.io/badge/discussions-https://github.com/plantuml--stdlib/C4--PlantUML/discussions-orange
 [Discussions Link]: https://github.com/plantuml-stdlib/C4-PlantUML/discussions
+
+> [!INFORMATION]
+> **C4 library is patched to version 2.12.1:** This version contains the [Fix for "Use !option handwritten true" warning](https://github.com/plantuml-stdlib/C4-PlantUML/pull/397) too.
 
 # C4 library (C4-PlantUML) [C4]
 


### PR DESCRIPTION
This is C4 library specific patch to v2.12.1 and fixes the displayed warning

![image](https://github.com/user-attachments/assets/866f8fff-20f2-4319-8b95-8d14986a6b83)

Details see [Fix for "Use !option handwritten true" warning](https://github.com/plantuml-stdlib/C4-PlantUML/pull/397)
