### PR TITLE
Update to stdlib ArchiMate-PlantUML v3.2.1

### DIFF
--- a/stdlib/archimate/Archimate.puml
+++ b/stdlib/archimate/Archimate.puml
@@ -3,7 +3,7 @@
 ' Version
 '######################################
 !function ArchimateVersion()
-  !$archimateVersion  =  "2.2.0alpha5"
+  !$archimateVersion  =  "3.2.1"
   !return $archimateVersion
 !endfunction
 
@@ -18,23 +18,30 @@
 ' Styling
 '######################################
 
-!global $ARCH_DEBUG ?= false
-!global $ARCH_LOCAL ?= false
+!global $ARCH_DEBUG ?= %false()
+!global $ARCH_LOCAL ?= %false()
+!global $ARCH_SEQUENCE_SUPPORT ?= %false()
 
-!if ($ARCH_LOCAL == true)
+!if ($ARCH_LOCAL == %true())
     !include themes/shared_style.puml
+    !if ($ARCH_SEQUENCE_SUPPORT == %true())
+        !include ArchimateSequenceDiagramSupport.puml
+    !endif
 !else
     !include <archimate/themes/shared_style>
+    !if ($ARCH_SEQUENCE_SUPPORT == %true())
+        !include <archimate/ArchimateSequenceDiagramSupport>
+    !endif
 !endif
 
-!if ($ARCH_DEBUG == true)
+!if ($ARCH_DEBUG == %true())
     left header "Created using Archimate.puml version ArchimateVersion()"
 !endif
 
 ' Layout
 ' ##################################
 !procedure LAYOUT_AS_SKETCH()
-    !option handwritten true
+    !option handwritten %true()
     <style>
         root {
             BackgroundColor #EEEBDC
@@ -79,198 +86,246 @@
 ' ##################################
 
 'Strategy Elements
-!unquoted procedure Strategy_Resource($alias, $label)
+!unquoted procedure Strategy_Resource($alias, $label, $nest=0)
   archimate $ARCH_STRATEGY_FILLCOLOR "$label" <<strategy-resource>> as $alias
 !endprocedure
-!unquoted procedure Strategy_Capability($alias, $label)
+!unquoted procedure Strategy_Capability($alias, $label, $nest=0)
   archimate $ARCH_STRATEGY_FILLCOLOR "$label" <<strategy-capability>> as $alias
 !endprocedure
-!unquoted procedure Strategy_CourseOfAction($alias, $label)
+!unquoted procedure Strategy_CourseOfAction($alias, $label, $nest=0)
   archimate $ARCH_STRATEGY_FILLCOLOR "$label" <<strategy-courseofaction>> as $alias
 !endprocedure
-!unquoted procedure Strategy_ValueStream($alias, $label)
-  archimate $ARCH_STRATEGY_FILLCOLOR "$label" <<strategy-valuestream>> as $alias
+!unquoted procedure Strategy_ValueStream($alias, $label, $nest=0, $special = $ARCH_SPECIAL_SHAPES)
+  !if ($special == %true())
+      process "$label" as $alias $ARCH_STRATEGY_FILLCOLOR
+  !else
+      archimate $ARCH_STRATEGY_FILLCOLOR "$label" <<strategy-valuestream>> as $alias
+  !endif
 !endprocedure
 
 'Business Elements
-!unquoted procedure Business_Actor($alias, $label)
-  archimate $ARCH_BUSINESS_FILLCOLOR "$label" <<business-actor>> as $alias
+!unquoted procedure Business_Actor($alias, $label, $nest=0, $special = $ARCH_SPECIAL_SHAPES)
+  !if ($special == %true() && $nest == %false())
+      actor "$label" as $alias $ARCH_BUSINESS_FILLCOLOR
+  !else
+      archimate $ARCH_BUSINESS_FILLCOLOR "$label" <<business-actor>> as $alias
+  !endif
 !endprocedure
-!unquoted procedure Business_Role($alias, $label)
-  archimate $ARCH_BUSINESS_FILLCOLOR "$label" <<business-role>> as $alias
+!unquoted procedure Business_Role($alias, $label, $nest=0, $special = $ARCH_SPECIAL_SHAPES)
+  !if ($special == %true())
+    queue "%n()$label%n()" as $alias $ARCH_BUSINESS_FILLCOLOR
+  !else
+    archimate $ARCH_BUSINESS_FILLCOLOR "$label" <<business-role>> as $alias
+  !endif
 !endprocedure
-!unquoted procedure Business_Collaboration($alias, $label)
+!unquoted procedure Business_Collaboration($alias, $label, $nest=0)
   archimate $ARCH_BUSINESS_FILLCOLOR "$label" <<business-collaboration>> as $alias
 !endprocedure
-!unquoted procedure Business_Interface($alias, $label)
+!unquoted procedure Business_Interface($alias, $label, $nest=0)
   archimate $ARCH_BUSINESS_FILLCOLOR "$label" <<business-interface>> as $alias
 !endprocedure
-!unquoted procedure Business_Process($alias, $label)
+!unquoted procedure Business_Process($alias, $label, $nest=0)
   archimate $ARCH_BUSINESS_FILLCOLOR "$label" <<business-process>> as $alias
 !endprocedure
-!unquoted procedure Business_Function($alias, $label)
+!unquoted procedure Business_Function($alias, $label, $nest=0)
   archimate $ARCH_BUSINESS_FILLCOLOR "$label" <<business-function>> as $alias
 !endprocedure
-!unquoted procedure Business_Interaction($alias, $label)
+!unquoted procedure Business_Interaction($alias, $label, $nest=0)
   archimate $ARCH_BUSINESS_FILLCOLOR "$label" <<business-interaction>> as $alias
 !endprocedure
-!unquoted procedure Business_Event($alias, $label)
+!unquoted procedure Business_Event($alias, $label, $nest=0)
   archimate $ARCH_BUSINESS_FILLCOLOR "$label" <<business-event>> as $alias
 !endprocedure
-!unquoted procedure Business_Service($alias, $label)
-  archimate $ARCH_BUSINESS_FILLCOLOR "$label" <<business-service>> as $alias
+!unquoted procedure Business_Service($alias, $label, $nest=0, $special = $ARCH_SPECIAL_SHAPES)
+  !if ($special == %true() && $nest == %false())
+      rectangle "$label" <<service-special>> as $alias $ARCH_BUSINESS_FILLCOLOR
+  !else
+      archimate $ARCH_BUSINESS_FILLCOLOR "$label" <<business-service>> as $alias
+  !endif
 !endprocedure
-!unquoted procedure Business_Object($alias, $label)
+!unquoted procedure Business_Object($alias, $label, $nest=0)
   archimate $ARCH_BUSINESS_FILLCOLOR "$label" <<business-object>> as $alias
 !endprocedure
-!unquoted procedure Business_Contract($alias, $label)
+!unquoted procedure Business_Contract($alias, $label, $nest=0)
   archimate $ARCH_BUSINESS_FILLCOLOR "$label" <<business-contract>> as $alias
 !endprocedure
-!unquoted procedure Business_Representation($alias, $label)
+!unquoted procedure Business_Representation($alias, $label, $nest=0)
   archimate $ARCH_BUSINESS_FILLCOLOR "$label" <<business-representation>> as $alias
 !endprocedure
-!unquoted procedure Business_Product($alias, $label)
-  archimate $ARCH_BUSINESS_FILLCOLOR "$label" <<business-product>> as $alias
+!unquoted procedure Business_Product($alias, $label, $nest=0, $special = $ARCH_SPECIAL_SHAPES)
+  !if ($special == %true())
+    frame "%n()$label%n()" as $alias $ARCH_BUSINESS_FILLCOLOR
+  !else
+    archimate $ARCH_BUSINESS_FILLCOLOR "$label" <<business-product>> as $alias
+  !endif
 !endprocedure
-!unquoted procedure Business_Location($alias, $label)
+!unquoted procedure Business_Location($alias, $label, $nest=0)
   archimate $ARCH_BUSINESS_FILLCOLOR "$label" <<business-location>> as $alias
 !endprocedure
 
 'Application Elements
-!unquoted procedure Application_Component($alias, $label)
+!unquoted procedure Application_Component($alias, $label, $nest=0)
   archimate $ARCH_APPLICATION_FILLCOLOR "$label" <<application-component>> as $alias
 !endprocedure
-!unquoted procedure Application_Collaboration($alias, $label)
+!unquoted procedure Application_Collaboration($alias, $label, $nest=0)
   archimate $ARCH_APPLICATION_FILLCOLOR "$label" <<application-collaboration>> as $alias
 !endprocedure
-!unquoted procedure Application_Interface($alias, $label)
+!unquoted procedure Application_Interface($alias, $label, $nest=0)
   archimate $ARCH_APPLICATION_FILLCOLOR "$label" <<application-interface>> as $alias
 !endprocedure
-!unquoted procedure Application_Function($alias, $label)
+!unquoted procedure Application_Function($alias, $label, $nest=0)
   archimate $ARCH_APPLICATION_FILLCOLOR "$label" <<application-function>> as $alias
 !endprocedure
-!unquoted procedure Application_Interaction($alias, $label)
+!unquoted procedure Application_Interaction($alias, $label, $nest=0)
   archimate $ARCH_APPLICATION_FILLCOLOR "$label" <<application-interaction>> as $alias
 !endprocedure
-!unquoted procedure Application_Process($alias, $label)
+!unquoted procedure Application_Process($alias, $label, $nest=0)
   archimate $ARCH_APPLICATION_FILLCOLOR "$label" <<application-process>> as $alias
 !endprocedure
-!unquoted procedure Application_Event($alias, $label)
+!unquoted procedure Application_Event($alias, $label, $nest=0)
   archimate $ARCH_APPLICATION_FILLCOLOR "$label" <<application-event>> as $alias
 !endprocedure
-!unquoted procedure Application_Service($alias, $label)
-  archimate $ARCH_APPLICATION_FILLCOLOR "$label" <<application-service>> as $alias
+!unquoted procedure Application_Service($alias, $label, $nest=0, $special = $ARCH_SPECIAL_SHAPES)
+  !if ($special == %true() && $nest == %false())
+      rectangle "$label" <<service-special>> as $alias $ARCH_APPLICATION_FILLCOLOR
+  !else
+      archimate $ARCH_APPLICATION_FILLCOLOR "$label" <<application-service>> as $alias
+  !endif
 !endprocedure
-!unquoted procedure Application_DataObject($alias, $label)
+!unquoted procedure Application_DataObject($alias, $label, $nest=0)
   archimate $ARCH_APPLICATION_FILLCOLOR "$label" <<application-dataobject>> as $alias
 !endprocedure
 
 'Technology Elements
-!unquoted procedure Technology_Node($alias, $label)
-  archimate $ARCH_TECHNOLOGY_FILLCOLOR "$label" <<technology-node>> as $alias
+!unquoted procedure Technology_Node($alias, $label, $nest=0, $special = $ARCH_SPECIAL_SHAPES)
+  !if ($special == %true())
+    node "$label" as $alias $ARCH_TECHNOLOGY_FILLCOLOR
+  !else
+    archimate $ARCH_TECHNOLOGY_FILLCOLOR "$label" <<technology-node>> as $alias
+  !endif
 !endprocedure
-!unquoted procedure Technology_Device($alias, $label)
+!unquoted procedure Technology_Device($alias, $label, $nest=0)
   archimate $ARCH_TECHNOLOGY_FILLCOLOR "$label" <<technology-device>> as $alias
 !endprocedure
-!unquoted procedure Technology_SystemSoftware($alias, $label)
+!unquoted procedure Technology_SystemSoftware($alias, $label, $nest=0)
   archimate $ARCH_TECHNOLOGY_FILLCOLOR "$label" <<technology-systemsoftware>> as $alias
 !endprocedure
-!unquoted procedure Technology_Collaboration($alias, $label)
+!unquoted procedure Technology_Collaboration($alias, $label, $nest=0)
   archimate $ARCH_TECHNOLOGY_FILLCOLOR "$label" <<technology-collaboration>> as $alias
 !endprocedure
-!unquoted procedure Technology_Interface($alias, $label)
+!unquoted procedure Technology_Interface($alias, $label, $nest=0)
   archimate $ARCH_TECHNOLOGY_FILLCOLOR "$label" <<technology-interface>> as $alias
 !endprocedure
-!unquoted procedure Technology_Path($alias, $label)
+!unquoted procedure Technology_Path($alias, $label, $nest=0)
   archimate $ARCH_TECHNOLOGY_FILLCOLOR "$label" <<technology-path>> as $alias
 !endprocedure
-!unquoted procedure Technology_CommunicationNetwork($alias, $label)
+!unquoted procedure Technology_CommunicationNetwork($alias, $label, $nest=0)
   archimate $ARCH_TECHNOLOGY_FILLCOLOR "$label" <<technology-communicationnetwork>> as $alias
 !endprocedure
-!unquoted procedure Technology_Function($alias, $label)
+!unquoted procedure Technology_Function($alias, $label, $nest=0)
   archimate $ARCH_TECHNOLOGY_FILLCOLOR "$label" <<technology-function>> as $alias
 !endprocedure
-!unquoted procedure Technology_Process($alias, $label)
+!unquoted procedure Technology_Process($alias, $label, $nest=0)
   archimate $ARCH_TECHNOLOGY_FILLCOLOR "$label" <<technology-process>> as $alias
 !endprocedure
-!unquoted procedure Technology_Interaction($alias, $label)
+!unquoted procedure Technology_Interaction($alias, $label, $nest=0)
   archimate $ARCH_TECHNOLOGY_FILLCOLOR "$label" <<technology-interaction>> as $alias
 !endprocedure
-!unquoted procedure Technology_Event($alias, $label)
+!unquoted procedure Technology_Event($alias, $label, $nest=0)
   archimate $ARCH_TECHNOLOGY_FILLCOLOR "$label" <<technology-event>> as $alias
 !endprocedure
-!unquoted procedure Technology_Service($alias, $label)
-  archimate $ARCH_TECHNOLOGY_FILLCOLOR "$label" <<technology-service>> as $alias
+!unquoted procedure Technology_Service($alias, $label, $nest=0, $special = $ARCH_SPECIAL_SHAPES)
+  !if ($special == %true() && $nest == %false())
+      rectangle "$label" <<service-special>> as $alias $ARCH_TECHNOLOGY_FILLCOLOR
+  !else
+      archimate $ARCH_TECHNOLOGY_FILLCOLOR "$label" <<technology-service>> as $alias
+  !endif
 !endprocedure
-!unquoted procedure Technology_Artifact($alias, $label)
-  archimate $ARCH_TECHNOLOGY_FILLCOLOR "$label" <<technology-artifact>> as $alias
+!unquoted procedure Technology_Artifact($alias, $label, $nest=0, $special = $ARCH_SPECIAL_SHAPES)
+  !if ($special == %true())
+    file "$label" as $alias $ARCH_TECHNOLOGY_FILLCOLOR
+  !else
+    archimate $ARCH_TECHNOLOGY_FILLCOLOR "$label" <<technology-artifact>> as $alias
+  !endif
 !endprocedure
 
 'Physical Elements
-!unquoted procedure Physical_Equipment($alias, $label)
+!unquoted procedure Physical_Equipment($alias, $label, $nest=0)
   archimate $ARCH_PHYSICAL_FILLCOLOR "$label" <<technology-equipment>> as $alias
 !endprocedure
-!unquoted procedure Physical_Facility($alias, $label)
+!unquoted procedure Physical_Facility($alias, $label, $nest=0)
   archimate $ARCH_PHYSICAL_FILLCOLOR "$label" <<technology-facility>> as $alias
 !endprocedure
-!unquoted procedure Physical_DistributionNetwork($alias, $label)
+!unquoted procedure Physical_DistributionNetwork($alias, $label, $nest=0)
   archimate $ARCH_PHYSICAL_FILLCOLOR "$label" <<technology-distributionnetwork>> as $alias
 !endprocedure
-!unquoted procedure Physical_Material($alias, $label)
+!unquoted procedure Physical_Material($alias, $label, $nest=0)
   archimate $ARCH_PHYSICAL_FILLCOLOR "$label" <<technology-material>> as $alias
 !endprocedure
 
 'Motivation Elements
-!unquoted procedure Motivation_Stakeholder($alias, $label)
-  archimate $ARCH_MOTIVATION_FILLCOLOR "$label" <<motivation-stakeholder>> as $alias
+!unquoted procedure Motivation_Stakeholder($alias, $label, $nest=0, $special = $ARCH_SPECIAL_SHAPES)
+  !if ($special == %true())
+    queue "%n()$label%n()" as $alias $ARCH_MOTIVATION_FILLCOLOR
+  !else
+    archimate $ARCH_MOTIVATION_FILLCOLOR "$label" <<motivation-stakeholder>> as $alias
+  !endif
 !endprocedure
-!unquoted procedure Motivation_Driver($alias, $label)
+!unquoted procedure Motivation_Driver($alias, $label, $nest=0)
   archimate $ARCH_MOTIVATION_FILLCOLOR "$label" <<motivation-driver>> as $alias
 !endprocedure
-!unquoted procedure Motivation_Assessment($alias, $label)
+!unquoted procedure Motivation_Assessment($alias, $label, $nest=0)
   archimate $ARCH_MOTIVATION_FILLCOLOR "$label" <<motivation-assessment>> as $alias
 !endprocedure
-!unquoted procedure Motivation_Goal($alias, $label)
+!unquoted procedure Motivation_Goal($alias, $label, $nest=0)
   archimate $ARCH_MOTIVATION_FILLCOLOR "$label" <<motivation-goal>> as $alias
 !endprocedure
-!unquoted procedure Motivation_Outcome($alias, $label)
+!unquoted procedure Motivation_Outcome($alias, $label, $nest=0)
   archimate $ARCH_MOTIVATION_FILLCOLOR "$label" <<motivation-outcome>> as $alias
 !endprocedure
-!unquoted procedure Motivation_Principle($alias, $label)
+!unquoted procedure Motivation_Principle($alias, $label, $nest=0)
   archimate $ARCH_MOTIVATION_FILLCOLOR "$label" <<motivation-principle>> as $alias
 !endprocedure
-!unquoted procedure Motivation_Requirement($alias, $label)
+!unquoted procedure Motivation_Requirement($alias, $label, $nest=0)
   archimate $ARCH_MOTIVATION_FILLCOLOR "$label" <<motivation-requirement>> as $alias
 !endprocedure
-!unquoted procedure Motivation_Constraint($alias, $label)
+!unquoted procedure Motivation_Constraint($alias, $label, $nest=0)
   archimate $ARCH_MOTIVATION_FILLCOLOR "$label" <<motivation-constraint>> as $alias
 !endprocedure
-!unquoted procedure Motivation_Meaning($alias, $label)
-  archimate $ARCH_MOTIVATION_FILLCOLOR "$label" <<motivation-meaning>> as $alias
+!unquoted procedure Motivation_Meaning($alias, $label, $nest=0, $special = $ARCH_SPECIAL_SHAPES)
+  !if ($special == %true())
+    cloud "$label" as $alias $ARCH_MOTIVATION_FILLCOLOR
+  !else
+    archimate $ARCH_MOTIVATION_FILLCOLOR "$label" <<motivation-meaning>> as $alias
+  !endif
 !endprocedure
-!unquoted procedure Motivation_Value($alias, $label)
-  archimate $ARCH_MOTIVATION_FILLCOLOR "$label" <<motivation-value>> as $alias
+!unquoted procedure Motivation_Value($alias, $label, $nest=0, $special = $ARCH_SPECIAL_SHAPES)
+  !if ($special == %true() && $nest == %false())
+    usecase "%n()$label%n()" as $alias $ARCH_MOTIVATION_FILLCOLOR
+  !else
+    archimate $ARCH_MOTIVATION_FILLCOLOR "$label" <<motivation-value>> as $alias
+  !endif
 !endprocedure
 
 'Implementation Elements
-!unquoted procedure Implementation_WorkPackage($alias, $label)
+!unquoted procedure Implementation_WorkPackage($alias, $label, $nest=0)
   archimate $ARCH_IMPLEMENTATION_FILLCOLOR "$label" <<implementation-workpackage>> as $alias
 !endprocedure
-!unquoted procedure Implementation_Deliverable($alias, $label)
+!unquoted procedure Implementation_Deliverable($alias, $label, $nest=0)
   archimate $ARCH_IMPLEMENTATION_FILLCOLOR "$label" <<implementation-deliverable>> as $alias
 !endprocedure
-!unquoted procedure Implementation_Event($alias, $label)
+!unquoted procedure Implementation_Event($alias, $label, $nest=0)
   archimate $ARCH_IMPLEMENTATION_FILLCOLOR "$label" <<implementation-event>> as $alias
 !endprocedure
-!unquoted procedure Implementation_Plateau($alias, $label)
+!unquoted procedure Implementation_Plateau($alias, $label, $nest=0)
   archimate $ARCH_IMPLEMENTATION_FILLCOLOR "$label" <<implementation-plateau>> as $alias
 !endprocedure
-!unquoted procedure Implementation_Gap($alias, $label)
+!unquoted procedure Implementation_Gap($alias, $label, $nest=0)
   archimate $ARCH_IMPLEMENTATION_FILLCOLOR "$label" <<implementation-gap>> as $alias
 !endprocedure
 
 'Other Elements
-!unquoted procedure Other_Location($alias, $label)
+!unquoted procedure Other_Location($alias, $label, $nest=0)
   archimate $ARCH_OTHER_FILLCOLOR "$label" <<location>> as $alias
 !endprocedure
 !unquoted procedure Other_Grouping($alias, $label)

--- a/stdlib/archimate/ArchimateSequenceDiagramSupport.puml
+++ b/stdlib/archimate/ArchimateSequenceDiagramSupport.puml
@@ -1,0 +1,226 @@
+' Defines functions and procedures to support Archimate elements as participants in sequence diagrams
+' Based on the work by Steven Mileham (see [1]), and included here with his permission.
+' [1] - https://smileham.co.uk/2019/04/23/archimate-plantuml-sequence-diagram-joy/
+
+!global $ARCH_DEBUG ?= %false()
+!global $ARCH_LOCAL ?= %false()
+
+!if ($ARCH_LOCAL == %true())
+    !include themes/shared_style.puml
+!else
+    !include <archimate/themes/shared_style>
+!endif
+
+<style>
+    sequenceDiagram {
+        participant {
+            HorizontalAlignment center
+            MinimumWidth 10
+            RoundCorner $ARCH_SHARP_CORNER
+            stereoType {
+                FontColor transparent
+                FontSize 1
+            }
+        }
+    }
+</style>
+
+!procedure $element($layer,$type,$label,$id)
+    !if ($id=="")
+        !$id = $label
+    !endif
+    !if ($type=="distributionnetwork")
+        !$bgcolor = "#PHYSICAL"
+    !else
+        !$bgcolor = "#" + $layer
+    !endif
+    participant "$label" as $id <<$archimate/$layer-$type>> $bgcolor
+!endprocedure
+
+' motivation
+!procedure $stakeholder($label, $name="")
+    $element("motivation", "stakeholder", $label, $name)
+!endprocedure
+!procedure $driver($label, $name="")
+    $element("motivation", "driver", $label, $name)
+!endprocedure
+!procedure $assessment($label, $name="")
+    $element("motivation", "assessment", $label, $name)
+!endprocedure
+!procedure $goal($label, $name="")
+    $element("motivation", "goal", $label, $name)
+!endprocedure
+!procedure $outcome($label, $name="")
+    $element("motivation", "outcome", $label, $name)
+!endprocedure
+!procedure $principle($label, $name="")
+    $element("motivation", "principle", $label, $name)
+!endprocedure
+!procedure $requirement($label, $name="")
+    $element("motivation", "requirement", $label, $name)
+!endprocedure
+!procedure $constraint($label, $name="")
+    $element("motivation", "constraint", $label, $name)
+!endprocedure
+!procedure $value($label, $name="")
+    $element("motivation", "value", $label, $name)
+!endprocedure
+!procedure $meaning($label, $name="")
+    $element("motivation", "meaning", $label, $name)
+!endprocedure
+
+' strategy
+!procedure $resource($label, $name="")
+    $element("strategy", "resource", $label, $name)
+!endprocedure
+!procedure $capability($label, $name="")
+    $element("strategy", "capability", $label, $name)
+!endprocedure
+!procedure $valueStream($label, $name="")
+    $element("strategy", "valuestream", $label, $name)
+!endprocedure
+!procedure $courseOfAction($label, $name="")
+    $element("strategy", "courseofaction", $label, $name)
+!endprocedure
+
+' implementation and Migration
+!procedure $workPackage($label, $name="")
+    $element("implementation", "workpackage", $label, $name)
+!endprocedure
+!procedure $implementationEvent($label, $name="")
+    $element("implementation", "event", $label, $name)
+!endprocedure
+!procedure $deliverable($label, $name="")
+    $element("implementation", "deliverable", $label, $name)
+!endprocedure
+!procedure $plateau($label, $name="")
+    $element("implementation", "plateau", $label, $name)
+!endprocedure
+!procedure $gap($label, $name="")
+    $element("implementation", "gap", $label, $name)
+!endprocedure
+
+' business
+!procedure $actor($label, $name="")
+    $element("business", "actor", $label, $name)
+!endprocedure
+!procedure $role($label, $name="")
+    $element("business", "role", $label, $name)
+!endprocedure
+!procedure $businessCollaboration($label, $name="")
+    $element("business", "collaboration", $label, $name)
+!endprocedure
+!procedure $businessInterface($label, $name="")
+    $element("business", "interface", $label, $name)
+!endprocedure
+!procedure $businessProcess($label, $name="")
+    $element("business", "process", $label, $name)
+!endprocedure
+!procedure $businessFunction($label, $name="")
+    $element("business", "function", $label, $name)
+!endprocedure
+!procedure $businessInteraction($label, $name="")
+    $element("business", "interaction", $label, $name)
+!endprocedure
+!procedure $businessService($label, $name="")
+    $element("business", "service", $label, $name)
+!endprocedure
+!procedure $businessEvent($label, $name="")
+    $element("business", "event", $label, $name)
+!endprocedure
+!procedure $businessObject($label, $name="")
+    $element("business", "object", $label, $name)
+!endprocedure
+!procedure $contract($label, $name="")
+    $element("business", "contract", $label, $name)
+!endprocedure
+!procedure $representation($label, $name="")
+    $element("business", "representation", $label, $name)
+!endprocedure
+!procedure $product($label, $name="")
+    $element("business", "product", $label, $name)
+!endprocedure
+
+' application
+!procedure $applicationComponent($label, $name="")
+    $element("application", "component", $label, $name)
+!endprocedure
+!procedure $applicationCollaboration($label, $name="")
+    $element("application", "collaboration", $label, $name)
+!endprocedure
+!procedure $applicationInterface($label, $name="")
+    $element("application", "interface", $label, $name)
+!endprocedure
+!procedure $applicationProcess($label, $name="")
+    $element("application", "process", $label, $name)
+!endprocedure
+!procedure $applicationFunction($label, $name="")
+    $element("application", "function", $label, $name)
+!endprocedure
+!procedure $applicationInteraction($label, $name="")
+    $element("application", "interaction", $label, $name)
+!endprocedure
+!procedure $applicationService($label, $name="")
+    $element("application", "service", $label, $name)
+!endprocedure
+!procedure $applicationEvent($label, $name="")
+    $element("application", "event", $label, $name)
+!endprocedure
+!procedure $dataObject($label, $name="")
+    $element("application", "object", $label, $name)
+!endprocedure
+
+' technology
+!procedure $node($label, $name="")
+    $element("technology", "node", $label, $name)
+!endprocedure
+!procedure $device($label, $name="")
+    $element("technology", "device", $label, $name)
+!endprocedure
+!procedure $systemSoftware($label, $name="")
+    $element("technology", "system-software", $label, $name)
+!endprocedure
+!procedure $technologyCollaboration($label, $name="")
+    $element("technology", "collaboration", $label, $name)
+!endprocedure
+!procedure $technologyInterface($label, $name="")
+    $element("technology", "interface", $label, $name)
+!endprocedure
+!procedure $technologyProcess($label, $name="")
+    $element("technology", "process", $label, $name)
+!endprocedure
+!procedure $technologyFunction($label, $name="")
+    $element("technology", "function", $label, $name)
+!endprocedure
+!procedure $technologyInteraction($label, $name="")
+    $element("technology", "interaction", $label, $name)
+!endprocedure
+!procedure $technologyService($label, $name="")
+    $element("technology", "service", $label, $name)
+!endprocedure
+!procedure $technologyEvent($label, $name="")
+    $element("technology", "event", $label, $name)
+!endprocedure
+!procedure $artifact($label, $name="")
+    $element("technology", "artifact", $label, $name)
+!endprocedure
+!procedure $communicationNetwork($label, $name="")
+    $element("technology", "communication-network", $label, $name)
+!endprocedure
+!procedure $path($label, $name="")
+    $element("technology", "communication-path", $label, $name)
+!endprocedure
+
+' physical
+!procedure $facility($label, $name="")
+    $element("physical", "facility", $label, $name)
+!endprocedure
+!procedure $equipment($label, $name="")
+    $element("physical", "equipment", $label, $name)
+!endprocedure
+!procedure $material($label, $name="")
+    $element("physical", "material", $label, $name)
+!endprocedure
+!procedure $distributionNetwork($label, $name="")
+    $element("technology", "distributionnetwork", $label, $name)
+!endprocedure

--- a/stdlib/archimate/README.md
+++ b/stdlib/archimate/README.md
@@ -1,13 +1,17 @@
 ---
 name: archimate
 display_name: Archimate
-description: 
+description: PlantUML support for Archimate diagrams
 author: 
-version: 1.1.0
+version: 3.2.1
 release: 
-license: 
+license: MIT
 source: https://github.com/plantuml-stdlib/Archimate-PlantUML
 origin: 
 ---
 
-Information about the `archimate` Standard Library.
+The `archimate` Standard Library provides icons and macros to simplify the creation of diagrams that meet 
+the ArchiMate 3.2 specification.
+
+PlantUML has built-in support, to activate use `!include <archimate/Archimate>`. For more information, see
+https://github.com/plantuml-stdlib/Archimate-PlantUML

--- a/stdlib/archimate/_examples_/Archimate-Elements.wsd
+++ b/stdlib/archimate/_examples_/Archimate-Elements.wsd
@@ -1,10 +1,10 @@
 @startuml
 
-!global $ARCH_LOCAL = false
-!global $ARCH_DEBUG = true
+!global $ARCH_LOCAL = %false()
+!global $ARCH_DEBUG = %true()
 !global $ARCH_MINIMUM_WIDTH = 120
 
-!if ($ARCH_LOCAL == false)
+!if ($ARCH_LOCAL == %false())
     !include <archimate/Archimate>
     '!theme archimate-alternate from <archimate/themes>
     '!theme archimate-handwriting from <archimate/themes>

--- a/stdlib/archimate/_examples_/example.puml
+++ b/stdlib/archimate/_examples_/example.puml
@@ -1,9 +1,13 @@
 @startuml
 
-!global $ARCH_LOCAL = false
-!global $ARCH_DEBUG = true
+!global $ARCH_LOCAL = %true()
+!global $ARCH_DEBUG = %true()
 
-!if ($ARCH_LOCAL == false)
+'!global $ARCH_LINETYPE = curve
+'!global $ARCH_LINETYPE = polyline
+'!global $ARCH_LINETYPE = ortho
+
+!if ($ARCH_LOCAL == %false())
     !include <archimate/Archimate>
     '!theme archimate-alternate from <archimate/themes>
     '!theme archimate-handwriting from <archimate/themes>

--- a/stdlib/archimate/themes/puml-theme-archimate-alternate.puml
+++ b/stdlib/archimate/themes/puml-theme-archimate-alternate.puml
@@ -16,9 +16,9 @@
 !global $ARCH_RELATIONSHIP_LINECOLOR = "#Black"
 !global $ARCH_RELATIONSHIP_FONTCOLOR = "#Black"
 
-!global $ARCH_LOCAL ?= false
+!global $ARCH_LOCAL ?= %false()
 
-!if ($ARCH_LOCAL == true)
+!if ($ARCH_LOCAL == %true())
     !include shared_style.puml
 !else
     !include <archimate/themes/shared_style>

--- a/stdlib/archimate/themes/puml-theme-archimate-handwriting.puml
+++ b/stdlib/archimate/themes/puml-theme-archimate-handwriting.puml
@@ -5,7 +5,7 @@
 !global $ARCH_DEFAULT_FONT = "Comic Sans MS"
 !global $ARCH_DEFAULT_FONTSIZE = 14
 
-!option handwritten true
+!option handwritten %true()
 
 center footer <font color=red>Warning:</font> Created for discussion, needs to be validated
 
@@ -19,9 +19,9 @@ center footer <font color=red>Warning:</font> Created for discussion, needs to b
     }
 </style>
 
-!global $ARCH_LOCAL ?= false
+!global $ARCH_LOCAL ?= %false()
 
-!if ($ARCH_LOCAL == true)
+!if ($ARCH_LOCAL == %true())
     !include shared_style.puml
 !else
     !include <archimate/themes/shared_style>

--- a/stdlib/archimate/themes/puml-theme-archimate-lowsaturation.puml
+++ b/stdlib/archimate/themes/puml-theme-archimate-lowsaturation.puml
@@ -16,9 +16,9 @@
 !global $ARCH_RELATIONSHIP_LINECOLOR = "#Black"
 !global $ARCH_RELATIONSHIP_FONTCOLOR = "#Black"
 
-!global $ARCH_LOCAL ?= false
+!global $ARCH_LOCAL ?= %false()
 
-!if ($ARCH_LOCAL == true)
+!if ($ARCH_LOCAL == %true())
     !include shared_style.puml
 !else
     !include <archimate/themes/shared_style>

--- a/stdlib/archimate/themes/puml-theme-archimate-saturated.puml
+++ b/stdlib/archimate/themes/puml-theme-archimate-saturated.puml
@@ -16,9 +16,9 @@
 !global $ARCH_RELATIONSHIP_LINECOLOR = "#Black"
 !global $ARCH_RELATIONSHIP_FONTCOLOR = "#Black"
 
-!global $ARCH_LOCAL ?= false
+!global $ARCH_LOCAL ?= %false()
 
-!if ($ARCH_LOCAL == true)
+!if ($ARCH_LOCAL == %true())
     !include shared_style.puml
 !else
     !include <archimate/themes/shared_style>

--- a/stdlib/archimate/themes/puml-theme-archimate-standard.puml
+++ b/stdlib/archimate/themes/puml-theme-archimate-standard.puml
@@ -16,9 +16,9 @@
 !global $ARCH_RELATIONSHIP_LINECOLOR = "#Black"
 !global $ARCH_RELATIONSHIP_FONTCOLOR = "#Black"
 
-!global $ARCH_LOCAL ?= false
+!global $ARCH_LOCAL ?= %false()
 
-!if ($ARCH_LOCAL == true)
+!if ($ARCH_LOCAL == %true())
     !include shared_style.puml
 !else
     !include <archimate/themes/shared_style>

--- a/stdlib/archimate/themes/shared_style.puml
+++ b/stdlib/archimate/themes/shared_style.puml
@@ -4,8 +4,12 @@ skinparam maxMessageSize 150
 ' No <style> alternative found yet for skinparam maxMessageSize to make it work on elements that have nested elements
 skinparam StereotypeAlignment right
 
+'No <style> alternative found yet for skinparam lineType ortho
+!global $ARCH_LINETYPE ?= ortho
+skinparam lineType $ARCH_LINETYPE
+
 ' fallback values if theme does not define it
-!global $ARCH_DEFAULT_BACKGROUND = "#white"
+!global $ARCH_DEFAULT_BACKGROUND ?= "#white"
 !global $ARCH_DEFAULT_FONT ?= "Verdana"
 !global $ARCH_DEFAULT_FONTSIZE ?= 12
 !global $ARCH_HANDWRITTEN_BACKGROUND ?= "#eeebdc"
@@ -34,7 +38,13 @@ skinparam StereotypeAlignment right
 
 !global $ARCH_DIAGONAL_CORNER ?= 12
 !global $ARCH_ROUND_CORNER ?= 25
+!global $ARCH_ROUND_CORNER_LARGE ?= 80
 !global $ARCH_SHARP_CORNER ?= 1
+
+' $ARCH_SPECIAL_SHAPES drives the usage of special shapes for some elements.
+' Note that there are some custom shapes that do not support nesting (actor and usecase).
+' This means that when using these elements as containers, one must add `$nest=%true()` to the call, so that the regular shape will be used.
+!global $ARCH_SPECIAL_SHAPES ?= %false()
 
 <style>
     archimate {
@@ -155,6 +165,13 @@ skinparam StereotypeAlignment right
     }
     .motivation-value {
         DiagonalCorner $ARCH_DIAGONAL_CORNER
+    }
+    .service-special {
+        RoundCorner $ARCH_ROUND_CORNER_LARGE
+        stereotype {
+            FontSize 1
+            FontColor transparent
+        }
     }
     .strategy-capability {
         RoundCorner $ARCH_ROUND_CORNER


### PR DESCRIPTION
I've just released a new version of ArchiMate-PlantUML (v.3.2.1)[1], that fixes some bugs (improper use of `true` and `false` literals, now replaced with `%true()` and `%false()`, and introduces new procedures to use ArchiMate symbols in Sequence Diagrams.
This PR pulls those changes into the `plantuml-stdlib` repo, to make them available for a future release of `plantuml`.

[1] - https://github.com/plantuml-stdlib/Archimate-PlantUML/releases/tag/v3.2.1
